### PR TITLE
section d file count bugfix

### DIFF
--- a/src/content/questionnaire/sections/D.tsx
+++ b/src/content/questionnaire/sections/D.tsx
@@ -164,6 +164,8 @@ const FormSectionD: FC<FormSectionProps> = ({ SectionOption, refs }: FormSection
     }
     // Override empty file array
     combinedData.files = formObject.files;
+    // Overwrite number type. If empty string, convert to null.
+    combinedData.files.map((file) => file.count = parseInt(file.count, 10) || null);
 
     return { ref: formRef, data: combinedData };
   };


### PR DESCRIPTION
This addresses a bug related to the file count variable in section D.
Right now, if you create a new submission request, go to section d, then navigate to another section without changing anything, the form says there are unsaved changes.
This was due to some typing oversight by me.
This fixes this bug.