### PR TITLE
CRDCDH-80 Unsaved Changes Dialog

### DIFF
--- a/src/components/Questionnaire/QuestionnaireBanner.tsx
+++ b/src/components/Questionnaire/QuestionnaireBanner.tsx
@@ -1,0 +1,67 @@
+import { Container, styled } from "@mui/material";
+import bannerBackgroundImage from "../../assets/banner/banner_background.png";
+
+const StyledBanner = styled("div")(() => ({
+  background: `url(${bannerBackgroundImage})`,
+  backgroundBlendMode: "luminosity, normal",
+  backgroundSize: "cover",
+  backgroundPosition: "center",
+  width: "100%",
+  height: "296px",
+  display: "flex",
+  justifyContent: "center",
+  alignItems: "center",
+}));
+
+const StyledBannerContentContainer = styled(Container)(() => ({
+  "&.MuiContainer-root": {
+    padding: "57px 0 0 65px",
+    width: "100%",
+    height: "100%",
+  },
+}));
+
+const StyledBannerTitle = styled("h2")(() => ({
+  maxWidth: "611px",
+  height: "79px",
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "center",
+  flexShrink: 0,
+  color: "#3E577C",
+  fontSize: "45px",
+  fontFamily: "'Nunito Sans', 'Rubik', sans-serif",
+  fontWeight: 800,
+  lineHeight: "40px",
+  letterSpacing: "-1.5px",
+  margin: 0,
+}));
+
+const StyledBannerSubtitle = styled("h6")(() => ({
+  display: "flex",
+  maxWidth: "565px",
+  height: "59px",
+  flexDirection: "column",
+  flexShrink: 0,
+  color: "#453E3E",
+  fontSize: "16px",
+  fontFamily: "'Inter', 'Rubik', sans-serif",
+  fontWeight: 400,
+  lineHeight: "22px",
+  margin: "0 0 0 5px",
+}));
+
+const QuestionnaireBanner = () => (
+  <StyledBanner>
+    <StyledBannerContentContainer maxWidth="xl">
+      <StyledBannerTitle>Submission Request</StyledBannerTitle>
+      <StyledBannerSubtitle>
+        The following set of high-level questions are intended to provide
+        insight to the CRDC Data Hub, related to data storage, access,
+        secondary sharing needs and other requirements of data submitters.
+      </StyledBannerSubtitle>
+    </StyledBannerContentContainer>
+  </StyledBanner>
+);
+
+export default QuestionnaireBanner;

--- a/src/components/Questionnaire/Repository.tsx
+++ b/src/components/Questionnaire/Repository.tsx
@@ -31,7 +31,7 @@ const Repository: FC<Props> = ({
 }: Props) => {
   const { status } = useFormContext();
 
-  const { name, studyID } = repository;
+  const { name, studyID, submittedDate } = repository;
 
   return (
     <GridContainer container>
@@ -56,8 +56,8 @@ const Repository: FC<Props> = ({
         />
         <TextInput
           label="Date submitted"
-          name={`study[repositories][${index}][dateSubmitted]`}
-          value={studyID}
+          name={`study[repositories][${index}][submittedDate]`}
+          value={submittedDate}
           placeholder="Enter date"
           maxLength={50}
           gridWidth={6}

--- a/src/components/Questionnaire/UnsavedChangesDialog.tsx
+++ b/src/components/Questionnaire/UnsavedChangesDialog.tsx
@@ -1,0 +1,97 @@
+import { LoadingButton } from "@mui/lab";
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogProps,
+  DialogTitle,
+  styled,
+} from "@mui/material";
+import { FC } from "react";
+
+const StyledDialog = styled(Dialog)({
+  "& .MuiDialog-paper": {
+    maxWidth: "451px",
+    borderRadius: "8px",
+    border: "1px solid #E25C22",
+    background: "#EDF0F1",
+    boxShadow: "0px 4px 10px 0px rgba(0, 0, 0, 0.15)",
+  },
+});
+
+const StyledDialogTitle = styled(DialogTitle)({
+  color: "#E25C22",
+  fontSize: "15px",
+  fontFamily: "'Inter', 'Rubik', sans-serif",
+  fontStyle: "normal",
+  fontWeight: "700",
+  lineHeight: "normal",
+  padding: "18px 15px 10px",
+});
+
+const StyledDialogContent = styled(DialogContent)({
+  padding: "0 15px 18px",
+});
+
+const StyledDialogContentText = styled(DialogContentText)({
+  color: "#000000",
+  fontSize: "15px",
+  fontFamily: "'Inter', 'Rubik', sans-serif",
+  fontStyle: "normal",
+  fontWeight: "400",
+  lineHeight: "normal",
+});
+
+const StyledDialogActions = styled(DialogActions)({
+  fontSize: "15px",
+  fontFamily: "'Inter', 'Rubik', sans-serif",
+  fontStyle: "normal",
+  fontWeight: "400",
+  lineHeight: "normal",
+  padding: "0 15px 10px",
+});
+
+type Props = {
+  title?: string;
+  message?: string;
+  disableActions?: boolean;
+  onCancel?: () => void;
+  onSave?: () => void;
+  onDiscard?: () => void;
+} & DialogProps;
+
+const UnsavedChangesDialog: FC<Props> = ({
+  title,
+  message,
+  disableActions,
+  onCancel,
+  onSave,
+  onDiscard,
+  open,
+  ...rest
+}) => (
+  <StyledDialog open={open} {...rest}>
+    <StyledDialogTitle>{title || "Unsaved Changes"}</StyledDialogTitle>
+    <StyledDialogContent>
+      <StyledDialogContentText>
+        {message
+          || "You have unsaved changes. Your changes will be lost if you leave this section without saving. Do you want to save your data?"}
+      </StyledDialogContentText>
+    </StyledDialogContent>
+    <StyledDialogActions>
+      <Button onClick={onCancel} disabled={disableActions}>
+        Cancel
+      </Button>
+      <LoadingButton onClick={onSave} loading={disableActions} autoFocus>
+        Save
+      </LoadingButton>
+      <Button onClick={onDiscard} disabled={disableActions} color="error">
+        Discard
+      </Button>
+    </StyledDialogActions>
+  </StyledDialog>
+);
+
+export default UnsavedChangesDialog;

--- a/src/content/questionnaire/FormView.tsx
+++ b/src/content/questionnaire/FormView.tsx
@@ -4,7 +4,7 @@ import {
   unstable_useBlocker as useBlocker, unstable_Blocker as Blocker
 } from 'react-router-dom';
 import { isEqual } from 'lodash';
-import { Button, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, Divider, Stack, styled } from '@mui/material';
+import { Button, Container, Divider, Stack, styled } from '@mui/material';
 import { LoadingButton } from '@mui/lab';
 import { WithStyles, withStyles } from "@mui/styles";
 import ForwardArrowIcon from '@mui/icons-material/ArrowForwardIos';
@@ -15,52 +15,14 @@ import StatusBar from '../../components/StatusBar/StatusBar';
 import ProgressBar from '../../components/ProgressBar/ProgressBar';
 import Section from './sections';
 import map from '../../config/SectionConfig';
-import bannerBackgroundImage from "../../assets/banner/banner_background.png";
+import UnsavedChangesDialog from '../../components/Questionnaire/UnsavedChangesDialog';
+import QuestionnaireBanner from '../../components/Questionnaire/QuestionnaireBanner';
 
-const StyledBanner = styled('div')(() => ({
-  position: "relative",
-  background: `url(${bannerBackgroundImage})`,
-  backgroundBlendMode: "LUMINOSITY, NORMAL",
-  backgroundSize: 'cover',
-  backgroundPosition: 'center',
-  width: '100%',
-  height: "296px",
-}));
-
-const StyledBannerText = styled('div')(() => ({
-  position: "absolute",
-  top: "57px",
-  left: "65px"
-}));
-
-const StyledBannerTitle = styled('h2')(() => ({
-  maxWidth: "611px",
-  height: "79px",
-  display: "flex",
-  flexDirection: "column",
-  justifyContent: "center",
-  flexShrink: 0,
-  color: "#3E577C",
-  fontSize: "45px",
-  fontFamily: "'Nunito Sans', 'Rubik', sans-serif",
-  fontWeight: 800,
-  lineHeight: "40px",
-  letterSpacing: "-1.5px",
-  margin: 0,
-}));
-
-const StyledBannerSubtitle = styled('h6')(() => ({
-  display: "flex",
-  maxWidth: "565px",
-  height: "59px",
-  flexDirection: "column",
-  flexShrink: 0,
-  color: "#453E3E",
-  fontSize: "16px",
-  fontFamily: "'Inter', 'Rubik', sans-serif",
-  fontWeight: 400,
-  lineHeight: "22px",
-  margin: "0 0 0 5px"
+const StyledContainer = styled(Container)(() => ({
+  "&.MuiContainer-root": {
+    padding: 0,
+    minHeight: "300px",
+  }
 }));
 
 type Props = {
@@ -85,7 +47,7 @@ const StyledDivider = styled(Divider)({
 });
 
 const StyledContentWrapper = styled(Stack)({
-  paddingBottom: "75px"
+  paddingBottom: "75px",
 });
 
 /**
@@ -225,103 +187,87 @@ const FormView: FC<Props> = ({ section, classes } : Props) => {
 
   return (
     <>
-      <StyledBanner>
-        <StyledBannerText>
-          <StyledBannerTitle>CRDC Intake Questionnaire</StyledBannerTitle>
-          <StyledBannerSubtitle>
-            The following set of high-level questions are intended to provide insight to
-            the CRDC Data Hub, related to data storage, access, secondary sharing
-            needs and other requirements of data submitters.
-          </StyledBannerSubtitle>
-        </StyledBannerText>
-      </StyledBanner>
+      <QuestionnaireBanner />
 
-      <StyledContentWrapper direction="row" justifyContent="center">
-        <StyledSidebar
-          direction="row"
-          justifyContent="center"
-          alignSelf="flex-start"
-        >
-          <ProgressBar section={activeSection} />
-          <StyledDivider orientation="vertical" />
-        </StyledSidebar>
-
-        <Stack className={classes.content} direction="column" spacing={5}>
-          <StatusBar />
-
-          <Section section={activeSection} refs={refs} />
-
-          <Stack
-            className={classes.controls}
+      <StyledContainer maxWidth="xl">
+        <StyledContentWrapper direction="row" justifyContent="center">
+          <StyledSidebar
             direction="row"
             justifyContent="center"
-            alignItems="center"
-            spacing={2}
+            alignSelf="flex-start"
           >
-            <Link to={prevSection} style={{ pointerEvents: prevSection ? "initial" : "none" }}>
-              <Button
-                className={classes.backButton}
-                variant="outlined"
-                type="button"
-                disabled={status === FormStatus.SAVING || !prevSection}
-                size="large"
-                startIcon={<BackwardArrowIcon />}
-              >
-                Back
-              </Button>
-            </Link>
-            <LoadingButton
-              className={classes.saveButton}
-              variant="outlined"
-              type="button"
-              ref={refs.saveFormRef}
-              size="large"
-              loading={status === FormStatus.SAVING}
-              onClick={saveForm}
-            >
-              Save
-            </LoadingButton>
-            <LoadingButton
-              className={classes.submitButton}
-              variant="outlined"
-              type="submit"
-              ref={refs.submitFormRef}
-              size="large"
-            >
-              Submit
-            </LoadingButton>
-            <Link to={nextSection} style={{ pointerEvents: nextSection ? "initial" : "none" }}>
-              <Button
-                className={classes.nextButton}
-                variant="outlined"
-                type="button"
-                disabled={status === FormStatus.SAVING || !nextSection}
-                size="large"
-                endIcon={<ForwardArrowIcon />}
-              >
-                Next
-              </Button>
-            </Link>
-          </Stack>
-        </Stack>
-      </StyledContentWrapper>
+            <ProgressBar section={activeSection} />
+            <StyledDivider orientation="vertical" />
+          </StyledSidebar>
 
-      <Dialog open={blockedNavigate}>
-        <DialogTitle>
-          Unsaved Changes
-        </DialogTitle>
-        <DialogContent>
-          <DialogContentText>
-            You have unsaved changes. Your changes will be lost if you leave this section without saving.
-            Do you want to save your data?
-          </DialogContentText>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => setBlockedNavigate(false)} disabled={status === FormStatus.SAVING}>Cancel</Button>
-          <LoadingButton onClick={saveAndNavigate} loading={status === FormStatus.SAVING} autoFocus>Save</LoadingButton>
-          <Button onClick={discardAndNavigate} disabled={status === FormStatus.SAVING} color="error">Discard</Button>
-        </DialogActions>
-      </Dialog>
+          <Stack className={classes.content} direction="column" spacing={5}>
+            <StatusBar />
+
+            <Section section={activeSection} refs={refs} />
+
+            <Stack
+              className={classes.controls}
+              direction="row"
+              justifyContent="center"
+              alignItems="center"
+              spacing={2}
+            >
+              <Link to={prevSection} style={{ pointerEvents: prevSection ? "initial" : "none" }}>
+                <Button
+                  className={classes.backButton}
+                  variant="outlined"
+                  type="button"
+                  disabled={status === FormStatus.SAVING || !prevSection}
+                  size="large"
+                  startIcon={<BackwardArrowIcon />}
+                >
+                  Back
+                </Button>
+              </Link>
+              <LoadingButton
+                className={classes.saveButton}
+                variant="outlined"
+                type="button"
+                ref={refs.saveFormRef}
+                size="large"
+                loading={status === FormStatus.SAVING}
+                onClick={saveForm}
+              >
+                Save
+              </LoadingButton>
+              <LoadingButton
+                className={classes.submitButton}
+                variant="outlined"
+                type="submit"
+                ref={refs.submitFormRef}
+                size="large"
+              >
+                Submit
+              </LoadingButton>
+              <Link to={nextSection} style={{ pointerEvents: nextSection ? "initial" : "none" }}>
+                <Button
+                  className={classes.nextButton}
+                  variant="outlined"
+                  type="button"
+                  disabled={status === FormStatus.SAVING || !nextSection}
+                  size="large"
+                  endIcon={<ForwardArrowIcon />}
+                >
+                  Next
+                </Button>
+              </Link>
+            </Stack>
+          </Stack>
+        </StyledContentWrapper>
+      </StyledContainer>
+
+      <UnsavedChangesDialog
+        open={blockedNavigate}
+        onCancel={() => setBlockedNavigate(false)}
+        onSave={saveAndNavigate}
+        onDiscard={discardAndNavigate}
+        disableActions={status === FormStatus.SAVING}
+      />
     </>
   );
 };

--- a/src/content/questionnaire/sections/B.tsx
+++ b/src/content/questionnaire/sections/B.tsx
@@ -15,8 +15,7 @@ import Repository from "../../../components/Questionnaire/Repository";
 import { findProgram, findStudy, mapObjectWithKey } from "../utils";
 import AddRemoveButton from "../../../components/Questionnaire/AddRemoveButton";
 import PlannedPublication from "../../../components/Questionnaire/PlannedPublication";
-import SelectInput from "../../../components/Questionnaire/SelectInput";
-import initialValues from "../../../config/InitialValues";
+  import initialValues from "../../../config/InitialValues";
 
 type KeyedPublication = {
   key: string;

--- a/src/layouts/index.tsx
+++ b/src/layouts/index.tsx
@@ -1,17 +1,14 @@
 import { FC, ReactNode } from 'react';
 import PropTypes from 'prop-types';
 import { Outlet } from 'react-router-dom';
-import { Container, styled } from '@mui/material';
+import { styled } from '@mui/material';
 import { Helmet } from 'react-helmet-async';
 import Footer from '../components/Footer';
 import Header from '../components/Header';
 import ScrollButton from '../components/ScrollButton/ScrollButtonView';
 
-const StyledContainer = styled(Container)(() => ({
-  "&.MuiContainer-root": {
-    padding: 0,
-    minHeight: "300px",
-  }
+const StyledWrapper = styled("div")(() => ({
+  minHeight: "300px",
 }));
 
 interface LayoutProps {
@@ -27,9 +24,9 @@ const Layout: FC<LayoutProps> = ({ children }) => (
       <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Nunito+Sans:wght@400;500;600;700;900&family=Nunito:wght@400;500;600;700&family=Public+Sans:wght@300;400;500;600;700&family=Rubik:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
     </Helmet>
     <Header />
-    <StyledContainer maxWidth="xl">
+    <StyledWrapper>
       {children || <Outlet />}
-    </StyledContainer>
+    </StyledWrapper>
     <Footer />
     <ScrollButton />
   </>


### PR DESCRIPTION
This PR is a redesign of the Unsaved Changes Dialog for the ticket [CRDCDH-80](https://tracker.nci.nih.gov/browse/CRDCDH-80) and it also includes modifications of the banner to extend the width of the screen for the ticket [CRDCDH-93](https://tracker.nci.nih.gov/browse/CRDCDH-93)


- Redesign Unsaved Changes Dialog
- Move Dialog to a separate component
- Move Banner to outside of container
- Make Banner extend entire width of screen
- Fix typo in name for Repository which cause for Unsaved Changes Dialog to trigger every time in section B