### PR TITLE
CRDCDH-37 Update cached state on save

### DIFF
--- a/src/components/Contexts/FormContext.test.tsx
+++ b/src/components/Contexts/FormContext.test.tsx
@@ -112,6 +112,7 @@ describe("FormContext > FormProvider Tests", () => {
           getApplication: {
             _id: "556ac14a-f247-42e8-8878-8468060fb49a",
             questionnaireData: JSON.stringify({
+              sections: [{ name: "A", status: "In Progress" }],
               pi: {
                 firstName: "Successfully",
                 lastName: "Fetched",

--- a/src/components/Contexts/FormContext.tsx
+++ b/src/components/Contexts/FormContext.tsx
@@ -172,8 +172,22 @@ export const FormProvider: FC<ProviderProps> = ({ children, id } : ProviderProps
     }
 
     if (d?.saveApplication?.["_id"] && data?.["_id"] === "new") {
-      newState.data._id = d.saveApplication["_id"];
+      newState.data = {
+        ...newState.data,
+        _id: d.saveApplication["_id"],
+        applicant: d?.saveApplication?.applicant,
+        organization: d?.saveApplication?.organization,
+      };
     }
+
+    newState.data = {
+      ...newState.data,
+      status: d?.saveApplication?.status,
+      updatedAt: d?.saveApplication?.updatedAt,
+      createdAt: d?.saveApplication?.createdAt,
+      submittedDate: d?.saveApplication?.submittedDate,
+      history: d?.saveApplication?.history
+    };
 
     setState({ ...newState, status: Status.LOADED });
     return d?.saveApplication?.["_id"] || false;

--- a/src/components/Contexts/FormContext.tsx
+++ b/src/components/Contexts/FormContext.tsx
@@ -344,8 +344,8 @@ export const FormProvider: FC<ProviderProps> = ({ children, id } : ProviderProps
       const questionnaireData: QuestionnaireData = JSON.parse(getApplication?.questionnaireData || null);
 
       // Check if we need to autofill the PI details
-      const sectionA = questionnaireData?.sections?.find((s: Section) => s?.name === "A");
-      if (!["In Progress", "Complete"].includes(sectionA?.status)) {
+      const sectionA: Section = questionnaireData?.sections?.find((s: Section) => s?.name === "A");
+      if (!sectionA || sectionA?.status === "Not Started") {
         const { data: lastAppData } = await lastApp();
         const { getMyLastApplication } = lastAppData || {};
         const parsedLastAppData = JSON.parse(getMyLastApplication?.questionnaireData || null) || {};

--- a/src/components/StatusBar/components/HistorySection.tsx
+++ b/src/components/StatusBar/components/HistorySection.tsx
@@ -1,4 +1,4 @@
-import { FC, useState } from "react";
+import { FC, useMemo, useState } from "react";
 import {
   Avatar,
   Button,
@@ -209,7 +209,7 @@ const HistorySection: FC = () => {
     data: { status, updatedAt, history },
   } = useFormContext();
   const [open, setOpen] = useState<boolean>(false);
-  const [sortedHistory] = useState<HistoryEvent[]>(SortHistory(history));
+  const sortedHistory = useMemo(() => SortHistory(history), [history]);
 
   return (
     <>

--- a/src/content/questionnaire/FormView.tsx
+++ b/src/content/questionnaire/FormView.tsx
@@ -371,7 +371,7 @@ const FormView: FC<Props> = ({ section, classes } : Props) => {
 
     // Update section status
     if (newData?.sections?.length !== Object.keys(map).length - 1) { // Not including review section
-      newData.sections = InitialSections;
+      newData.sections = { ...InitialSections };
     }
     const newStatus = ref.current.checkValidity() ? "Completed" : "In Progress";
     const currentSection : Section = newData.sections.find((s) => s.name === activeSection);

--- a/src/content/questionnaire/FormView.tsx
+++ b/src/content/questionnaire/FormView.tsx
@@ -9,6 +9,7 @@ import { LoadingButton } from '@mui/lab';
 import { WithStyles, withStyles } from "@mui/styles";
 import ForwardArrowIcon from '@mui/icons-material/ArrowForwardIos';
 import BackwardArrowIcon from '@mui/icons-material/ArrowBackIos';
+import { cloneDeep } from '@apollo/client/utilities';
 import { Status as FormStatus, useFormContext } from '../../components/Contexts/FormContext';
 import SuspenseLoader from '../../components/SuspenseLoader';
 import StatusBar from '../../components/StatusBar/StatusBar';
@@ -368,7 +369,7 @@ const FormView: FC<Props> = ({ section, classes } : Props) => {
 
     // Update section status
     if (newData?.sections?.length !== Object.keys(map).length - 1) { // Not including review section
-      newData.sections = { ...InitialSections };
+      newData.sections = cloneDeep(InitialSections);
     }
     const newStatus = ref.current.checkValidity() ? "Completed" : "In Progress";
     const currentSection : Section = newData.sections.find((s) => s.name === activeSection);

--- a/src/content/questionnaire/FormView.tsx
+++ b/src/content/questionnaire/FormView.tsx
@@ -3,13 +3,12 @@ import {
   useNavigate,
   unstable_useBlocker as useBlocker, unstable_Blocker as Blocker, Navigate
 } from 'react-router-dom';
-import { isEqual } from 'lodash';
+import { isEqual, cloneDeep } from 'lodash';
 import { Alert, Button, Container, Divider, Stack, styled } from '@mui/material';
 import { LoadingButton } from '@mui/lab';
 import { WithStyles, withStyles } from "@mui/styles";
 import ForwardArrowIcon from '@mui/icons-material/ArrowForwardIos';
 import BackwardArrowIcon from '@mui/icons-material/ArrowBackIos';
-import { cloneDeep } from '@apollo/client/utilities';
 import { Status as FormStatus, useFormContext } from '../../components/Contexts/FormContext';
 import SuspenseLoader from '../../components/SuspenseLoader';
 import StatusBar from '../../components/StatusBar/StatusBar';

--- a/src/graphql/saveApplication.ts
+++ b/src/graphql/saveApplication.ts
@@ -4,10 +4,28 @@ export const mutation = gql`
   mutation saveApplication($application: AppInput!) {
     saveApplication(application : $application) {
       _id
+      status
+      createdAt
+      updatedAt
+      submittedDate
+      history {
+        status
+        reviewComment
+        dateTime
+        userID
+      }
+      applicant {
+        applicantID
+        applicantName
+      }
+      organization {
+        _id
+        name
+      }
     }
   }
 `;
 
 export type Response = {
-  saveApplication: Pick<Application, "_id">;
+  saveApplication: Omit<Application, "programName" | "studyAbbreviation" | "questionnaireData">;
 };


### PR DESCRIPTION
### Overview

This PR is tangentially related to ticket CRDCDH-37 and incorporates general bug fixes.

**Specifics**:

- Fetches BE-populated fields and updates them in our local state on save. This will allow the Status Bar to always represent the BE stored application details (e.g. History / Status).
- Fixes a bug with overwriting the initial values for the section status array, which carries over between applications.
- Fixes a bug referencing the status of "Complete" instead of "Completed" when determining if we should fetch past data for Questionnaire Section A