### PR TITLE
CRDCDH-132 Autofill PI data only when Section A is not started

### DIFF
--- a/src/components/Contexts/FormContext.test.tsx
+++ b/src/components/Contexts/FormContext.test.tsx
@@ -182,6 +182,98 @@ describe("FormContext > FormProvider Tests", () => {
     expect(screen.getByTestId("pi-last-name").textContent).toEqual("");
   });
 
+  it("should autofill PI details if Section A is not started", async () => {
+    const mocks = [
+      {
+        request: {
+          query: GET_LAST_APP,
+        },
+        result: {
+          data: {
+            getMyLastApplication: {
+              _id: "ABC-LAST-ID-123",
+              questionnaireData: JSON.stringify({
+                pi: {
+                  firstName: "Test",
+                  lastName: "User",
+                }
+              }),
+            },
+          },
+        },
+      },
+      {
+        request: {
+          query: GET_APP,
+          variables: {
+            id: "AAA-BBB-EXISTING-APP",
+          },
+        },
+        result: {
+          data: {
+            getApplication: {
+              _id: "AAA-BBB-EXISTING-APP",
+              questionnaireData: JSON.stringify({}),
+            },
+          },
+        },
+      }
+    ];
+    const screen = render(<TestParent mocks={mocks} appId="AAA-BBB-EXISTING-APP" />);
+
+    await waitFor(() => expect(screen.getByTestId("status")).toBeInTheDocument());
+
+    expect(screen.getByTestId("status").textContent).toEqual(FormStatus.LOADED);
+    expect(screen.getByTestId("pi-first-name").textContent).toEqual("Test");
+    expect(screen.getByTestId("pi-last-name").textContent).toEqual("User");
+  });
+
+  it("should not execute getMyLastApplication if Section A is started", async () => {
+    const mocks = [
+      {
+        request: {
+          query: GET_LAST_APP,
+        },
+        result: {
+          data: {
+            getMyLastApplication: {
+              _id: "ABC-LAST-ID-123",
+              questionnaireData: JSON.stringify({
+                pi: {
+                  firstName: "Should not be",
+                  lastName: "Used or called",
+                }
+              }),
+            },
+          },
+        },
+      },
+      {
+        request: {
+          query: GET_APP,
+          variables: {
+            id: "AAA-BBB-EXISTING-APP",
+          },
+        },
+        result: {
+          data: {
+            getApplication: {
+              _id: "AAA-BBB-EXISTING-APP",
+              questionnaireData: JSON.stringify({ sections: [{ name: "A", status: "In Progress" }] }),
+            },
+          },
+        },
+      }
+    ];
+    const screen = render(<TestParent mocks={mocks} appId="AAA-BBB-EXISTING-APP" />);
+
+    await waitFor(() => expect(screen.getByTestId("status")).toBeInTheDocument());
+
+    expect(screen.getByTestId("status").textContent).toEqual(FormStatus.LOADED);
+    expect(screen.getByTestId("pi-first-name").textContent).toEqual("");
+    expect(screen.getByTestId("pi-last-name").textContent).toEqual("");
+  });
+
   // it("should execute saveApplication when setData is called", async () => {
   //   fail("Not implemented");
   // });

--- a/src/components/Contexts/FormContext.tsx
+++ b/src/components/Contexts/FormContext.tsx
@@ -250,12 +250,26 @@ export const FormProvider: FC<ProviderProps> = ({ children, id } : ProviderProps
 
       const { getApplication } = d;
       const questionnaireData: QuestionnaireData = JSON.parse(getApplication?.questionnaireData || null);
+
+      // Check if we need to autofill the PI details
+      const sectionA = questionnaireData?.sections?.find((s: Section) => s?.name === "A");
+      if (!["In Progress", "Complete"].includes(sectionA?.status)) {
+        const { data: lastAppData } = await lastApp();
+        const { getMyLastApplication } = lastAppData || {};
+        const parsedLastAppData = JSON.parse(getMyLastApplication?.questionnaireData || null) || {};
+
+        questionnaireData.pi = {
+          ...questionnaireData.pi,
+          ...parsedLastAppData.pi,
+        };
+      }
+
       setState({
         status: Status.LOADED,
         data: {
           ...merge(cloneDeep(InitialApplication), d?.getApplication),
           questionnaireData: {
-          ...merge(cloneDeep(InitialQuestionnaire), questionnaireData),
+            ...merge(cloneDeep(InitialQuestionnaire), questionnaireData),
             // To avoid false positive form changes
             // NOTE: We may be able to remove this since we control the nested object
             targetedReleaseDate: FormatDate(questionnaireData.targetedReleaseDate, datePattern, dateTodayFallback),


### PR DESCRIPTION
### Overview

This updates the "PI Autofill" functionality to execute ONLY if Section A is not started.

NOTE: This is a slower approach because the form has to wait until the `getApplication` query resolves before executing the `getMyLastApplication` query–but this is implemented exactly per the requirements.