### PR TITLE
CRDCDH-136 Validate inputs on save

### DIFF
--- a/src/components/Questionnaire/AutocompleteInput.tsx
+++ b/src/components/Questionnaire/AutocompleteInput.tsx
@@ -11,6 +11,7 @@ import {
 } from "@mui/material";
 import { SyntheticEvent, useEffect, useId, useRef, useState } from "react";
 import { ReactComponent as DropdownArrowsIconSvg } from "../../assets/icons/dropdown_arrows.svg";
+import { updateInputValidity } from '../../utils';
 
 const StyledFormControl = styled(FormControl)(() => ({
   height: "100%",
@@ -160,18 +161,16 @@ const AutocompleteInput = <T,>({
   const [error, setError] = useState<boolean>(false);
   const helperText = helpText || (required ? "This field is required" : " ");
   const inputRef = useRef<HTMLInputElement>(null);
-  const valRef = useRef<T>(value);
 
-  const validateInput = (input: AutocompleteValue<T, false, false, false>,): boolean => {
-    const isString = typeof input === "string";
-    if (validate) {
-      const customIsValid = validate(input);
-      return customIsValid;
+  const processValue = (newValue: T) => {
+    if (typeof validate === "function") {
+      const customIsValid = validate(newValue);
+      updateInputValidity(inputRef, !customIsValid ? helpText : "");
+    } else if (required) {
+      updateInputValidity(inputRef, !newValue ? helperText : "");
     }
-    if ((required && !input) || !(required && isString && input?.length > 0)) {
-      return false;
-    }
-    return true;
+
+    setVal(newValue);
   };
 
   const onChangeWrapper = (
@@ -183,19 +182,21 @@ const AutocompleteInput = <T,>({
       onChange(event, newValue, reason);
     }
 
-    setVal(newValue);
-    setError(!validateInput(newValue));
-  };
-
-  const onBlurWrapper = (value: string): void => {
-    if (freeSolo) {
-      setError(!validateInput(value as T));
-    }
+    processValue(newValue);
+    setError(false);
   };
 
   useEffect(() => {
-    if (value !== valRef.current) onChangeWrapper(null, value, null);
-    valRef.current = value;
+    const invalid = () => setError(true);
+
+    inputRef.current?.addEventListener("invalid", invalid);
+    return () => {
+      inputRef.current?.removeEventListener("invalid", invalid);
+    };
+  }, [inputRef]);
+
+  useEffect(() => {
+    processValue(value);
   }, [value]);
 
   return (
@@ -208,7 +209,6 @@ const AutocompleteInput = <T,>({
         <StyledAutocomplete
           value={val}
           onChange={onChangeWrapper}
-          onBlur={(event: React.FocusEvent<HTMLInputElement>) => onBlurWrapper(event.target.value)}
           options={options}
           readOnly={readOnly}
           forcePopupIcon
@@ -232,7 +232,7 @@ const AutocompleteInput = <T,>({
           renderInput={(params) => (
             <TextField
               {...params}
-              ref={inputRef}
+              inputRef={inputRef}
               name={name}
               required={required}
               placeholder={placeholder}

--- a/src/components/Questionnaire/FormGroupCheckbox.tsx
+++ b/src/components/Questionnaire/FormGroupCheckbox.tsx
@@ -8,6 +8,7 @@ import {
 import { FC, useEffect, useId, useRef, useState } from "react";
 import Tooltip from "./Tooltip";
 import CheckboxInput from "./CheckboxInput";
+import { updateInputValidity } from '../../utils';
 
 const StyledFormLabel = styled("label")(({ theme }) => ({
   fontWeight: 700,
@@ -29,15 +30,6 @@ const StyledAsterisk = styled("span")(() => ({
 const StyledFormHelperText = styled(FormHelperText)(() => ({
   marginLeft: 0,
 }));
-
-export type FormGroupCheckboxOption = {
-  label: string;
-  value: string;
-  name?: string; // overrides parent name in checkboxes
-  tooltipText?: string;
-  errorText?: string;
-  required?: boolean;
-};
 
 type Props = {
   idPrefix?: string;
@@ -111,24 +103,27 @@ const FormGroupCheckbox: FC<Props> = ({
     const multipleChecked = val?.length > 1;
 
     if (notSelectedAndRequired) {
-      firstCheckboxInputRef?.current.setCustomValidity(
-        "Please select at least one option"
-      );
-      setError(true);
+      updateInputValidity(firstCheckboxInputRef, "Please select at least one option");
       return;
     }
 
     if (!allowMultipleChecked && multipleChecked) {
-      firstCheckboxInputRef?.current.setCustomValidity(
-        "Please select only one option"
-      );
-      setError(true);
+      updateInputValidity(firstCheckboxInputRef, "Please select only one option");
       return;
     }
 
-    firstCheckboxInputRef?.current.setCustomValidity("");
+    updateInputValidity(firstCheckboxInputRef);
     setError(false);
   }, [val]);
+
+  useEffect(() => {
+    const invalid = () => setError(true);
+
+    firstCheckboxInputRef.current?.addEventListener("invalid", invalid);
+    return () => {
+      firstCheckboxInputRef.current?.removeEventListener("invalid", invalid);
+    };
+  }, [firstCheckboxInputRef]);
 
   return (
     <Grid md={gridWidth || 6} xs={12} item>

--- a/src/components/Questionnaire/RadioYesNoInput.tsx
+++ b/src/components/Questionnaire/RadioYesNoInput.tsx
@@ -134,10 +134,10 @@ const RadioYesNoInput: FC<Props> = ({
 
   useEffect(() => {
     if (required && val === null) {
-          updateInputValidity(radioGroupInputRef, "Please select an option");
-        } else {
-          updateInputValidity(radioGroupInputRef);
-        }
+      updateInputValidity(radioGroupInputRef, "Please select an option");
+    } else {
+      updateInputValidity(radioGroupInputRef);
+    }
   }, [val]);
 
   useEffect(() => {

--- a/src/components/Questionnaire/RadioYesNoInput.tsx
+++ b/src/components/Questionnaire/RadioYesNoInput.tsx
@@ -1,4 +1,3 @@
-// TODO
 import React, { FC, useState, useRef, useEffect } from 'react';
 import { Grid, FormControl, FormControlLabel, Radio, RadioGroup, RadioProps, RadioGroupProps, FormHelperText } from '@mui/material';
 import styled from "styled-components";

--- a/src/components/Questionnaire/RadioYesNoInput.tsx
+++ b/src/components/Questionnaire/RadioYesNoInput.tsx
@@ -1,5 +1,6 @@
+// TODO
 import React, { FC, useState, useRef, useEffect } from 'react';
-import { Grid, FormControl, FormControlLabel, Radio, RadioGroup, RadioProps, RadioGroupProps } from '@mui/material';
+import { Grid, FormControl, FormControlLabel, Radio, RadioGroup, RadioProps, RadioGroupProps, FormHelperText } from '@mui/material';
 import styled from "styled-components";
 import { updateInputValidity } from '../../utils';
 
@@ -18,10 +19,20 @@ const GridStyled = styled(Grid)<{ $containerWidth?: string; }>`
   }
 
   #invisibleRadioInput{
-    height: 0; 
-    border: none; 
+    height: 0;
+    border: none;
     width: 0;
   }
+  "& .MuiFormHelperText-root": {
+    color: "#083A50",
+    marginLeft: "0",
+    [theme.breakpoints.up("lg")]: {
+      whiteSpace: "nowrap",
+    },
+  },
+  "& .MuiFormHelperText-root.Mui-error": {
+    color: "#D54309 !important",
+  },
 `;
 
 const BpIcon = styled('span')(() => ({
@@ -110,15 +121,18 @@ const RadioYesNoInput: FC<Props> = ({
   ...rest
 }) => {
   const [val, setVal] = useState<string>(value?.toString() === "" ? null : value);
+  const [error, setError] = useState(false);
   const radioGroupInputRef = useRef<HTMLInputElement>(null);
 
-  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const onChangeWrapper = (event: React.ChangeEvent<HTMLInputElement>) => {
     if (readOnly) {
       return;
     }
     const newValue = (event.target as HTMLInputElement).value;
     setVal(newValue === "" ? null : newValue);
+    setError(false);
   };
+
   useEffect(() => {
     if (required && !val) {
       updateInputValidity(radioGroupInputRef, "Please select an option");
@@ -127,9 +141,18 @@ const RadioYesNoInput: FC<Props> = ({
     }
   }, [val]);
 
+  useEffect(() => {
+    const invalid = () => setError(true);
+
+    radioGroupInputRef.current?.addEventListener("invalid", invalid);
+    return () => {
+      radioGroupInputRef.current?.removeEventListener("invalid", invalid);
+    };
+  }, [radioGroupInputRef]);
+
   return (
     <GridStyled md={gridWidth || 6} xs={12} item $containerWidth={containerWidth}>
-      <FormControl className="formControl">
+      <FormControl className="formControl" error={error}>
         <StyledFormLabel>
           {required ? <StyledAsterisk>*</StyledAsterisk> : ""}
           {label}
@@ -137,7 +160,7 @@ const RadioYesNoInput: FC<Props> = ({
         <RadioGroup
           name={name}
           value={val}
-          onChange={handleChange}
+          onChange={onChangeWrapper}
           id={id}
           data-type="string"
           {...rest}
@@ -145,6 +168,9 @@ const RadioYesNoInput: FC<Props> = ({
           <FormControlLabel value="true" color="#275D89" control={<BpRadio inputRef={radioGroupInputRef} id={id.concat("-yes-radio-button")} readOnly={readOnly} />} label="Yes" />
           <FormControlLabel value="false" color="#275D89" control={<BpRadio id={id.concat("-no-radio-button")} readOnly={readOnly} />} label="No" />
         </RadioGroup>
+        <FormHelperText>
+          {(!readOnly && error ? "This field is required" : null) || " "}
+        </FormHelperText>
       </FormControl>
     </GridStyled>
   );

--- a/src/components/Questionnaire/SelectInput.tsx
+++ b/src/components/Questionnaire/SelectInput.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useId, useState } from "react";
+import React, { FC, useEffect, useId, useRef, useState } from "react";
 import {
   FormControl,
   FormHelperText,
@@ -9,6 +9,7 @@ import {
   styled,
 } from "@mui/material";
 import dropdownArrowsIcon from "../../assets/icons/dropdown_arrows.svg";
+import { updateInputValidity } from '../../utils';
 
 const DropdownArrowsIcon = styled("div")(() => ({
   backgroundImage: `url(${dropdownArrowsIcon})`,
@@ -159,27 +160,24 @@ const SelectInput: FC<Props> = ({
   const id = useId();
 
   const [val, setVal] = useState(multiple ? [] : "");
-  const [error] = useState(false);
+  const [error, setError] = useState(false);
   const helperText = helpText || (required ? "This field is required" : " ");
+  const inputRef = useRef(null);
 
-  const validateInput = (input: string | string[]) => {
-    const inputIsArray = Array.isArray(input);
+  const processValue = (newValue: string | string[]) => {
+    const inputIsArray = Array.isArray(newValue);
     if (multiple && !inputIsArray) {
-      return false;
+      updateInputValidity(inputRef, "Please select at least one option");
+    } else if (inputIsArray) {
+      const containsOnlyValidOptions = newValue.every((value: string) => !!options.find((option) => option.value === value));
+      updateInputValidity(inputRef, containsOnlyValidOptions ? "" : "Please select only valid options");
+    } else if (required && !options.findIndex((option) => option.value === newValue)) {
+      updateInputValidity(inputRef, "Please select an entry from the list");
+    } else {
+      updateInputValidity(inputRef, "");
     }
 
-    if (inputIsArray) {
-      const containsOnlyValidOptions = input.every((value: string) => !!options.find((option) => option.value === value));
-      return containsOnlyValidOptions;
-    }
-    const isValidOption = !!options.find((option) => option.value === input);
-    return isValidOption;
-  };
-
-  const getValidInitialValue = (input: string | string[]) => {
-    const validInitialValue = multiple ? [] : "";
-
-    return validateInput(input) ? input : validInitialValue;
+    setVal(newValue);
   };
 
   const onChangeWrapper = (newVal) => {
@@ -187,11 +185,21 @@ const SelectInput: FC<Props> = ({
       onChange(newVal);
     }
 
-    setVal(newVal);
+    processValue(newVal);
+    setError(false);
   };
 
   useEffect(() => {
-    onChangeWrapper(getValidInitialValue(value));
+    const invalid = () => setError(true);
+
+    inputRef.current?.node?.addEventListener("invalid", invalid);
+    return () => {
+      inputRef.current?.node?.removeEventListener("invalid", invalid);
+    };
+  }, [inputRef]);
+
+  useEffect(() => {
+    processValue(value);
   }, [value]);
 
   return (
@@ -212,6 +220,7 @@ const SelectInput: FC<Props> = ({
           multiple={multiple}
           placeholderText={placeholder}
           readOnly={readOnly}
+          inputRef={inputRef}
           {...rest}
         >
           {options.map((option) => (

--- a/src/components/Questionnaire/SwitchInput.tsx
+++ b/src/components/Questionnaire/SwitchInput.tsx
@@ -1,4 +1,7 @@
-import React, { FC, ReactElement, useEffect, useId, useMemo, useRef, useState } from 'react';
+import React, {
+  FC, ReactElement, useEffect,
+  useId, useMemo, useRef, useState
+} from 'react';
 import { SwitchProps, Grid, Switch, FormHelperText } from '@mui/material';
 import styled from "styled-components";
 import Tooltip from "./Tooltip";
@@ -156,9 +159,9 @@ const CustomSwitch: FC<Props> = ({
   const [val, setVal] = useState<boolean | null>(value);
   const [touched, setTouched] = useState(value?.toString()?.length > 0);
   const [error, setError] = useState(false);
-
   const errorMsg = errorText || (required ? "This field is required" : null);
-  const switchInputRef = useRef<HTMLInputElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
   const proxyValue = useMemo(() => {
     if (isBoolean) {
       return touchRequired && !touched ? undefined : val?.toString();
@@ -172,12 +175,11 @@ const CustomSwitch: FC<Props> = ({
       return;
     }
     if (!touched) {
-      updateInputValidity(switchInputRef, errorMsg);
-      setError(true);
+      updateInputValidity(inputRef, errorMsg);
       return;
     }
-    updateInputValidity(switchInputRef);
-    setError(false);
+
+    updateInputValidity(inputRef);
   }, [touched, touchRequired]);
 
   const onChangeWrapper = (event: React.ChangeEvent<HTMLInputElement>, checked: boolean) => {
@@ -192,7 +194,17 @@ const CustomSwitch: FC<Props> = ({
     }
 
     setVal(checked);
+    setError(false);
   };
+
+  useEffect(() => {
+    const invalid = () => setError(true);
+
+    inputRef.current?.addEventListener("invalid", invalid);
+    return () => {
+      inputRef.current?.removeEventListener("invalid", invalid);
+    };
+  }, [inputRef]);
 
   return (
     <GridStyled md={gridWidth || 6} xs={12} item>
@@ -206,7 +218,7 @@ const CustomSwitch: FC<Props> = ({
           <div className="switchYesNoContainer">
             <div className={val ? "text" : "textChecked"}>No</div>
             <Switch
-              inputRef={switchInputRef}
+              inputRef={inputRef}
               inputProps={{ datatype: "boolean" }}
               focusVisibleClassName="focusVisible"
               id={id}

--- a/src/components/Questionnaire/TableTextInput.tsx
+++ b/src/components/Questionnaire/TableTextInput.tsx
@@ -1,3 +1,4 @@
+// TODO
 import React, { FC, useEffect, useId, useState, useRef } from "react";
 import {
   Input,
@@ -5,6 +6,7 @@ import {
 } from "@mui/material";
 import { WithStyles, withStyles } from "@mui/styles";
 import useFormMode from "../../content/questionnaire/sections/hooks/useFormMode";
+import { updateInputValidity } from '../../utils';
 
 /*
 *Pass in a regex pattern if you want this field to have custom validation checking
@@ -41,15 +43,15 @@ const TableTextInput: FC<Props> = ({
 
   const [val, setVal] = useState(value);
   const regex = new RegExp(pattern);
-  const inputElement = useRef<HTMLInputElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
   const onChange = (newVal) => {
     if (typeof maxLength === "number" && newVal.length > maxLength) {
       newVal = newVal.slice(0, maxLength);
     }
     if (!newVal.match(regex)) {
-      inputElement.current.setCustomValidity(patternValidityMessage || "Please enter input in the correct format");
+      updateInputValidity(inputRef, patternValidityMessage || "Please enter input in the correct format");
     } else {
-      inputElement.current.setCustomValidity("");
+      updateInputValidity(inputRef);
     }
     setVal(newVal);
   };
@@ -60,7 +62,7 @@ const TableTextInput: FC<Props> = ({
 
   return (
     <Input
-      inputRef={inputElement}
+      inputRef={inputRef}
       sx={{ width: "100%" }}
       classes={{ root: classes.input }}
       id={id}

--- a/src/components/Questionnaire/TableTextInput.tsx
+++ b/src/components/Questionnaire/TableTextInput.tsx
@@ -1,4 +1,3 @@
-// TODO
 import React, { FC, useEffect, useId, useState, useRef } from "react";
 import {
   Input,

--- a/src/config/AccessTypesConfig.ts
+++ b/src/config/AccessTypesConfig.ts
@@ -1,20 +1,18 @@
-import { FormGroupCheckboxOption } from "../components/Questionnaire/FormGroupCheckbox";
+/**
+ * Configuration for Questionnaire Section C Access Types
+ *
+ */
+const options: FormGroupCheckboxOption[] = [
+  {
+    label: "Open Access",
+    value: "Open Access",
+    tooltipText: "Data made publicly available to everyone without access restrictions"
+  },
+  {
+    label: "Controlled Access",
+    value: "Controlled Access",
+    tooltipText: "Data made available for secondary research only after investigators have obtained approval from NIH to use the requested data for a particular project"
+  },
+];
 
-  /**
-   * Configuration for Questionnaire Section C Access Types
-   *
-   */
-  const options: FormGroupCheckboxOption[] = [
-    {
-      label: "Open Access",
-      value: "Open Access",
-      tooltipText: "Data made publicly available to everyone without access restrictions"
-    },
-    {
-      label: "Controlled Access",
-      value: "Controlled Access",
-      tooltipText: "Data made available for secondary research only after investigators have obtained approval from NIH to use the requested data for a particular project"
-    },
-  ];
-
-  export default options;
+export default options;

--- a/src/config/CellLineModelSystemConfig.ts
+++ b/src/config/CellLineModelSystemConfig.ts
@@ -1,20 +1,18 @@
-import { FormGroupCheckboxOption } from "../components/Questionnaire/FormGroupCheckbox";
+/**
+ * Configuration for Questionnaire Section C Cell Line Model System
+ *
+ */
+const options: FormGroupCheckboxOption[] = [
+  {
+    label: "Cell lines",
+    value: "Cell lines",
+    name: "cellLines",
+  },
+  {
+    label: "Model systems",
+    value: "Model systems",
+    name: "modelSystems",
+  },
+];
 
-  /**
-   * Configuration for Questionnaire Section C Cell Line Model System
-   *
-   */
-  const options: FormGroupCheckboxOption[] = [
-    {
-      label: "Cell lines",
-      value: "Cell lines",
-      name: "cellLines",
-    },
-    {
-      label: "Model systems",
-      value: "Model systems",
-      name: "modelSystems",
-    },
-  ];
-
-  export default options;
+export default options;

--- a/src/content/questionnaire/FormView.tsx
+++ b/src/content/questionnaire/FormView.tsx
@@ -283,7 +283,7 @@ const FormView: FC<Props> = ({ section, classes } : Props) => {
    *
    * @returns {Promise<boolean>} true if the save was successful, false otherwise
    */
-  const saveForm = async (hideValidation = false) => {
+  const saveForm = async () => {
     if (readOnlyInputs || !userCanEdit) {
       return false;
     }
@@ -299,9 +299,6 @@ const FormView: FC<Props> = ({ section, classes } : Props) => {
       newData.sections = InitialSections;
     }
     const newStatus = ref.current.checkValidity() ? "Completed" : "In Progress";
-    if (!hideValidation) {
-      ref.current.reportValidity();
-    }
     const currentSection : Section = newData.sections.find((s) => s.name === activeSection);
     if (currentSection) {
       currentSection.status = newStatus;
@@ -335,7 +332,7 @@ const FormView: FC<Props> = ({ section, classes } : Props) => {
    */
   const saveAndNavigate = async () => {
     // Wait for the save handler to complete
-    const newId = await saveForm(true);
+    const newId = await saveForm();
     const reviewSectionUrl = `/submission/${data["_id"]}/REVIEW`; // TODO: Update to dynamic url instead
     const isNavigatingToReviewSection = blocker?.location?.pathname === reviewSectionUrl;
 

--- a/src/content/questionnaire/sections/D.tsx
+++ b/src/content/questionnaire/sections/D.tsx
@@ -2,7 +2,7 @@ import React, { FC, useEffect, useRef, useState } from "react";
 import { parseForm } from "@jalik/form-parser";
 import { cloneDeep } from "lodash";
 import styled from 'styled-components';
-import { Table, TableBody, TableCell, TableHead, TableRow } from '@mui/material';
+import { FormHelperText, Table, TableBody, TableCell, TableHead, TableRow, styled as MuiStyled } from '@mui/material';
 import RemoveCircleIcon from "@mui/icons-material/RemoveCircle";
 import AddCircleIcon from "@mui/icons-material/AddCircle";
 import { Status as FormStatus, useFormContext } from "../../../components/Contexts/FormContext";
@@ -18,12 +18,6 @@ import TableTextInput from "../../../components/Questionnaire/TableTextInput";
 import DatePickerInput from "../../../components/Questionnaire/DatePickerInput";
 import RadioYesNoInput from "../../../components/Questionnaire/RadioYesNoInput";
 import useFormMode from "./hooks/useFormMode";
-/**
- * Form Section D View
- *
- * @param {FormSectionProps} props
- * @returns {JSX.Element}
- */
 
 export type KeyedFileTypeData = {
   key: string;
@@ -142,6 +136,12 @@ const TableContainer = styled.div`
     }
 `;
 
+const TableHelperText = MuiStyled(FormHelperText)({
+  color: "#D54309",
+  marginLeft: "22px",
+  marginTop: "-15px",
+});
+
 const FormSectionD: FC<FormSectionProps> = ({ SectionOption, refs }: FormSectionProps) => {
   const { status, data: { questionnaireData: data } } = useFormContext();
   const { readOnlyInputs } = useFormMode();
@@ -166,18 +166,11 @@ const FormSectionD: FC<FormSectionProps> = ({ SectionOption, refs }: FormSection
     getFormObjectRef.current = getFormObject;
   }, [refs]);
 
-  useEffect(() => {
-    if (fileTypeData.length === 0) {
-      fileTypeDataRef.current.setCustomValidity("At least one file type is required");
-    } else {
-      fileTypeDataRef.current.setCustomValidity("");
-    }
-  }, [fileTypeDataRef]);
-
   const getFormObject = (): FormObject | null => {
     if (!formRef.current) {
       return null;
     }
+
     const formObject = parseForm(formRef.current, { nullify: false });
     const combinedData = { ...cloneDeep(data), ...formObject };
     // Remove empty strings from dataType arrays
@@ -193,6 +186,13 @@ const FormSectionD: FC<FormSectionProps> = ({ SectionOption, refs }: FormSection
     }
     // Override empty file array
     combinedData.files = formObject.files;
+
+    if (fileTypeData.length === 0) {
+      fileTypeDataRef.current.setCustomValidity("At least one file type is required");
+    } else {
+      fileTypeDataRef.current.setCustomValidity("");
+    }
+
     return { ref: formRef, data: combinedData };
   };
 
@@ -235,6 +235,7 @@ const FormSectionD: FC<FormSectionProps> = ({ SectionOption, refs }: FormSection
           label="Targeted Data Submission Delivery Date"
           name="targetedSubmissionDate"
           tooltipText="The date that transfer of data from the submitter to DataHub is expected to begin."
+          errorText="Please enter a valid date"
           initialValue={data.targetedSubmissionDate}
           gridWidth={6}
           disablePast
@@ -244,6 +245,7 @@ const FormSectionD: FC<FormSectionProps> = ({ SectionOption, refs }: FormSection
           label="Expected Publication Date"
           name="targetedReleaseDate"
           tooltipText="The date that submitters would like their data to be released to the public."
+          errorText="Please enter a valid date"
           initialValue={data.targetedReleaseDate}
           gridWidth={6}
           disablePast
@@ -518,6 +520,11 @@ const FormSectionD: FC<FormSectionProps> = ({ SectionOption, refs }: FormSection
             </TableBody>
           </Table>
         </TableContainer>
+        {!fileTypeDataRef?.current?.checkValidity() && (
+          <TableHelperText>
+            At least one file type is required
+          </TableHelperText>
+        )}
       </SectionGroup>
       <SectionGroup
         title="Additional Comments"

--- a/src/content/questionnaire/sections/D.tsx
+++ b/src/content/questionnaire/sections/D.tsx
@@ -166,6 +166,14 @@ const FormSectionD: FC<FormSectionProps> = ({ SectionOption, refs }: FormSection
     getFormObjectRef.current = getFormObject;
   }, [refs]);
 
+  useEffect(() => {
+    if (fileTypeData.length === 0) {
+      fileTypeDataRef.current.setCustomValidity("At least one file type is required");
+    } else {
+      fileTypeDataRef.current.setCustomValidity("");
+    }
+  }, [fileTypeDataRef]);
+
   const getFormObject = (): FormObject | null => {
     if (!formRef.current) {
       return null;
@@ -186,12 +194,6 @@ const FormSectionD: FC<FormSectionProps> = ({ SectionOption, refs }: FormSection
     }
     // Override empty file array
     combinedData.files = formObject.files;
-
-    if (fileTypeData.length === 0) {
-      fileTypeDataRef.current.setCustomValidity("At least one file type is required");
-    } else {
-      fileTypeDataRef.current.setCustomValidity("");
-    }
 
     return { ref: formRef, data: combinedData };
   };

--- a/src/types/Globals.d.ts
+++ b/src/types/Globals.d.ts
@@ -30,3 +30,12 @@ type SectionOption = {
   id: string;
   component: React.ComponentType<FormSectionProps>;
 };
+
+type FormGroupCheckboxOption = {
+  label: string;
+  value: string;
+  name?: string; // overrides parent name in checkboxes
+  tooltipText?: string;
+  errorText?: string;
+  required?: boolean;
+};

--- a/src/utils/formUtils.ts
+++ b/src/utils/formUtils.ts
@@ -1,4 +1,3 @@
-import { FormGroupCheckboxOption } from '../components/Questionnaire/FormGroupCheckbox';
 import programOptions, { BlankProgram, BlankStudy, OptionalProgram, OptionalStudy } from '../config/ProgramConfig';
 
 /**

--- a/src/utils/validationUtils.ts
+++ b/src/utils/validationUtils.ts
@@ -8,6 +8,9 @@ export const updateInputValidity = (inputRef: React.RefObject<HTMLInputElement>,
   if (!inputRef?.current) {
     return; // Invalid ref
   }
+  if (typeof inputRef.current.setCustomValidity !== 'function') {
+    return; // Input element doesn't support custom validity
+  }
 
   inputRef.current.setCustomValidity(message);
 };

--- a/src/utils/validationUtils.ts
+++ b/src/utils/validationUtils.ts
@@ -16,6 +16,25 @@ export const updateInputValidity = (inputRef: React.RefObject<HTMLInputElement>,
 };
 
 /**
+ *  Updates the validity of a MUI select component by setting a custom validation message.
+ *
+ * NOTE: This interfaces with the MUI Select ref which returns { node, value, focus }
+ *
+ * @param selectRef - the reference to the MUI select component to be validated
+ * @param message - The custom validation message to be set. Defaults to an empty string if not provided.
+ */
+export const updateSelectValidity = (selectRef, message = ""): void => {
+  if (!selectRef?.current?.node) {
+    return; // Invalid ref
+  }
+  if (typeof selectRef.current.node?.setCustomValidity !== 'function') {
+    return; // Input element doesn't support custom validity
+  }
+
+  selectRef.current.node.setCustomValidity(message);
+};
+
+/**
  * Validates whether a given value (string or number) lies within a specified range.
  *
  * @param value - The value to be validated. It can be of type string or number.


### PR DESCRIPTION
### Overview

This PR changes all required input components to display validation on save only, and clears the error state on change. Additionally, it removes the visible HTML5 validation alert (see below).

![image](https://github.com/CBIIT/crdc-datahub-ui/assets/38357871/7a861c58-b896-4a03-98d3-b59e0cd8254c)
