### PR TITLE
CRDC-45 Section D updates and login styling

### DIFF
--- a/src/components/Questionnaire/RadioYesNoInput.tsx
+++ b/src/components/Questionnaire/RadioYesNoInput.tsx
@@ -6,8 +6,8 @@ import { updateInputValidity } from '../../utils';
 const GridStyled = styled(Grid)<{ $containerWidth?: string; }>`
   width: ${(props) => props.$containerWidth};
   .formControl{
-    margin-top: 6px;
-    margin-bottom: 8px;
+    margin-top: 8px;
+    margin-bottom: 4px;
   }
   .css-hsm3ra-MuiFormLabel-root {
     color: rgba(0, 0, 0, 0.6) !important;
@@ -17,21 +17,21 @@ const GridStyled = styled(Grid)<{ $containerWidth?: string; }>`
     margin-left: 10px;
   }
 
-  #invisibleRadioInput{
+  #invisibleRadioInput {
     height: 0;
     border: none;
     width: 0;
   }
-  "& .MuiFormHelperText-root": {
-    color: "#083A50",
-    marginLeft: "0",
-    [theme.breakpoints.up("lg")]: {
-      whiteSpace: "nowrap",
-    },
-  },
-  "& .MuiFormHelperText-root.Mui-error": {
-    color: "#D54309 !important",
-  },
+  .MuiFormHelperText-root {
+    color: #083A50;
+    margin-left: 0;
+  }
+  .MuiFormHelperText-root.Mui-error {
+    color: #D54309 !important;
+  }
+  .displayNone {
+    display: none !important;
+  }
 `;
 
 const BpIcon = styled('span')(() => ({
@@ -167,7 +167,7 @@ const RadioYesNoInput: FC<Props> = ({
           <FormControlLabel value="true" color="#1D91AB" control={<BpRadio inputRef={radioGroupInputRef} id={id.concat("-yes-radio-button")} readOnly={readOnly} />} label="Yes" />
           <FormControlLabel value="false" color="#1D91AB" control={<BpRadio id={id.concat("-no-radio-button")} readOnly={readOnly} />} label="No" />
         </RadioGroup>
-        <FormHelperText>
+        <FormHelperText className={(!readOnly && error ? "" : "displayNone") || ""}>
           {(!readOnly && error ? "This field is required" : null) || " "}
         </FormHelperText>
       </FormControl>

--- a/src/components/Questionnaire/SectionGroup.tsx
+++ b/src/components/Questionnaire/SectionGroup.tsx
@@ -9,6 +9,7 @@ type Props = {
   title?: string;
   description?: string | React.ReactNode;
   endButton?: React.ReactNode;
+  beginButton?: React.ReactNode;
 };
 
 const StyledGrid = styled(Grid)({
@@ -47,6 +48,12 @@ export const StyledDescription = styled(Typography)({
 const StyledEndAdornment = styled(Box)({
   marginLeft: "auto",
 });
+const StyledBeginAdornment = styled(Box)({
+  marginRight: "12px",
+  marginTop: "auto",
+  marginBottom: "auto",
+  paddingTop: "25px",
+});
 
 /**
  * Generic Form Input Section Group
@@ -54,7 +61,7 @@ const StyledEndAdornment = styled(Box)({
  * @param {Props} props
  * @returns {React.ReactNode}
  */
-const SectionGroup: FC<Props> = ({ title, description, children, endButton }) => (
+const SectionGroup: FC<Props> = ({ title, description, children, endButton, beginButton }) => (
   <StyledGrid container rowSpacing={0} columnSpacing={1.5}>
     <StyledHeader xs={12} item>
       <Stack direction="column" alignItems="flex-start">
@@ -63,11 +70,15 @@ const SectionGroup: FC<Props> = ({ title, description, children, endButton }) =>
             {title}
           </StyledTitle>
         )}
-        {description && (
+        <Stack direction="row" alignItems="flex-start" justifyContent="space-between" width="100%">
+          {description && (
           <StyledDescription variant="body1">
             {description}
           </StyledDescription>
         )}
+          {beginButton && <StyledBeginAdornment>{beginButton}</StyledBeginAdornment>}
+        </Stack>
+
       </Stack>
     </StyledHeader>
     {children}

--- a/src/components/Questionnaire/SwitchInput.tsx
+++ b/src/components/Questionnaire/SwitchInput.tsx
@@ -85,7 +85,7 @@ const GridStyled = styled(Grid)`
   .switchYesNoContainer {
     display: flex;
     align-items: center;
-    margin-right: 32px;
+    margin-right: 72px;
     min-height: 50px;
   }
   .tooltip {

--- a/src/components/Questionnaire/SwitchInput.tsx
+++ b/src/components/Questionnaire/SwitchInput.tsx
@@ -8,6 +8,7 @@ import Tooltip from "./Tooltip";
 import { updateInputValidity } from '../../utils';
 
 const GridStyled = styled(Grid)`
+  margin-bottom: 20px;
   // Customize the root class
   .switchRoot {
     width: 65px;
@@ -76,6 +77,7 @@ const GridStyled = styled(Grid)`
     margin-right: 4px;
   }
   .labelContainer {
+    color: #083A50;
     display: flex;
     align-items: center;
     height: 20px;
@@ -152,6 +154,7 @@ const CustomSwitch: FC<Props> = ({
   containerWidth = "auto",
   touchRequired,
   readOnly,
+  sx,
   ...rest
 }) => {
   const id = useId();
@@ -207,7 +210,7 @@ const CustomSwitch: FC<Props> = ({
   }, [inputRef]);
 
   return (
-    <GridStyled md={gridWidth || 6} xs={12} item>
+    <GridStyled md={gridWidth || 6} xs={12} item sx={sx}>
       <Container $containerWidth={containerWidth}>
         <div className="labelContainer">
           {required ? <span className="asterisk">*</span> : ""}

--- a/src/components/Questionnaire/TableFileTypeAndExtensionInput.tsx
+++ b/src/components/Questionnaire/TableFileTypeAndExtensionInput.tsx
@@ -54,6 +54,37 @@ const TableAutocompleteInput: FC<Props> = ({
   const [extensionVal, setExtensionVal] = useState(extensionValue);
   const fileTypeRef = useRef<HTMLInputElement>(null);
   const fileExtensionRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    const invalid = (e) => {
+      if (!e.target.reportValidityInProgress) {
+        e.target.reportValidityInProgress = true;
+        e.target.reportValidity();
+        e.target.reportValidityInProgress = false;
+      }
+    };
+
+    fileTypeRef.current?.addEventListener("invalid", invalid);
+    return () => {
+      fileTypeRef.current?.removeEventListener("invalid", invalid);
+    };
+  }, [fileTypeRef]);
+
+  useEffect(() => {
+    const invalid = (e) => {
+      if (!e.target.reportValidityInProgress) {
+        e.target.reportValidityInProgress = true;
+        e.target.reportValidity();
+        e.target.reportValidityInProgress = false;
+      }
+    };
+
+    fileExtensionRef.current?.addEventListener("invalid", invalid);
+    return () => {
+      fileExtensionRef.current?.removeEventListener("invalid", invalid);
+    };
+  }, [fileExtensionRef]);
+
   const onTypeValChangeWrapper = (e, v, r) => {
     v = v || "";
     if (v === "") {

--- a/src/components/Questionnaire/TableTextInput.tsx
+++ b/src/components/Questionnaire/TableTextInput.tsx
@@ -43,6 +43,20 @@ const TableTextInput: FC<Props> = ({
   const [val, setVal] = useState(value);
   const regex = new RegExp(pattern);
   const inputRef = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    const invalid = (e) => {
+      if (!e.target.reportValidityInProgress) {
+        e.target.reportValidityInProgress = true;
+        e.target.reportValidity();
+        e.target.reportValidityInProgress = false;
+      }
+    };
+
+    inputRef.current?.addEventListener("invalid", invalid);
+    return () => {
+      inputRef.current?.removeEventListener("invalid", invalid);
+    };
+  }, [inputRef]);
   const onChange = (newVal) => {
     if (typeof maxLength === "number" && newVal.length > maxLength) {
       newVal = newVal.slice(0, maxLength);

--- a/src/config/InitialValues.ts
+++ b/src/config/InitialValues.ts
@@ -73,6 +73,6 @@ sections: [],
     otherDataTypes: "",
     futureDataTypes: false,
   },
-  files: [],
+  files: [{ type: ``, count: null, amount: "", extension: "" }],
   submitterComment: "",
 };

--- a/src/content/index.tsx
+++ b/src/content/index.tsx
@@ -14,7 +14,7 @@ const StyledDialog = styled(Dialog)`
   }
   .buttonContainer {
     display: flex;
-    justify-content: space-around;
+    justify-content: center;
   }
   .loginDialogText {
     margin-top: 57px;
@@ -37,6 +37,8 @@ const StyledDialog = styled(Dialog)`
     margin-top: 39px;
     text-decoration: none;
     color: rgba(0, 0, 0, 0.87);
+    margin-left: 7px;
+    margin-right: 7px;
   }
   .loginDialogButton:hover {
     cursor: pointer;
@@ -80,21 +82,6 @@ const Home: FC = () => {
             >
               <strong>Close</strong>
             </div>
-            {/* <div
-              role="button"
-              tabIndex={0}
-              id="loginDialogLoginButton"
-              className="loginDialogButton"
-              onKeyDown={(e) => {
-                    if (e.key === "Enter") {
-                        setShowRedirectDialog(false);
-                    }
-                }}
-              onClick={() => setShowRedirectDialog(false)}
-            >
-              <strong>Log In</strong>
-
-            </div> */}
             <Link
               id="loginDialogLoginButton" className="loginDialogButton"
               to="/login" state={{ redirectURLOnLoginSuccess: dialogRedirectPath }}

--- a/src/content/questionnaire/sections/D.tsx
+++ b/src/content/questionnaire/sections/D.tsx
@@ -451,7 +451,7 @@ const FormSectionD: FC<FormSectionProps> = ({ SectionOption, refs }: FormSection
                       name={`files[${idx}][count]`}
                       type="number"
                       value={fileData.count ?? ""}
-                      placeholder="Enter file counts"
+                      placeholder="Enter file count"
                       pattern="^[1-9]\d*$"
                       patternValidityMessage="Please enter a whole number greater than 0"
                     />

--- a/src/content/questionnaire/sections/D.tsx
+++ b/src/content/questionnaire/sections/D.tsx
@@ -2,7 +2,7 @@ import React, { FC, useEffect, useRef, useState } from "react";
 import { parseForm } from "@jalik/form-parser";
 import { cloneDeep } from "lodash";
 import styled from 'styled-components';
-import { FormHelperText, Table, TableBody, TableCell, TableHead, TableRow, styled as MuiStyled } from '@mui/material';
+import { Table, TableBody, TableCell, TableHead, TableRow } from '@mui/material';
 import RemoveCircleIcon from "@mui/icons-material/RemoveCircle";
 import AddCircleIcon from "@mui/icons-material/AddCircle";
 import { Status as FormStatus, useFormContext } from "../../../components/Contexts/FormContext";
@@ -23,21 +23,6 @@ export type KeyedFileTypeData = {
   key: string;
 } & FileInfo;
 
-const AdditionalDataInFutureSection = styled.div`
-    display: flex;
-    flex-direction: column;
-    width: fit-content;
-    margin-left: 12px;
-    color: #083A50;
-    font-size: 16px;
-    font-family: Nunito;
-    font-weight: 700;
-    line-height: 19.6px;
-
-    #AdditionalDataInFutureSectionText {
-      margin-bottom: 16px;
-    }
-`;
 const TableContainer = styled.div`
     margin-left: 12px;
     margin-bottom: 24px;
@@ -129,18 +114,10 @@ const TableContainer = styled.div`
       color: #D54309;
       margin-left: 6px;
     }
-    #invisibleTableInput {
-       height: 0;
-       border: none;
-       width: 0;
+    .MuiButton-startIcon {
+      margin: 0 !important;
     }
 `;
-
-const TableHelperText = MuiStyled(FormHelperText)({
-  color: "#D54309",
-  marginLeft: "22px",
-  marginTop: "-15px",
-});
 
 const FormSectionD: FC<FormSectionProps> = ({ SectionOption, refs }: FormSectionProps) => {
   const { status, data: { questionnaireData: data } } = useFormContext();
@@ -150,7 +127,6 @@ const FormSectionD: FC<FormSectionProps> = ({ SectionOption, refs }: FormSection
   const formRef = useRef<HTMLFormElement>();
   const { nextButtonRef, saveFormRef, submitFormRef, approveFormRef, rejectFormRef, getFormObjectRef } = refs;
   const [fileTypeData, setFileTypeData] = useState<KeyedFileTypeData[]>(data.files?.map(mapObjectWithKey) || []);
-  const fileTypeDataRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     if (!saveFormRef.current || !submitFormRef.current) {
@@ -165,14 +141,6 @@ const FormSectionD: FC<FormSectionProps> = ({ SectionOption, refs }: FormSection
 
     getFormObjectRef.current = getFormObject;
   }, [refs]);
-
-  useEffect(() => {
-    if (fileTypeData.length === 0) {
-      fileTypeDataRef.current.setCustomValidity("At least one file type is required");
-    } else {
-      fileTypeDataRef.current.setCustomValidity("");
-    }
-  }, [fileTypeDataRef]);
 
   const getFormObject = (): FormObject | null => {
     if (!formRef.current) {
@@ -201,17 +169,11 @@ const FormSectionD: FC<FormSectionProps> = ({ SectionOption, refs }: FormSection
   const addFileDataType = () => {
     setFileTypeData([
       ...fileTypeData,
-      { key: `${fileTypeData.length}_${new Date().getTime()}`, type: ``, count: 0, amount: "", extension: "" },
+      { key: `${fileTypeData.length}_${new Date().getTime()}`, type: ``, count: null, amount: "", extension: "" },
     ]);
-    fileTypeDataRef.current.setCustomValidity("");
   };
 
   const removeFileDataType = (key: string) => {
-    if (fileTypeData.length === 1) {
-      fileTypeDataRef.current.setCustomValidity("At least one file type is required");
-    } else {
-      fileTypeDataRef.current.setCustomValidity("");
-    }
     setFileTypeData(fileTypeData.filter((c) => c.key !== key));
   };
 
@@ -337,7 +299,7 @@ const FormSectionD: FC<FormSectionProps> = ({ SectionOption, refs }: FormSection
         />
         <TextInput
           id="section-d-other-data-types"
-          label="Other data types (Specify)"
+          label="Other Data Type(s)"
           name="otherDataTypes"
           value={data.otherDataTypes}
           placeholder="Other Data Types (Specify)"
@@ -409,7 +371,7 @@ const FormSectionD: FC<FormSectionProps> = ({ SectionOption, refs }: FormSection
         />
         <TextInput
           id="section-d-clinical-data-other-data-types"
-          label="Other Clinical Data Types (Specify)"
+          label="Other Clinical Data Types"
           name="clinicalData[otherDataTypes]"
           value={data.clinicalData.otherDataTypes}
           placeholder="Other clinical data types (Specify)"
@@ -417,20 +379,16 @@ const FormSectionD: FC<FormSectionProps> = ({ SectionOption, refs }: FormSection
           tooltipText="If there are any additional types of data included with the study not already specified above, describe here."
           readOnly={readOnlyInputs}
         />
-        <AdditionalDataInFutureSection>
-          <div id="AdditionalDataInFutureSectionText">
-            Inidcate if there will be additional types of data included with a future submission
-          </div>
-          <SwitchInput
-            id="section-d-additional-data-in-future"
-            label="Additional Data in future"
-            name="clinicalData[futureDataTypes]"
-            value={data.clinicalData.futureDataTypes}
-            gridWidth={10}
-            isBoolean
-            readOnly={readOnlyInputs}
-          />
-        </AdditionalDataInFutureSection>
+        <SwitchInput
+          id="section-d-additional-data-in-future"
+          label="Additional Data Types with a future submission?"
+          name="clinicalData[futureDataTypes]"
+          value={data.clinicalData.futureDataTypes}
+          gridWidth={8}
+          isBoolean
+          readOnly={readOnlyInputs}
+          tooltipText="Indicate if there will be additional types of data included with a future submission."
+        />
       </SectionGroup>
       <SectionGroup
         title="File Types"
@@ -441,7 +399,7 @@ const FormSectionD: FC<FormSectionProps> = ({ SectionOption, refs }: FormSection
             Indicate one file type per row. At least one file type is required.
           </>
         )}
-        endButton={(
+        beginButton={(
           <AddRemoveButton
             id="section-d-add-file-type-button"
             label="Add File Type"
@@ -458,18 +416,17 @@ const FormSectionD: FC<FormSectionProps> = ({ SectionOption, refs }: FormSection
                 <TableCell width="25%" className="fileTypeTableCell">
                   File Type
                   <span className="asterisk">*</span>
-                  <input tabIndex={-1} id="invisibleTableInput" ref={fileTypeDataRef} />
                 </TableCell>
-                <TableCell width="20%" className="fileTypeTableCell">
+                <TableCell width="24%" className="fileTypeTableCell">
                   File Extension
                   <span className="asterisk">*</span>
                 </TableCell>
-                <TableCell width="13%" className="tableTopRowMiddle">
-                  File Count
+                <TableCell width="15%" className="tableTopRowMiddle">
+                  Number of files
                   <span className="asterisk">*</span>
                 </TableCell>
                 <TableCell width="20%" className="tableTopRowMiddle">
-                  Estimated amount of data (KB, MB, GB, TB)
+                  Estimated data size
                   <span className="asterisk">*</span>
                 </TableCell>
                 <TableCell width="5%" className="topRowLast">Remove</TableCell>
@@ -493,8 +450,8 @@ const FormSectionD: FC<FormSectionProps> = ({ SectionOption, refs }: FormSection
                       id={`section-d-file-type-${idx}-number-of-files`}
                       name={`files[${idx}][count]`}
                       type="number"
-                      value={fileData.count}
-                      placeholder="12345"
+                      value={fileData.count ?? ""}
+                      placeholder="Enter file counts"
                       pattern="^[1-9]\d*$"
                       patternValidityMessage="Please enter a whole number greater than 0"
                     />
@@ -504,33 +461,31 @@ const FormSectionD: FC<FormSectionProps> = ({ SectionOption, refs }: FormSection
                       id={`section-d-file-type-${idx}-amount-of-data`}
                       name={`files[${idx}][amount]`}
                       value={fileData.amount}
-                      placeholder="E.g. 200GB (50 Char Limit)"
+                      placeholder="E.g. 500 GB"
                       maxLength={50}
+                      required
                     />
                   </TableCell>
                   <TableCell className="bottomRowLast">
-                    <div className="removeButtonContainer">
-                      <AddRemoveButton
-                        id={`section-d-file-type-${idx}-remove-file-type-button`}
-                        placement="start"
-                        onClick={() => removeFileDataType(fileData.key)}
-                        startIcon={<RemoveCircleIcon />}
-                        iconColor="#F18E8E"
-                        disabled={readOnlyInputs || status === FormStatus.SAVING}
-                        sx={{ minWidth: "0px !important" }}
-                      />
-                    </div>
+                    {idx !== 0 ? (
+                      <div className="removeButtonContainer">
+                        <AddRemoveButton
+                          id={`section-d-file-type-${idx}-remove-file-type-button`}
+                          placement="start"
+                          onClick={() => removeFileDataType(fileData.key)}
+                          startIcon={<RemoveCircleIcon />}
+                          iconColor="#F18E8E"
+                          disabled={readOnlyInputs || status === FormStatus.SAVING}
+                          sx={{ minWidth: "0px !important" }}
+                        />
+                      </div>
+                    ) : null}
                   </TableCell>
                 </TableRow>
               ))}
             </TableBody>
           </Table>
         </TableContainer>
-        {!fileTypeDataRef?.current?.checkValidity() && (
-          <TableHelperText>
-            At least one file type is required
-          </TableHelperText>
-        )}
       </SectionGroup>
       <SectionGroup
         title="Additional Comments"

--- a/src/content/questionnaire/sections/D.tsx
+++ b/src/content/questionnaire/sections/D.tsx
@@ -323,6 +323,7 @@ const FormSectionD: FC<FormSectionProps> = ({ SectionOption, refs }: FormSection
           )}
           tooltipText="Medical and experimental images from disciplines such as radiology, pathology, and microscopy."
           readOnly={readOnlyInputs}
+          sx={{ paddingBottom: "8px" }}
         />
         <SwitchInput
           id="section-d-epidemiologic-or-cohort"
@@ -395,6 +396,7 @@ const FormSectionD: FC<FormSectionProps> = ({ SectionOption, refs }: FormSection
           value={data.clinicalData.dataTypes.includes("treatmentData")}
           tooltipText="Treatment data refers to information on the action or administration of therapeutic agents to produce an effect that is intended to alter the course of a pathological process. Indicate whether treatment data is available for the study."
           readOnly={readOnlyInputs}
+          sx={{ paddingBottom: "8px" }}
         />
         <SwitchInput
           id="section-d-biospecimen-data"


### PR DESCRIPTION
This is to update the styling for the login dialog according to kailing's requests.
Requested:
![image](https://github.com/CBIIT/crdc-datahub-ui/assets/27042573/f57425d4-2772-4ffc-b901-659fa342bf3d)
Chaged to:
<img width="580" alt="Screenshot 2023-08-08 at 9 13 09 AM" src="https://github.com/CBIIT/crdc-datahub-ui/assets/27042573/ef445817-0f0f-479a-a2ed-334f0364e755">

This also implements changes kailing wanted for ticket CRDC-45.
