### PR TITLE
CRDCDH-80 Implement Unsaved Changes Prompt

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
-import { useRoutes } from 'react-router-dom';
+import { RouterProvider, createBrowserRouter } from 'react-router-dom';
 import { ThemeProvider, CssBaseline, createTheme } from '@mui/material';
-import router from './router';
+import routeConfig from './router';
 
 const theme = createTheme({
   typography: {
@@ -17,12 +17,15 @@ const theme = createTheme({
   },
 });
 
+const router = createBrowserRouter(
+  routeConfig,
+);
+
 function App() {
-  const content = useRoutes(router);
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
-      {content}
+      <RouterProvider router={router} />
     </ThemeProvider>
   );
 }

--- a/src/components/Contexts/FormContext.tsx
+++ b/src/components/Contexts/FormContext.tsx
@@ -10,7 +10,7 @@ import React, {
 type ContextState = {
   status: Status;
   data: Application;
-  setData?: (Application) => void;
+  setData?: (Application) => Promise<boolean>;
   error?: string;
 };
 
@@ -66,19 +66,22 @@ export const FormProvider: FC<ProviderProps> = (props) => {
 
   // Here we update the state and send the data to the API
   // otherwise we can just update the local state (i.e. within form sections)
-  const setData = (data: Application) => {
-    console.log("[UPDATING DATA]");
-    console.log("prior state", state);
+  const setData = async (data: Application) => {
+    return new Promise<boolean>((resolve, reject) => {
+      console.log("[UPDATING DATA]");
+      console.log("prior state", state);
 
-    const newState = { ...state, data };
-    setState({ ...newState, status: Status.SAVING });
-    console.log("new state", newState);
+      const newState = { ...state, data };
+      setState({ ...newState, status: Status.SAVING });
+      console.log("new state", newState);
 
-    // simulate the save event
-    setTimeout(() => {
-      setState({ ...newState, status: Status.LOADED });
-      console.log("saved");
-    }, 1500);
+      // simulate the save event
+      setTimeout(() => {
+        setState({ ...newState, status: Status.LOADED });
+        console.log("saved");
+        resolve(true);
+      }, 1500);
+    });
   };
 
   useEffect(() => {

--- a/src/content/questionnaire/FormView.tsx
+++ b/src/content/questionnaire/FormView.tsx
@@ -1,6 +1,6 @@
-import React, { FC, createRef, useState } from 'react';
+import React, { FC, createRef, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Button } from '@mui/material';
+import { Button, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle } from '@mui/material';
 import { LoadingButton } from '@mui/lab';
 import { WithStyles, withStyles } from "@mui/styles";
 import ForwardArrowIcon from '@mui/icons-material/ArrowForwardIos';
@@ -28,16 +28,19 @@ const FormView: FC<Props> = ({ section, classes } : Props) => {
   const navigate = useNavigate();
   const { status, data, error } = useFormContext();
   const [activeSection, setActiveSection] = useState(validateSection(section) ? section : "A");
+  const [blockedNavigate, setBlockedNavigate] = useState(null);
   const sectionKeys = Object.keys(map);
   const sectionIndex = sectionKeys.indexOf(activeSection);
 
   const refs = {
     saveFormRef: createRef<HTMLButtonElement>(),
     submitFormRef: createRef<HTMLButtonElement>(),
+    saveHandlerRef: useRef<(() => Promise<boolean>) | null>(null),
+    isDirtyHandlerRef: useRef<(() => boolean) | null>(null),
   };
 
   /**
-   * Trigger navigation to a specific section
+   * Handles the actual navigation to a specific section
    *
    * @param section string
    * @returns void
@@ -55,29 +58,50 @@ const FormView: FC<Props> = ({ section, classes } : Props) => {
   };
 
   /**
-   * Traverse to the previous section
+   * Wrapper for navigating to the next section
+   * will catch an unsaved form and open the prompt
    *
-   * @returns void
+   * @param {number} direction
+   * @returns {void}
    */
-  const goBack = () => {
-    const previousSection = sectionKeys[sectionIndex - 1];
+  const goToSection = (direction: -1 | 1) => {
+    const section = sectionKeys[sectionIndex + direction];
 
-    if (previousSection) {
-      navigateToSection(previousSection);
+    if (!section) {
+      return;
     }
+    if (refs.isDirtyHandlerRef.current?.()) {
+      setBlockedNavigate(section);
+      return;
+    }
+
+    navigateToSection(section);
   };
 
   /**
-   * Traverse to the next section
+   * Provides a save handler for the Unsaved Changes
+   * dialog. Will save the form and then navigate to the
+   * blocked section.
    *
-   * @returns void
+   * @returns {void}
    */
-  const goForward = () => {
-    const nextSection = sectionKeys[sectionIndex + 1];
+  const saveAndNavigate = async () => {
+    // Wait for the save handler to complete
+    await refs.saveHandlerRef.current?.();
+    setBlockedNavigate(null);
+    navigateToSection(blockedNavigate);
+  };
 
-    if (nextSection) {
-      navigateToSection(nextSection);
-    }
+  /**
+   * Provides a discard handler for the Unsaved Changes
+   * dialog. Will discard the form changes and then navigate to the
+   * blocked section.
+   *
+   * @returns {void}
+   */
+  const discardAndNavigate = () => {
+    setBlockedNavigate(null);
+    navigateToSection(blockedNavigate);
   };
 
   if (status === FormStatus.LOADING) {
@@ -101,7 +125,7 @@ const FormView: FC<Props> = ({ section, classes } : Props) => {
         <Button
           variant="outlined"
           type="button"
-          onClick={goBack}
+          onClick={() => goToSection(-1)}
           disabled={status === FormStatus.SAVING || !sectionKeys[sectionIndex - 1]}
           size="large"
           startIcon={<BackwardArrowIcon />}
@@ -114,6 +138,7 @@ const FormView: FC<Props> = ({ section, classes } : Props) => {
           ref={refs.saveFormRef}
           size="large"
           loading={status === FormStatus.SAVING}
+          onClick={() => refs.saveHandlerRef.current?.()}
         >
           Save
         </LoadingButton>
@@ -128,7 +153,7 @@ const FormView: FC<Props> = ({ section, classes } : Props) => {
         <Button
           variant="outlined"
           type="button"
-          onClick={goForward}
+          onClick={() => goToSection(1)}
           disabled={status === FormStatus.SAVING || !sectionKeys[sectionIndex + 1]}
           size="large"
           endIcon={<ForwardArrowIcon />}
@@ -136,6 +161,23 @@ const FormView: FC<Props> = ({ section, classes } : Props) => {
           Next
         </Button>
       </div>
+
+      <Dialog open={blockedNavigate !== null}>
+        <DialogTitle>
+          Unsaved Changes
+        </DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            You have unsaved changes. Your changes will be lost if you leave this section without saving.
+            Do you want to save your data?
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setBlockedNavigate(null)} disabled={status === FormStatus.SAVING}>Cancel</Button>
+          <Button onClick={saveAndNavigate} disabled={status === FormStatus.SAVING} autoFocus>Save</Button>
+          <Button onClick={discardAndNavigate} disabled={status === FormStatus.SAVING} color="error">Discard</Button>
+        </DialogActions>
+      </Dialog>
     </div>
   );
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { HelmetProvider } from 'react-helmet-async';
-import { BrowserRouter } from 'react-router-dom';
 import App from './App';
 import * as serviceWorker from './serviceWorker';
 import reportWebVitals from './reportWebVitals';
@@ -11,9 +10,7 @@ const root = ReactDOM.createRoot(
 );
 root.render(
   <HelmetProvider>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
+    <App />
   </HelmetProvider>,
 );
 

--- a/src/types/Globals.d.ts
+++ b/src/types/Globals.d.ts
@@ -1,6 +1,9 @@
 type FormSectionProps = {
   classes?: any;
   refs: {
-    [key: string]: React.RefObject<HTMLInputElement | HTMLButtonElement>;
+    saveFormRef: React.RefObject<HTMLButtonElement>;
+    submitFormRef: React.RefObject<HTMLButtonElement>;
+    saveHandlerRef: React.MutableRefObject<(() => Promise<boolean>) | null>;
+    isDirtyHandlerRef: React.MutableRefObject<(() => boolean) | null>;
   };
 };


### PR DESCRIPTION
### Overview

This PR covers the implementation of an "Unsaved Changes" prompt that invokes user action when leaving the current form section with unsaved changed.

Notably, when leaving a section with unsaved changes the following options become available to the user:

- Cancel – Cancel current action, hides prompt and stops invoked navigation action
- Save – Save the current form section then navigate onward
- Discard – Discards current changes and continues navigation

> **Note**: Any changes restored (i.e. Changing the Firstname field then restoring it back to the original value) will not count toward unsaved changes.

<img width="613" alt="image" src="https://github.com/CBIIT/crdc-datahub-ui/assets/38357871/3fca4edf-cfd0-4464-8075-41dbd0b7874d">
