### PR TITLE
CRDCDH-38 Fix top alignment

### DIFF
--- a/src/content/questionnaire/FormView.tsx
+++ b/src/content/questionnaire/FormView.tsx
@@ -42,7 +42,7 @@ const validateSection = (section: string) => typeof map[section] !== 'undefined'
 const StyledSidebar = styled(Stack)({
   position: "sticky",
   top: "25px",
-  paddingTop: "45px",
+  marginTop: "90px",
 });
 
 const StyledDivider = styled(Divider)({


### PR DESCRIPTION
### Overview

Updates the Questionnaire Form progressbar to match the offset alignment in the Figma mockup

Old:
<img width="741" alt="image" src="https://github.com/CBIIT/crdc-datahub-ui/assets/38357871/4919dc5f-0b2c-4344-b3cf-9865e25d0be2">

New:
<img width="741" alt="image" src="https://github.com/CBIIT/crdc-datahub-ui/assets/38357871/e9c700d0-c8bd-45cc-b6d7-7741a72ae9da">
