### PR TITLE
CRDCDH-80 Hide validation when saving from dialog

### DIFF
--- a/src/content/questionnaire/FormView.tsx
+++ b/src/content/questionnaire/FormView.tsx
@@ -124,7 +124,7 @@ const FormView: FC<Props> = ({ section, classes } : Props) => {
    *
    * @returns {Promise<boolean>} true if the save was successful, false otherwise
    */
-  const saveForm = async () => {
+  const saveForm = async (hideValidation = false) => {
     const { ref, data: newData } = refs.getFormObjectRef.current?.() || {};
 
     if (!ref.current || !newData) {
@@ -132,7 +132,10 @@ const FormView: FC<Props> = ({ section, classes } : Props) => {
     }
 
     // Update section status
-    const newStatus = ref.current.reportValidity() ? "Completed" : "In Progress";
+    const newStatus = ref.current.checkValidity() ? "Completed" : "In Progress";
+    if (!hideValidation) {
+      ref.current.reportValidity();
+    }
     const currentSection : Section = newData.sections.find((s) => s.name === activeSection);
     if (currentSection) {
       currentSection.status = newStatus;
@@ -158,7 +161,7 @@ const FormView: FC<Props> = ({ section, classes } : Props) => {
    */
   const saveAndNavigate = async () => {
     // Wait for the save handler to complete
-    await saveForm();
+    await saveForm(true);
     setBlockedNavigate(false);
     blocker.proceed();
   };
@@ -236,7 +239,7 @@ const FormView: FC<Props> = ({ section, classes } : Props) => {
                 ref={refs.saveFormRef}
                 size="large"
                 loading={status === FormStatus.SAVING}
-                onClick={saveForm}
+                onClick={() => saveForm()}
               >
                 Save
               </LoadingButton>

--- a/src/content/questionnaire/sections/C.tsx
+++ b/src/content/questionnaire/sections/C.tsx
@@ -40,6 +40,7 @@ const FormSectionC: FC<FormSectionProps> = ({ SectionOption, refs }: FormSection
   const { saveFormRef, submitFormRef, getFormObjectRef } = refs;
 
   const [timeConstraints, setTimeConstraints] = useState<KeyedTimeConstraint[]>(data.timeConstraints?.map(mapObjectWithKey));
+  const [cellLineModelSystemCheckboxes, setCellLineModelSystemCheckboxes] = useState<string[]>(reshapeCheckboxGroupOptions(cellLineModelSystemOptions, data));
 
   useEffect(() => {
     if (!saveFormRef.current || !submitFormRef.current) {
@@ -232,7 +233,8 @@ const FormSectionC: FC<FormSectionProps> = ({ SectionOption, refs }: FormSection
           idPrefix="section-c-"
           label="Cell lines, model systems, or neither"
           options={cellLineModelSystemOptions}
-          value={reshapeCheckboxGroupOptions(cellLineModelSystemOptions, data)}
+          value={cellLineModelSystemCheckboxes}
+          onChange={(val: string[]) => setCellLineModelSystemCheckboxes(val)}
           orientation="horizontal"
           gridWidth={12}
           allowMultipleChecked={false}


### PR DESCRIPTION
**Overview**
This PR is to hide validation when saving from unsaved changes dialog. Also, I fixed issue with Cell Line & Model Systems to persist state as the value was changed to initial value when dialog appeared. 