### PR TITLE
Crdcdh 148-191-196

### DIFF
--- a/src/components/Header/HeaderTabletAndMobile.tsx
+++ b/src/components/Header/HeaderTabletAndMobile.tsx
@@ -345,6 +345,7 @@ const Header = () => {
                           <NavLink
                             id={navMobileItem.id}
                             to={navMobileItem.link}
+                            target={navMobileItem.link.startsWith("https://") ? "_blank" : "_self"}
                             onClick={() => setNavMobileDisplay('none')}
                           >
                             <div className="navMobileItem">{navMobileItem.name}</div>
@@ -373,6 +374,7 @@ const Header = () => {
                             <Link
                               id={navMobileItem.id}
                               to={navMobileItem.link}
+                              target={navMobileItem.link.startsWith("https://") ? "_blank" : "_self"}
                             >
                               <div
                                 role="button"

--- a/src/components/Header/HeaderTabletAndMobile.tsx
+++ b/src/components/Header/HeaderTabletAndMobile.tsx
@@ -9,6 +9,7 @@ import rightArrowIcon from '../../assets/header/Right_Arrow.svg';
 import leftArrowIcon from '../../assets/header/Left_Arrow.svg';
 import { navMobileList, navbarSublists } from '../../config/globalHeaderData';
 import { useAuthContext } from '../Contexts/AuthContext';
+import GenericAlert from '../GenericAlert';
 
 const HeaderBanner = styled.div`
   width: 100%;
@@ -210,10 +211,20 @@ const Header = () => {
   const setNavbarMobileList = navMobileListHookResult[1];
   const [showNavDialog, setShowNavDialog] = useState(false);
   const [loginDialogTitle, setLoginDialogTitle] = useState("");
+  const [showLogoutAlert, setShowLogoutAlert] = useState<boolean>(false);
 
   const authData = useAuthContext();
   const displayName = authData?.user?.displayName || "random first name no one has";
   const navigate = useNavigate();
+
+  const handleLogout = async () => {
+    const logoutStatus = await authData.logout();
+    if (logoutStatus) {
+      navigate("/");
+      setShowLogoutAlert(true);
+      setTimeout(() => setShowLogoutAlert(false), 10000);
+    }
+  };
 
   const handleAuthenticationNavLinkClick = (dropItem) => {
     setNavMobileDisplay('none');
@@ -245,6 +256,11 @@ const Header = () => {
 
   return (
     <>
+      <GenericAlert open={showLogoutAlert}>
+        <span>
+          You have been logged out.
+        </span>
+      </GenericAlert>
       <HeaderBanner role="banner">
         <HeaderContainer>
           <Logo />
@@ -366,7 +382,7 @@ const Header = () => {
                                   if (e.key === "Enter") {
                                     setNavMobileDisplay('none');
                                     if (navMobileItem.name === "Logout") {
-                                      authData.logout();
+                                      handleLogout();
                                       setNavbarMobileList(navMobileList);
                                     } else {
                                       navigate(navMobileItem.link);
@@ -376,7 +392,7 @@ const Header = () => {
                                 onClick={() => {
                                   setNavMobileDisplay('none');
                                   if (navMobileItem.name === "Logout") {
-                                    authData.logout();
+                                    handleLogout();
                                     setNavbarMobileList(navMobileList);
                                   } else {
                                     navigate(navMobileItem.link);

--- a/src/components/Header/components/NavbarDesktop.tsx
+++ b/src/components/Header/components/NavbarDesktop.tsx
@@ -501,7 +501,7 @@ const NavBar = () => {
                               {navMobileItem.name}
                             </div>
                           ) : (
-                            <NavLink to={navMobileItem.link}>
+                            <NavLink to={navMobileItem.link} target={navMobileItem.link.startsWith("https://") ? "_blank" : "_self"}>
                               <div
                                 id={navMobileItem.id}
                                 onKeyDown={onKeyPressHandler}
@@ -568,7 +568,7 @@ const NavBar = () => {
                   return (
                     dropItem.link && (!dropItem.needsAuthentication
                       ? (
-                        <Link id={dropItem.id} to={dropItem.link} className="dropdownItem" key={dropkey} onClick={() => setClickedTitle("")}>
+                        <Link target={dropItem.link.startsWith("https://") ? "_blank" : "_self"} id={dropItem.id} to={dropItem.link} className="dropdownItem" key={dropkey} onClick={() => setClickedTitle("")}>
                           {dropItem.name}
                           <div className="dropdownItemText">{dropItem.text}</div>
                         </Link>

--- a/src/components/Header/components/NavbarDesktop.tsx
+++ b/src/components/Header/components/NavbarDesktop.tsx
@@ -414,6 +414,7 @@ const NavBar = () => {
     setClickedTitle("");
     const logoutStatus = await authData.logout();
     if (logoutStatus) {
+      navigate("/");
       setShowLogoutAlert(true);
       setTimeout(() => setShowLogoutAlert(false), 10000);
     }

--- a/src/content/index.tsx
+++ b/src/content/index.tsx
@@ -1,5 +1,83 @@
-import React, { FC } from 'react';
+import React, { FC, useState, useEffect } from 'react';
+import styled from 'styled-components';
+import { Dialog } from "@mui/material";
+import { Link, useLocation } from 'react-router-dom';
 
-const Home: FC = () => <div>This is Home Page</div>;
+const StyledDialog = styled(Dialog)`
+  .MuiDialog-paper {
+    width: 550px;
+    height: 218px;
+    border-radius: 8px;
+    border: 2px solid var(--secondary-one, #0B7F99);
+    background: linear-gradient(0deg, #F2F6FA 0%, #F2F6FA 100%), #2E4D7B;
+    box-shadow: 0px 4px 45px 0px rgba(0, 0, 0, 0.40);
+  }
+  .loginDialogText {
+    margin-top: 57px;
+    /* Body */
+    font-family: Nunito;
+    font-size: 16px;
+    font-style: normal;
+    font-weight: 400;
+    line-height: 19.6px; /* 122.5% */
+    text-align: center;
+  }
+  .loginDialogCloseButton{
+    display: flex;
+    width: 128px;
+    height: 42px;
+    justify-content: center;
+    align-items: center;
+    border-radius: 8px;
+    border: 1px solid #000;
+    align-self: center;
+    margin-top: 39px;
+  }
+  .loginDialogCloseButton:hover {
+    cursor: pointer;
+  }
+  #loginDialogLinkToLogin{
+    color:black;
+  }
+`;
+
+const Home: FC = () => {
+    const [showRedirectDialog, setShowRedirectDialog] = useState(false);
+    const { state } = useLocation();
+    let dialogRedirectPath = state?.path ?? "";
+    let dialogLinkName = state?.name ?? "";
+    useEffect(() => {
+        if (state !== null) {
+            dialogRedirectPath = state.path;
+            dialogLinkName = state.name;
+            setShowRedirectDialog(true);
+        }
+      }, []);
+    return (
+      <>
+        <StyledDialog open={showRedirectDialog}>
+          <pre className="loginDialogText">
+            {/* eslint-disable-next-line react/jsx-one-expression-per-line */}
+            Please <Link id="loginDialogLinkToLogin" to="/login" state={{ redirectURLOnLoginSuccess: dialogRedirectPath }} onClick={() => setShowRedirectDialog(false)}><strong>log in</strong></Link> to access {dialogLinkName}.
+          </pre>
+          <div
+            role="button"
+            tabIndex={0}
+            id="loginDialogCloseButton"
+            className="loginDialogCloseButton"
+            onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                        setShowRedirectDialog(false);
+                    }
+                }}
+            onClick={() => setShowRedirectDialog(false)}
+          >
+            <strong>Close</strong>
+          </div>
+        </StyledDialog>
+        <div>This is Home Page</div>
+      </>
+);
+};
 
 export default Home;


### PR DESCRIPTION
This PR implement ticket 148, adding auth check on URL's. It currently protects the Submission Requests and Data Submissions tabs, although protecting others would be easy.
This also resolves ticket 191 by adding navigation to home page on every available logout button.
This also resolves ticket 196 by adding functionality to open external links in a new tab from the navigation bar.
**This does not add navigation to the logout function provided by authContext. Every logout button located in the header just navigates to home and displays the logout banner. If you are adding other logout buttons, they will not automatically navigate.**