### PR TITLE
CRDCDH-49 Form Auth Update

### DIFF
--- a/src/components/ProgressBar/ProgressBar.test.tsx
+++ b/src/components/ProgressBar/ProgressBar.test.tsx
@@ -47,12 +47,11 @@ describe("ProgressBar General Tests", () => {
   const keys = Object.keys(config);
   const sections = Object.values(config);
 
-  it("renders the progress bar with all config-defined sections", () => {
+  it("renders the progress bar with all A-D config-defined sections", () => {
     const screen = render(<BaseComponent section={keys[0]} data={{}} />);
 
-    sections.forEach(({ id, title }, index) => {
-      const isReviewSection = id === "review";
-      const root = screen.getByText(isReviewSection ? title || "Review" : title).closest("a");
+    sections.filter((section) => section.id !== config.REVIEW.id).forEach(({ title }, index) => {
+      const root = screen.getByText(title).closest("a");
 
       expect(root).toBeVisible();
       expect(root).toHaveAttribute("data-testId", `progress-bar-section-${index}`);

--- a/src/components/ProgressBar/ProgressBar.tsx
+++ b/src/components/ProgressBar/ProgressBar.tsx
@@ -99,12 +99,13 @@ const ProgressBar: FC<Props> = ({ section }) => {
     const reviewSection = newSections.find((s) => s.id === "review");
     const reviewUnlocked = completedSections === sectionKeys.length - 1;
     if (reviewSection) {
+      const showReviewTitle = formMode === "View Only" || formMode === "Review";
       // eslint-disable-next-line no-nested-ternary
       reviewSection.icon = ["Approved"].includes(status) && reviewUnlocked
         ? "Completed"
         : reviewUnlocked ? "Review" : "ReviewDisabled";
       reviewSection.disabled = completedSections !== sectionKeys.length - 1;
-      reviewSection.title = formMode === "Review" ? "Review" : reviewSection.title;
+      reviewSection.title = showReviewTitle ? "Review" : reviewSection.title;
     }
 
     setSections(newSections);

--- a/src/components/Questionnaire/ApproveFormDialog.tsx
+++ b/src/components/Questionnaire/ApproveFormDialog.tsx
@@ -1,6 +1,6 @@
 import { LoadingButton } from "@mui/lab";
 import { Button, DialogProps, styled } from "@mui/material";
-import { FC } from "react";
+import { FC, useState } from "react";
 import Dialog from "./Dialog";
 import TextInput from "./TextInput";
 
@@ -15,12 +15,10 @@ const StyledDialog = styled(Dialog)({
 type Props = {
   title?: string;
   message?: string;
-  reviewComment?: string;
   disableActions?: boolean;
   loading?: boolean;
-  onReviewCommentChange?: (comment: string) => void;
   onCancel?: () => void;
-  onSubmit?: () => void;
+  onSubmit?: (reviewComment: string) => void;
 } & DialogProps;
 
 const ApproveFormDialog: FC<Props> = ({
@@ -28,17 +26,24 @@ const ApproveFormDialog: FC<Props> = ({
   message,
   disableActions,
   loading,
-  reviewComment,
-  onReviewCommentChange,
   onCancel,
   onSubmit,
   open,
   onClose,
   ...rest
 }) => {
+  const [reviewComment, setReviewComment] = useState("");
+
   const handleCommentChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const val = event?.target?.value || "";
-    onReviewCommentChange(val);
+    setReviewComment(val);
+  };
+
+  const handleOnCancel = () => {
+    if (typeof onCancel === "function") {
+      onCancel();
+    }
+    setReviewComment("");
   };
 
   return (
@@ -48,11 +53,11 @@ const ApproveFormDialog: FC<Props> = ({
       title={title || "Approve Application"}
       actions={(
         <>
-          <Button onClick={onCancel} disabled={disableActions}>
+          <Button onClick={handleOnCancel} disabled={disableActions}>
             Cancel
           </Button>
           <LoadingButton
-            onClick={onSubmit}
+            onClick={() => onSubmit(reviewComment)}
             loading={loading}
             disabled={!reviewComment || disableActions}
             autoFocus

--- a/src/components/Questionnaire/ApproveFormDialog.tsx
+++ b/src/components/Questionnaire/ApproveFormDialog.tsx
@@ -72,6 +72,7 @@ const ApproveFormDialog: FC<Props> = ({
         placeholder="500 characters allowed"
         required
         minRows={2}
+        maxRows={2}
         multiline
         sx={{ paddingY: "16px" }}
       />

--- a/src/components/Questionnaire/RejectFormDialog.tsx
+++ b/src/components/Questionnaire/RejectFormDialog.tsx
@@ -1,6 +1,6 @@
 import { LoadingButton } from "@mui/lab";
 import { Button, DialogProps, styled } from "@mui/material";
-import { FC } from "react";
+import { FC, useState } from "react";
 import Dialog from "./Dialog";
 import TextInput from "./TextInput";
 
@@ -15,12 +15,10 @@ const StyledDialog = styled(Dialog)({
 type Props = {
   title?: string;
   message?: string;
-  reviewComment?: string;
   disableActions?: boolean;
   loading?: boolean;
-  onReviewCommentChange?: (comment: string) => void;
   onCancel?: () => void;
-  onSubmit?: () => void;
+  onSubmit?: (reviewComment: string) => void;
 } & DialogProps;
 
 const RejectFormDialog: FC<Props> = ({
@@ -28,17 +26,24 @@ const RejectFormDialog: FC<Props> = ({
   message,
   disableActions,
   loading,
-  reviewComment,
-  onReviewCommentChange,
   onCancel,
   onSubmit,
   open,
   onClose,
   ...rest
 }) => {
+  const [reviewComment, setReviewComment] = useState("");
+
   const handleCommentChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const val = event?.target?.value || "";
-    onReviewCommentChange(val);
+    setReviewComment(val);
+  };
+
+  const handleOnCancel = () => {
+    if (typeof onCancel === "function") {
+      onCancel();
+    }
+    setReviewComment("");
   };
 
   return (
@@ -48,11 +53,11 @@ const RejectFormDialog: FC<Props> = ({
       title={title || "Reject Application"}
       actions={(
         <>
-          <Button onClick={onCancel} disabled={disableActions}>
+          <Button onClick={handleOnCancel} disabled={disableActions}>
             Cancel
           </Button>
           <LoadingButton
-            onClick={onSubmit}
+            onClick={() => onSubmit(reviewComment)}
             loading={loading}
             disabled={!reviewComment || disableActions}
             autoFocus

--- a/src/components/Questionnaire/RejectFormDialog.tsx
+++ b/src/components/Questionnaire/RejectFormDialog.tsx
@@ -72,6 +72,7 @@ const RejectFormDialog: FC<Props> = ({
         placeholder="500 characters allowed"
         required
         minRows={2}
+        maxRows={2}
         multiline
         sx={{ paddingY: "16px" }}
       />

--- a/src/content/questionnaire/FormView.tsx
+++ b/src/content/questionnaire/FormView.tsx
@@ -105,10 +105,13 @@ const FormView: FC<Props> = ({ section, classes } : Props) => {
   };
 
   useEffect(() => {
-    if (formMode === "Unauthorized" && status === FormStatus.LOADED && authStatus === AuthStatus.LOADED && data) {
-      navigate('/');
+    const formLoaded = status === FormStatus.LOADED && authStatus === AuthStatus.LOADED && data;
+    const invalidFormAuth = formMode === "Unauthorized" || authStatus === AuthStatus.ERROR || !user;
+
+    if (formLoaded && invalidFormAuth) {
+      navigate("/");
     }
-  }, [formMode, navigate, status, authStatus]);
+  }, [formMode, navigate, status, authStatus, user, data]);
 
   useEffect(() => {
     const isComplete = isAllSectionsComplete();
@@ -480,8 +483,8 @@ const FormView: FC<Props> = ({ section, classes } : Props) => {
     return <SuspenseLoader />;
   }
 
-  if (authStatus === AuthStatus.ERROR || !user) {
-    navigate('/');
+  // hide content while being re-routed
+  if (authStatus === AuthStatus.ERROR) {
     return null;
   }
 

--- a/src/content/questionnaire/FormView.tsx
+++ b/src/content/questionnaire/FormView.tsx
@@ -79,7 +79,6 @@ const FormView: FC<Props> = ({ section, classes } : Props) => {
   const [openSubmitDialog, setOpenSubmitDialog] = useState<boolean>(false);
   const [openApproveDialog, setOpenApproveDialog] = useState<boolean>(false);
   const [openRejectDialog, setOpenRejectDialog] = useState<boolean>(false);
-  const [reviewComment, setReviewComment] = useState<string>("");
   const [hasError, setHasError] = useState<boolean>(false);
   const { formMode, readOnlyInputs } = useFormMode();
   const [changesAlert, setChangesAlert] = useState<string>("");
@@ -221,13 +220,11 @@ const FormView: FC<Props> = ({ section, classes } : Props) => {
     try {
       const r = await submitData();
       setOpenSubmitDialog(false);
-      setReviewComment("");
       navigate('/submissions');
       setHasError(false);
       return r;
     } catch (err) {
       setOpenSubmitDialog(false);
-      setReviewComment("");
       setHasError(true);
       return false;
     }
@@ -239,7 +236,7 @@ const FormView: FC<Props> = ({ section, classes } : Props) => {
    *
    * @returns {Promise<boolean>} true if the review submit was successful, false otherwise
    */
-  const submitApproveForm = async (): Promise<string | boolean> => {
+  const submitApproveForm = async (reviewComment): Promise<string | boolean> => {
     if (formMode !== "Review") {
       return false;
     }
@@ -252,7 +249,6 @@ const FormView: FC<Props> = ({ section, classes } : Props) => {
     try {
       const res = await approveForm(reviewComment, true);
       setOpenApproveDialog(false);
-      setReviewComment("");
       if (res) {
         setHasError(false);
         navigate('/submissions');
@@ -260,7 +256,6 @@ const FormView: FC<Props> = ({ section, classes } : Props) => {
       return res;
     } catch (err) {
       setOpenApproveDialog(false);
-      setReviewComment("");
       setHasError(true);
       return false;
     }
@@ -272,7 +267,7 @@ const FormView: FC<Props> = ({ section, classes } : Props) => {
    *
    * @returns {Promise<boolean>} true if the review submit was successful, false otherwise
    */
-  const submitRejectForm = async (): Promise<string | boolean> => {
+  const submitRejectForm = async (reviewComment: string): Promise<string | boolean> => {
     if (formMode !== "Review") {
       return false;
     }
@@ -290,7 +285,6 @@ const FormView: FC<Props> = ({ section, classes } : Props) => {
       return res;
     } catch (err) {
       setOpenRejectDialog(false);
-      setReviewComment("");
       setHasError(true);
       return false;
     }
@@ -458,12 +452,10 @@ const FormView: FC<Props> = ({ section, classes } : Props) => {
   };
 
   const handleCloseApproveFormDialog = () => {
-    setReviewComment("");
     setOpenApproveDialog(false);
   };
 
   const handleCloseRejectFormDialog = () => {
-    setReviewComment("");
     setOpenRejectDialog(false);
   };
 
@@ -482,13 +474,6 @@ const FormView: FC<Props> = ({ section, classes } : Props) => {
       return;
     }
     navigate(nextSection);
-  };
-
-  const handleReviewCommentChange = (newComment: string) => {
-    if (formMode !== "Review") {
-      return;
-    }
-    setReviewComment(newComment);
   };
 
   if (status === FormStatus.LOADING || authStatus === AuthStatus.LOADING) {
@@ -633,17 +618,13 @@ const FormView: FC<Props> = ({ section, classes } : Props) => {
       />
       <ApproveFormDialog
         open={openApproveDialog}
-        reviewComment={reviewComment}
-        onReviewCommentChange={handleReviewCommentChange}
         onCancel={handleCloseApproveFormDialog}
-        onSubmit={submitApproveForm}
+        onSubmit={(reviewComment) => submitApproveForm(reviewComment)}
       />
       <RejectFormDialog
         open={openRejectDialog}
-        reviewComment={reviewComment}
-        onReviewCommentChange={handleReviewCommentChange}
         onCancel={handleCloseRejectFormDialog}
-        onSubmit={submitRejectForm}
+        onSubmit={(reviewComment) => submitRejectForm(reviewComment)}
       />
     </>
   );

--- a/src/content/questionnaire/sections/Review.tsx
+++ b/src/content/questionnaire/sections/Review.tsx
@@ -48,7 +48,7 @@ const FormSectionReview: FC<FormSectionProps> = ({
   refs,
 }: FormSectionProps) => {
   const { data: { questionnaireData: data } } = useFormContext();
-  const { userCanReview } = useFormMode();
+  const { formMode } = useFormMode();
   const { pi, primaryContact, piAsPrimaryContact, program, study } = data;
   const formRef = useRef<HTMLFormElement>();
   const { saveFormRef, submitFormRef, nextButtonRef, approveFormRef, rejectFormRef, getFormObjectRef } = refs;
@@ -68,7 +68,7 @@ const FormSectionReview: FC<FormSectionProps> = ({
     saveFormRef.current.style.display = "none";
     nextButtonRef.current.style.display = "none";
 
-    if (userCanReview) {
+    if (formMode === "Review") {
       approveFormRef.current.style.display = "initial";
       rejectFormRef.current.style.display = "initial";
       submitFormRef.current.style.display = "none";
@@ -79,7 +79,7 @@ const FormSectionReview: FC<FormSectionProps> = ({
     }
 
     getFormObjectRef.current = getFormObject;
-  }, [refs]);
+  }, [refs, formMode]);
 
   const getFormObject = (): FormObject | null => {
     if (!formRef.current) {

--- a/src/content/questionnaire/sections/hooks/useFormMode.ts
+++ b/src/content/questionnaire/sections/hooks/useFormMode.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { Status as AuthStatus, useAuthContext } from "../../../../components/Contexts/AuthContext";
 import { Status as FormStatus, useFormContext } from "../../../../components/Contexts/FormContext";
-import { FormMode, FormModes, getFormMode } from "../../../../utils/formModeUtils";
+import { FormMode, FormModes, getFormMode } from "../../../../utils";
 
 const useFormMode = () => {
   const { user, status: authStatus } = useAuthContext();

--- a/src/content/questionnaire/sections/hooks/useFormMode.ts
+++ b/src/content/questionnaire/sections/hooks/useFormMode.ts
@@ -1,77 +1,25 @@
 import { useEffect, useState } from "react";
 import { Status as AuthStatus, useAuthContext } from "../../../../components/Contexts/AuthContext";
 import { Status as FormStatus, useFormContext } from "../../../../components/Contexts/FormContext";
-
-export type FormMode = "Unauthorized" | "Edit" | "View Only" | "Review";
-
-export const formModes = {
-  UNAUTHORIZED: "Unauthorized",
-  EDIT: "Edit",
-  VIEW_ONLY: "View Only",
-  REVIEW: "Review",
-} as const;
+import { FormMode, FormModes, getFormMode } from "../../../../utils/formModeUtils";
 
 const useFormMode = () => {
   const { user, status: authStatus } = useAuthContext();
   const { data, status } = useFormContext();
-  const { status: formStatus } = data || {};
-  const { role } = user || {};
-
   const [formMode, setFormMode] = useState<FormMode>(undefined);
   const [readOnlyInputs, setReadOnlyInputs] = useState<boolean>(false);
-
-  const isStatusViewOnlyForUser = (): boolean => ["Submitted", "In Review", "Approved"].includes(formStatus);
-  const isStatusViewOnlyForLead = (): boolean => ["In Progress", "Approved", "Rejected"].includes(formStatus);
-  const isStatusEdit = (): boolean => ["New", "In Progress", "Rejected"].includes(formStatus);
-  const isStatusReview = (): boolean => ["Submitted", "In Review"].includes(formStatus);
-
-  const authorizedRolesForReview = ["FederalLead"];
-  const authorizedRolesForEdit = ["User"];
-
-  const userCanReview = isStatusReview() && authorizedRolesForReview?.includes(role);
-  const userCanEdit = isStatusEdit() && authorizedRolesForEdit?.includes(role);
-
-  const formBelongsToUser = (): boolean => data?.applicant?.applicantID === user?.["_id"];
-
-  const getFormModeForUser = (): FormMode => {
-    if (formStatus !== "New" && !formBelongsToUser()) {
-      return formModes.UNAUTHORIZED;
-    }
-    if (isStatusViewOnlyForUser()) {
-      return formModes.VIEW_ONLY;
-    }
-    if (isStatusEdit()) {
-      return formModes.EDIT;
-    }
-    return formModes.UNAUTHORIZED;
-  };
-
-  const getFormModeForFederalLead = (): FormMode => {
-    if (isStatusReview()) {
-      return formModes.REVIEW;
-    }
-    if (isStatusViewOnlyForLead()) {
-      return formModes.VIEW_ONLY;
-    }
-    return formModes.UNAUTHORIZED;
-  };
 
   useEffect(() => {
     if (status === FormStatus.LOADING || authStatus === AuthStatus.LOADING) {
       return;
     }
-    let updatedFormMode: FormMode = formModes.UNAUTHORIZED;
-    if (role === "User") {
-      updatedFormMode = getFormModeForUser();
-    } else if (role === "FederalLead") {
-      updatedFormMode = getFormModeForFederalLead();
-    }
 
+    const updatedFormMode: FormMode = getFormMode(user, data);
     setFormMode(updatedFormMode);
-    setReadOnlyInputs(updatedFormMode === formModes.VIEW_ONLY || updatedFormMode === formModes.REVIEW);
-  }, [user, data, formStatus]);
+    setReadOnlyInputs(updatedFormMode === FormModes.VIEW_ONLY || updatedFormMode === FormModes.REVIEW);
+  }, [user, data]);
 
-  return { formMode, readOnlyInputs, userCanReview, userCanEdit };
+  return { formMode, readOnlyInputs };
 };
 
 export default useFormMode;

--- a/src/graphql/getMyUser.ts
+++ b/src/graphql/getMyUser.ts
@@ -12,6 +12,12 @@ export const query = gql`
       email
       createdAt
       updateAt
+      organization {
+        orgID
+        orgName
+        orgRole
+        orgStatus
+      }
     }
   }
 `;

--- a/src/lib/AuthUser.ts
+++ b/src/lib/AuthUser.ts
@@ -23,6 +23,8 @@ class AuthUser {
 
   private _role: User["role"];
 
+  private _organization: User["organization"];
+
   private _userStatus: User["userStatus"];
 
   private _createdAt: User["createdAt"];
@@ -36,6 +38,7 @@ class AuthUser {
     this._IDP = userData._IDP ?? userData.IDP ?? '';
     this._lastName = userData._lastName ?? userData.lastName ?? '';
     this._role = userData._role ?? userData.role ?? '';
+    this._organization = userData._organization ?? userData.organization ?? '';
     this._userStatus = userData._userStatus ?? userData.userStatus ?? '';
     this._createdAt = userData._createdAt ?? userData.createdAt ?? '';
     this._updateAt = userData._updateAt ?? userData.updateAt ?? '';
@@ -74,6 +77,13 @@ class AuthUser {
    */
   get role() {
     return this._role;
+  }
+
+  /**
+   * @returns {string}
+   */
+  get organization() {
+    return this._organization;
   }
 
   /**

--- a/src/lib/AuthUser.ts
+++ b/src/lib/AuthUser.ts
@@ -38,7 +38,7 @@ class AuthUser {
     this._IDP = userData._IDP ?? userData.IDP ?? '';
     this._lastName = userData._lastName ?? userData.lastName ?? '';
     this._role = userData._role ?? userData.role ?? '';
-    this._organization = userData._organization ?? userData.organization ?? '';
+    this._organization = userData._organization ?? userData.organization ?? {};
     this._userStatus = userData._userStatus ?? userData.userStatus ?? '';
     this._createdAt = userData._createdAt ?? userData.createdAt ?? '';
     this._updateAt = userData._updateAt ?? userData.updateAt ?? '';

--- a/src/types/Application.d.ts
+++ b/src/types/Application.d.ts
@@ -158,12 +158,3 @@ type Organization = {
   _id: string;
   name: string;
 };
-
-type OrgInfo = {
-  orgID: string;
-  orgName: string;
-  orgRole: "Owner" | "Submitter" | "Concierge"; // Concierge can only be assign to a Curator
-  orgStatus: "Active" | "Inactive" | "Disabled";
-  createdAt: string; // 2023-05-01T09:23:30Z, ISO data time format
-  updateAt: string; // 2023-05-01T09:23:30Z  ISO data time format
-};

--- a/src/types/Application.d.ts
+++ b/src/types/Application.d.ts
@@ -158,3 +158,12 @@ type Organization = {
   _id: string;
   name: string;
 };
+
+type OrgInfo = {
+  orgID: string;
+  orgName: string;
+  orgRole: "Owner" | "Submitter" | "Concierge"; // Concierge can only be assign to a Curator
+  orgStatus: "Active" | "Inactive" | "Disabled";
+  createdAt: string; // 2023-05-01T09:23:30Z, ISO data time format
+  updateAt: string; // 2023-05-01T09:23:30Z  ISO data time format
+};

--- a/src/types/Auth.d.ts
+++ b/src/types/Auth.d.ts
@@ -4,6 +4,7 @@ type User = {
   lastName: string;
   userStatus: 'Active' | 'Inactive' | 'Disabled';
   role: 'Admin' | 'User' | 'Curator' | 'FederalLead' | 'DC_POC';
+  organization: OrgInfo;
   IDP: 'nih' | 'login.gov';
   email: string;
   createdAt: string; // YYYY-MM-DDTHH:mm:ssZ

--- a/src/types/Auth.d.ts
+++ b/src/types/Auth.d.ts
@@ -15,3 +15,12 @@ type UserInput = {
   firstName: string;
   lastName: string;
 };
+
+type OrgInfo = {
+  orgID: string;
+  orgName: string;
+  orgRole: "Owner" | "Submitter" | "Concierge"; // Concierge can only be assigned to a Curator
+  orgStatus: "Active" | "Inactive" | "Disabled";
+  createdAt: string; // 2023-05-01T09:23:30Z, ISO data time format
+  updateAt: string; // 2023-05-01T09:23:30Z  ISO data time format
+};

--- a/src/utils/formModeUtils.test.ts
+++ b/src/utils/formModeUtils.test.ts
@@ -115,10 +115,10 @@ describe('getFormMode tests based on provided requirements', () => {
       });
     });
 
-    it('should allow Submitter to edit without a role', () => {
+    it('should set Unauthorized if Submitter tries to access without a role', () => {
       user = { ...user, role: null };
 
-      expect(utils.getFormMode(user, baseSubmission)).toBe(utils.FormModes.EDIT);
+      expect(utils.getFormMode(user, baseSubmission)).toBe(utils.FormModes.UNAUTHORIZED);
     });
   });
 
@@ -134,12 +134,8 @@ describe('getFormMode tests based on provided requirements', () => {
       });
     });
 
-    it('should set Unauthorized mode for Fed Lead when status is New', () => {
-      expect(utils.getFormMode(user, { ...baseSubmission, status: "New" })).toBe(utils.FormModes.UNAUTHORIZED);
-    });
-
     it('should set View Only mode for Fed Lead for all other statuses', () => {
-      const statuses: ApplicationStatus[] = ['Approved', 'In Progress', 'Rejected'];
+      const statuses: ApplicationStatus[] = ['New', 'Approved', 'In Progress', 'Rejected'];
 
       statuses.forEach((status) => {
         expect(utils.getFormMode(user, { ...baseSubmission, status })).toBe(utils.FormModes.VIEW_ONLY);
@@ -155,15 +151,6 @@ describe('getFormMode tests based on provided requirements', () => {
         statuses.forEach((status) => {
           expect(utils.getFormMode(user, { ...baseSubmission, status })).toBe(utils.FormModes.REVIEW);
         });
-      });
-    });
-
-    it('should set Unauthorized mode for Fed Lead when status is New when orgRole assigned', () => {
-      const orgRoles: OrgInfo["orgRole"][] = ['Submitter', 'Owner', "Concierge"];
-
-      orgRoles.forEach((orgRole) => {
-        user = { ...baseUser, role: "FederalLead", organization: { ...baseUser.organization, orgRole } };
-        expect(utils.getFormMode(user, { ...baseSubmission, status: "New" })).toBe(utils.FormModes.UNAUTHORIZED);
       });
     });
 
@@ -289,8 +276,8 @@ describe('getFormMode tests based on provided requirements', () => {
     describe('getFormMode > Edge Case Tests > Unknown role or no role and belongs to org tests', () => {
       const user: User = { ...baseUser, role: undefined };
 
-      it('should set Edit form if user role is unknown or not defined but has an orgRole', () => {
-        expect(utils.getFormMode(user, baseSubmission)).toBe(utils.FormModes.EDIT);
+      it('should set Unauthorized form if user role is unknown or not defined but has an orgRole', () => {
+        expect(utils.getFormMode(user, baseSubmission)).toBe(utils.FormModes.UNAUTHORIZED);
       });
     });
 

--- a/src/utils/formModeUtils.test.ts
+++ b/src/utils/formModeUtils.test.ts
@@ -1,0 +1,334 @@
+import { InitialApplication, InitialQuestionnaire } from "../config/InitialValues";
+import * as utils from './formModeUtils';
+
+describe('getFormMode tests based on provided requirements', () => {
+  const baseUser: Omit<User, "role"> = {
+    _id: 'user-123',
+    firstName: 'John',
+    lastName: 'Doe',
+    userStatus: 'Active' as User["userStatus"],
+    email: 'johndoe@example.com',
+    IDP: 'nih',
+    createdAt: '2023-05-01T09:23:30Z',
+    updateAt: '2023-05-02T09:23:30Z',
+    organization: {
+      orgID: 'org1',
+      orgName: 'TestOrg',
+      orgRole: 'Submitter',
+      orgStatus: 'Active' as User["organization"]["orgStatus"],
+      createdAt: '2023-05-01T09:23:30Z',
+      updateAt: '2023-05-02T09:23:30Z'
+    }
+  };
+
+  // submission created by baseUser and part of the same org
+  const baseSubmission: Application = {
+    ...InitialApplication,
+    _id: 'submission-123',
+    questionnaireData: InitialQuestionnaire,
+    status: 'New',
+    organization: {
+      _id: baseUser.organization.orgID,
+      name: baseUser.organization.orgName,
+    },
+    applicant: {
+      applicantID: baseUser._id,
+      applicantName: baseUser.firstName,
+      applicantEmail: baseUser.email
+    },
+    createdAt: '2023-05-01T09:23:30Z',
+    updatedAt: '2023-05-02T09:23:30Z',
+  };
+
+  // User Tests
+  describe('getFormMode > User tests', () => {
+    let user: User = { ...baseUser, role: 'User', organization: null };
+
+    it('should allow User to edit when form status is New', () => {
+      expect(utils.getFormMode(user, baseSubmission)).toBe(utils.FormModes.EDIT);
+    });
+
+    it('should set View Only for User when form is Submitted, In Review, or Approved', () => {
+      const statuses: ApplicationStatus[] = ['Submitted', 'In Review', 'Approved'];
+
+      statuses.forEach((status) => {
+        expect(utils.getFormMode(user, { ...baseSubmission, status })).toBe(utils.FormModes.VIEW_ONLY);
+      });
+    });
+
+    it('should allow User to edit when form status is New or In Progress', () => {
+      const statuses: ApplicationStatus[] = ['New', 'In Progress'];
+
+      statuses.forEach((status) => {
+        expect(utils.getFormMode(user, { ...baseSubmission, status })).toBe(utils.FormModes.EDIT);
+      });
+    });
+
+    it('should be View Only for User when User belongs to an organization and is not a Submitter orgRole', () => {
+      user = { ...user, organization: { ...user.organization, orgRole: "Concierge" } };
+
+      expect(utils.getFormMode(user, { ...baseSubmission, organization: { ...baseSubmission.organization, _id: user.organization.orgID } })).toBe(utils.FormModes.VIEW_ONLY);
+    });
+
+    it('should be Unauthorized for User when User belongs to a different org than form org and is not a Submitter orgRole', () => {
+      user = { ...user, organization: { ...user.organization, orgRole: "Concierge" } };
+      const submission: Application = { ...baseSubmission, organization: { ...baseSubmission.organization, _id: "random org id" } };
+
+      expect(utils.getFormMode(user, submission)).toBe(utils.FormModes.UNAUTHORIZED);
+    });
+
+    it('should be Unauthorized for User when User does not own the Submission', () => {
+      user = { ...user, role: "User", organization: { ...user.organization, orgRole: "Submitter" } };
+      const submission: Application = { ...baseSubmission, applicant: { ...baseSubmission.applicant, applicantID: "user-456-another-user" } };
+
+      expect(utils.getFormMode(user, submission)).toBe(utils.FormModes.UNAUTHORIZED);
+    });
+  });
+
+  // Submitter Tests
+  describe('getFormMode > Submitter tests', () => {
+    let user: User = { ...baseUser, role: 'User', organization: { ...baseUser.organization, orgRole: "Submitter" } };
+
+    it('should allow Submitter to edit when form status is New', () => {
+      expect(utils.getFormMode(user, baseSubmission)).toBe(utils.FormModes.EDIT);
+    });
+
+    it('should be Unauthorized for Submitter when Submitter belongs to a different org than form org', () => {
+      const submission: Application = { ...baseSubmission, organization: { ...baseSubmission.organization, _id: "random org id" } };
+
+      expect(utils.getFormMode(user, submission)).toBe(utils.FormModes.UNAUTHORIZED);
+    });
+
+    it('should set View Only for Submitter when form is Submitted, In Review, or Approved', () => {
+      const statuses: ApplicationStatus[] = ['Submitted', 'In Review', 'Approved'];
+
+      statuses.forEach((status) => {
+        expect(utils.getFormMode(user, { ...baseSubmission, status })).toBe(utils.FormModes.VIEW_ONLY);
+      });
+    });
+
+    it('should allow Submitter to edit when form status is New or In Progress', () => {
+      const statuses: ApplicationStatus[] = ['New', 'In Progress'];
+
+      statuses.forEach((status) => {
+        expect(utils.getFormMode(user, { ...baseSubmission, status })).toBe(utils.FormModes.EDIT);
+      });
+    });
+
+    it('should allow Submitter to edit without a role', () => {
+      user = { ...user, role: null };
+
+      expect(utils.getFormMode(user, baseSubmission)).toBe(utils.FormModes.EDIT);
+    });
+  });
+
+  // Federal Lead Tests
+  describe('getFormMode > Federal Lead tests', () => {
+    let user: User = { ...baseUser, role: 'FederalLead' };
+
+    it('should set Review mode for Fed Lead when status is Submitted or In Review', () => {
+      const statuses: ApplicationStatus[] = ['Submitted', 'In Review'];
+
+      statuses.forEach((status) => {
+        expect(utils.getFormMode(user, { ...baseSubmission, status })).toBe(utils.FormModes.REVIEW);
+      });
+    });
+
+    it('should set Unauthorized mode for Fed Lead when status is New', () => {
+      expect(utils.getFormMode(user, { ...baseSubmission, status: "New" })).toBe(utils.FormModes.UNAUTHORIZED);
+    });
+
+    it('should set View Only mode for Fed Lead for all other statuses', () => {
+      const statuses: ApplicationStatus[] = ['Approved', 'In Progress', 'Rejected'];
+
+      statuses.forEach((status) => {
+        expect(utils.getFormMode(user, { ...baseSubmission, status })).toBe(utils.FormModes.VIEW_ONLY);
+      });
+    });
+
+    it('should set Review mode for Fed Lead when status is Submitted or In Review when orgRole assigned', () => {
+      const orgRoles: OrgInfo["orgRole"][] = ['Submitter', 'Owner', "Concierge"];
+      const statuses: ApplicationStatus[] = ['Submitted', 'In Review'];
+
+      orgRoles.forEach((orgRole) => {
+        user = { ...baseUser, role: "FederalLead", organization: { ...baseUser.organization, orgRole } };
+        statuses.forEach((status) => {
+          expect(utils.getFormMode(user, { ...baseSubmission, status })).toBe(utils.FormModes.REVIEW);
+        });
+      });
+    });
+
+    it('should set Unauthorized mode for Fed Lead when status is New when orgRole assigned', () => {
+      const orgRoles: OrgInfo["orgRole"][] = ['Submitter', 'Owner', "Concierge"];
+
+      orgRoles.forEach((orgRole) => {
+        user = { ...baseUser, role: "FederalLead", organization: { ...baseUser.organization, orgRole } };
+        expect(utils.getFormMode(user, { ...baseSubmission, status: "New" })).toBe(utils.FormModes.UNAUTHORIZED);
+      });
+    });
+
+    it('should set View Only mode for Fed Lead for all other statuses when orgRole assigned', () => {
+      const orgRoles: OrgInfo["orgRole"][] = ['Submitter', 'Owner', "Concierge"];
+      const statuses: ApplicationStatus[] = ['Approved', 'In Progress', 'Rejected'];
+
+      orgRoles.forEach((orgRole) => {
+        user = { ...baseUser, role: "FederalLead", organization: { ...baseUser.organization, orgRole } };
+        statuses.forEach((status) => {
+          expect(utils.getFormMode(user, { ...baseSubmission, status })).toBe(utils.FormModes.VIEW_ONLY);
+        });
+      });
+    });
+  });
+
+  // Org Owner Tests
+  describe('getFormMode > Org Owner tests', () => {
+    const user: User = { ...baseUser, role: "User", organization: { ...baseUser.organization, orgRole: 'Owner' } };
+
+    it('should allow Org Owner to edit their own unsubmitted or rejected forms', () => {
+      const statuses: ApplicationStatus[] = ['New', 'In Progress', 'Rejected'];
+
+      statuses.forEach((status) => {
+        expect(utils.getFormMode(user, { ...baseSubmission, status })).toBe(utils.FormModes.EDIT);
+      });
+    });
+
+    it('should set View Only for Org Owner when form is Submitted, In Review, or Approved', () => {
+      const statuses: ApplicationStatus[] = ['Submitted', 'In Review', 'Approved'];
+
+      statuses.forEach((status) => {
+        expect(utils.getFormMode(user, { ...baseSubmission, status })).toBe(utils.FormModes.VIEW_ONLY);
+      });
+    });
+
+    it('should set View Only for Org Owner on other forms in his organization', () => {
+      const data: Application = {
+        ...baseSubmission,
+        applicant: { ...baseSubmission.applicant, applicantID: 'random user ID 123' },
+        organization: { ...baseSubmission.organization, _id: user.organization.orgID }
+      };
+
+      expect(utils.getFormMode(user, data)).toBe(utils.FormModes.VIEW_ONLY);
+    });
+  });
+
+  // Admin Tests
+  describe('getFormMode > Admin tests', () => {
+    let user: User = { ...baseUser, role: 'Admin', organization: null };
+
+    it('should always set View Only for Admin', () => {
+      const statuses: ApplicationStatus[] = ['New', 'Submitted', 'In Review', 'Approved', 'In Progress', 'Rejected'];
+
+      statuses.forEach((status) => {
+        expect(utils.getFormMode(user, { ...baseSubmission, status })).toBe(utils.FormModes.VIEW_ONLY);
+      });
+    });
+
+    it('should always set View Only for Admin even when orgRole assigned', () => {
+      const orgRoles: OrgInfo["orgRole"][] = ['Submitter', 'Owner', "Concierge"];
+      const statuses: ApplicationStatus[] = ['New', 'Submitted', 'In Review', 'Approved', 'In Progress', 'Rejected'];
+
+      orgRoles.forEach((orgRole) => {
+        user = { ...baseUser, role: "Admin", organization: { ...baseUser.organization, orgRole } };
+        statuses.forEach((status) => {
+          expect(utils.getFormMode(user, { ...baseSubmission, status })).toBe(utils.FormModes.VIEW_ONLY);
+        });
+      });
+    });
+  });
+
+  // Other role Tests
+  describe('getFormMode > Other roles tests', () => {
+    it('should always set View Only for all other roles', () => {
+      const roles: User["role"][] = ['DC_POC', "Some other role", "This role doesn't exist"] as User["role"][];
+      const statuses: ApplicationStatus[] = ['In Progress', 'Submitted', 'In Review', 'Approved', 'Rejected'];
+
+      roles.forEach((role) => {
+        const user: User = { ...baseUser, role, organization: null };
+        statuses.forEach((status) => {
+          expect(utils.getFormMode(user, { ...baseSubmission, status })).toBe(utils.FormModes.VIEW_ONLY);
+        });
+      });
+    });
+  });
+
+  // Other orgRole Tests
+  describe('getFormMode > Other orgRoles tests', () => {
+    it('should always set View Only for all other orgRoles', () => {
+      const orgRoles: OrgInfo["orgRole"][] = ['Concierge', 'A fake orgRole', 'Another fake one'] as OrgInfo["orgRole"][];
+      const statuses: ApplicationStatus[] = ['In Progress', 'Submitted', 'In Review', 'Approved', 'Rejected'];
+
+      orgRoles.forEach((orgRole) => {
+        const user: User = { ...baseUser, role: "User", organization: { ...baseUser.organization, orgRole } };
+        statuses.forEach((status) => {
+          expect(utils.getFormMode(user, { ...baseSubmission, status, organization: { ...baseSubmission.organization, _id: user.organization.orgID } })).toBe(utils.FormModes.VIEW_ONLY);
+        });
+      });
+    });
+  });
+
+  describe('getFormMode > Edge Case Tests', () => {
+    describe('getFormMode > Edge Case Tests > null User', () => {
+      it('should set Unauthorized when a null User is provided', () => {
+        expect(utils.getFormMode(null, baseSubmission)).toBe(utils.FormModes.UNAUTHORIZED);
+      });
+    });
+
+    describe('getFormMode > Edge Case Tests > null data submission', () => {
+      const user: User = { ...baseUser, role: "User" };
+      it('should set Unauthorized when a null data Submission is provided', () => {
+        expect(utils.getFormMode(user, null)).toBe(utils.FormModes.UNAUTHORIZED);
+      });
+    });
+
+    describe('getFormMode > Edge Case Tests > null User and null data submission', () => {
+      it('should set Unauthorized when a null data Submission and User is provided', () => {
+        expect(utils.getFormMode(null, null)).toBe(utils.FormModes.UNAUTHORIZED);
+      });
+    });
+
+    describe('getFormMode > Edge Case Tests > Unknown role or no role and belongs to org tests', () => {
+      const user: User = { ...baseUser, role: undefined };
+
+      it('should set Edit form if user role is unknown or not defined but has an orgRole', () => {
+        expect(utils.getFormMode(user, baseSubmission)).toBe(utils.FormModes.EDIT);
+      });
+    });
+
+    describe('getFormMode > Edge Case Tests > Unknown role or no role and does not belong to org tests', () => {
+      const user: User = { ...baseUser, role: undefined, organization: undefined };
+
+      it('should set Unauthorized if user does not belong to any organization and has no role', () => {
+        expect(utils.getFormMode(user, baseSubmission)).toBe(utils.FormModes.UNAUTHORIZED);
+      });
+    });
+
+    describe('getFormMode > Edge Case Tests > Submitter organization role tests', () => {
+      const user: User = { ...baseUser, role: "User", organization: { ...baseUser.organization, orgRole: 'Submitter' } };
+
+      it('should allow Submitter to edit their own unsubmitted or rejected forms', () => {
+        const statuses: ApplicationStatus[] = ['New', 'In Progress', 'Rejected'];
+
+        statuses.forEach((status) => {
+          expect(utils.getFormMode(user, { ...baseSubmission, status })).toBe(utils.FormModes.EDIT);
+        });
+      });
+      it('should set View Only for Submitter when form is Submitted, In Review, or Approved', () => {
+        const statuses: ApplicationStatus[] = ['Submitted', 'In Review', 'Approved'];
+
+        statuses.forEach((status) => {
+          expect(utils.getFormMode(user, { ...baseSubmission, status })).toBe(utils.FormModes.VIEW_ONLY);
+        });
+      });
+    });
+
+    describe('getFormMode > Edge Case Tests > Invalid form status tests', () => {
+      const user: User = { ...baseUser, role: 'User' };
+
+      it('should set Unauthorized if form status is unknown or not defined', () => {
+        const submission: Application = { ...baseSubmission, status: undefined };
+
+        expect(utils.getFormMode(user, submission)).toBe(utils.FormModes.UNAUTHORIZED);
+      });
+    });
+  });
+});

--- a/src/utils/formModeUtils.ts
+++ b/src/utils/formModeUtils.ts
@@ -1,0 +1,158 @@
+export type FormMode = "Unauthorized" | "Edit" | "View Only" | "Review";
+export type FormStatus = "New" | "Submitted" | "In Review" | "Approved" | "In Progress" | "Rejected";
+
+export const EditStatuses = ["New", "In Progress", "Rejected"];
+export const ReviewStatuses = ["Submitted", "In Review"];
+export const FormModes = {
+  UNAUTHORIZED: "Unauthorized",
+  EDIT: "Edit",
+  VIEW_ONLY: "View Only",
+  REVIEW: "Review",
+} as const;
+
+/**
+ * Calculate the form mode for a user
+ * NOTE:
+ *  - This is a private helper function for getFormMode
+ *
+ * @param {FormStatus} formStatus - Current form status.
+ * @param {boolean} formBelongsToUser - True if the form belongs to the user.
+ * @returns {FormMode} - Form mode corresponding to the given form status and user.
+ */
+const _getFormModeForUser = (
+  user: User,
+  data: Application
+): FormMode => {
+  const userOrgRoleExists = user?.organization?.orgRole?.length > 0;
+  const belongsToSameOrg = user?.organization?.orgID === data?.organization?._id;
+  if ((user?.role !== "User" && !userOrgRoleExists) || (userOrgRoleExists && belongsToSameOrg && user.organization?.orgRole !== "Submitter")) {
+    return FormModes.UNAUTHORIZED;
+  }
+
+  const { status: formStatus } = data || {};
+  const formBelongsToUser = data?.applicant?.applicantID === user?.["_id"];
+  const isStatusViewOnlyForUser = ["Submitted", "In Review", "Approved"].includes(formStatus);
+
+  if (formStatus !== "New" && !formBelongsToUser) {
+    return FormModes.UNAUTHORIZED;
+  }
+  if (isStatusViewOnlyForUser) {
+    return FormModes.VIEW_ONLY;
+  }
+  if (EditStatuses.includes(formStatus)) {
+    return FormModes.EDIT;
+  }
+  return FormModes.UNAUTHORIZED;
+};
+
+/**
+ * Calculate the form mode for a Federal Lead
+ * NOTE:
+ *  - This is a private helper function for getFormMode
+ *
+ * @param {User} user - The current user
+ * @param {Application} data - The current application/submission
+ * @returns {FormMode} - Form mode corresponding to the given form status for a Federal Lead.
+ */
+const _getFormModeForFederalLead = (
+  user: User,
+  data: Application
+): FormMode => {
+  if (user?.role !== "FederalLead") {
+    return FormModes.UNAUTHORIZED;
+  }
+
+  const { status: formStatus } = data || {};
+  const isStatusViewOnlyForLead = ["In Progress", "Approved", "Rejected"].includes(formStatus);
+
+  if (ReviewStatuses.includes(formStatus)) {
+    return FormModes.REVIEW;
+  }
+  if (isStatusViewOnlyForLead) {
+    return FormModes.VIEW_ONLY;
+  }
+
+  return FormModes.UNAUTHORIZED;
+};
+
+/**
+ * Calculate the form mode for an Organization Owner
+ * NOTE:
+ *  - This is a private helper function for getFormMode
+ *
+ * @param {User} user - The current user
+ * @param {Application} data - The current application/submission
+ * @returns {FormMode} - Form mode corresponding to the given form status and organization owner.
+ */
+const _getFormModeForOrgOwner = (
+  user: User,
+  data: Application
+): FormMode => {
+  const belongsToSameOrg = user.organization?.orgID === data?.organization?._id;
+  const orgRole = belongsToSameOrg ? user.organization?.orgRole : null;
+  if (orgRole !== "Owner") {
+    return FormModes.UNAUTHORIZED;
+  }
+
+  const { status: formStatus } = data || {};
+  const formBelongsToUser = data?.applicant?.applicantID === user?.["_id"];
+  const isStatusViewOnlyForOrgOwner = ["Submitted", "In Review", "Approved"].includes(formStatus);
+
+  if (!formBelongsToUser || isStatusViewOnlyForOrgOwner) {
+    return FormModes.VIEW_ONLY;
+  }
+  if (EditStatuses.includes(formStatus)) {
+    return FormModes.EDIT;
+  }
+  return FormModes.UNAUTHORIZED;
+};
+
+/**
+ * Get updated form mode based on role, organization role, and form status
+ * NOTE:
+ * - Depends on the following private helper functions:
+ *    _getFormModeForUser,
+ *    _getFormModeForFederalLead,
+ *    _getFormModeForOrgOwner
+ *
+ * @param {User} user - The current user
+ * @param {Application} data - The current application/submission
+ * @returns {FormMode} - Updated form mode based on role, organization role, and form status
+ */
+export const getFormMode = (
+  user: User,
+  data: Application,
+): FormMode => {
+  if (!user || (!user?.role && !user?.organization?.orgRole) || !data) {
+    return FormModes.UNAUTHORIZED;
+  }
+
+  const userOrgRoleExists = user?.organization?.orgRole?.length > 0;
+  const belongsToSameOrg = user.organization?.orgID === data?.organization?._id;
+  const orgRole = belongsToSameOrg ? user.organization?.orgRole : null;
+
+  if (user.role === "FederalLead") {
+    return _getFormModeForFederalLead(user, data);
+  }
+  if (user.role === "Admin") {
+    return FormModes.VIEW_ONLY;
+  }
+  if (userOrgRoleExists && !belongsToSameOrg) {
+    return FormModes.UNAUTHORIZED;
+  }
+  if (userOrgRoleExists && orgRole === "Owner") {
+    return _getFormModeForOrgOwner(user, data);
+  }
+  if (userOrgRoleExists && orgRole !== "Submitter") {
+    return FormModes.VIEW_ONLY;
+  }
+  if (user.role === "User" || (userOrgRoleExists && orgRole === "Submitter")) {
+    return _getFormModeForUser(user, data);
+  }
+  // Any other authorized user
+  if (user.role) {
+    return FormModes.VIEW_ONLY;
+  }
+
+  return FormModes.UNAUTHORIZED;
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,3 +2,4 @@ export * from './dateUtils';
 export * from './validationUtils';
 export * from './stringUtils';
 export * from './formUtils';
+export * from './formModeUtils';


### PR DESCRIPTION
**OVERVIEW**
This PR aims to expand the amount of variables to calculate the form mode, rather than just "User" and "FederalLead" roles and form status. I separated the logic for calculating the form mode into its own utility file where I could create tests for it easier and also simplify the useFormMode hook itself.

- Added organization to getMyUser query and User type
- Separated useFormMode hook logic into separate utility file to make it testable
- Created detailed tests for each role, orgRole, formStatus, who submitted the form, which organization the submission belongs to, which organization the user belongs to (if any), etc.
- Updated Approve/Reject form dialog to maintain internal state for review comment and only pass the value onSubmit. Previously, it was causing the parent to re-render due to state changes. 

**TICKETS**
[CRDCDH-49](https://tracker.nci.nih.gov/browse/CRDCDH-49)

**NOTE**
This implementation assumes a user will only belong to a single organization.