### PR TITLE
CRDCDH-37 Fix margin between Status/Date and buttons

### DIFF
--- a/src/components/StatusBar/components/HistorySection.tsx
+++ b/src/components/StatusBar/components/HistorySection.tsx
@@ -28,6 +28,7 @@ const StyledDate = styled("span")({
   fontFamily: "Public Sans",
   textTransform: "uppercase",
   color: "#2E5481",
+  marginRight: "10px !important",
 });
 
 const StyledButton = styled(Button)({

--- a/src/components/StatusBar/components/StatusSection.tsx
+++ b/src/components/StatusBar/components/StatusSection.tsx
@@ -26,6 +26,7 @@ const StyledStatus = styled("span")<{ status: ApplicationStatus, leftGap: boolea
     fontFamily: "Public Sans",
     textTransform: "uppercase",
     marginLeft: !leftGap ? "6px !important" : null,
+    marginRight: "10px !important",
     letterSpacing: "0.32px",
     color: theme.palette?.[status]?.main || "#2E5481",
   })


### PR DESCRIPTION
### Overview

This updates the Submission Request Form status bar to add more margin between the Form Status / Form Date and the action buttons next to it. 

Old:
<img width="999" alt="image" src="https://github.com/CBIIT/crdc-datahub-ui/assets/38357871/6c5d5e74-6a98-46a8-8882-68c19d948d40">

New:
<img width="999" alt="image" src="https://github.com/CBIIT/crdc-datahub-ui/assets/38357871/e6b57c32-db14-4c62-9428-609372952369">
