### PR TITLE
Organization roles update

### DIFF
--- a/src/content/questionnaire/ListView.tsx
+++ b/src/content/questionnaire/ListView.tsx
@@ -140,15 +140,14 @@ const columns: Column[] = [
     value: (a, user) => {
       const role = user?.role;
 
-      // NOTE for MVP-2: Org Owners can also Resume their own submissions
-      if ((role === "User" && a.applicant?.applicantID === user._id) && ["New", "In Progress", "Rejected"].includes(a.status)) {
+      if (((role === "User" || role === "Submitter" || role === "ORG_OWNER") && a.applicant?.applicantID === user._id) && ["New", "In Progress", "Rejected"].includes(a.status)) {
         return (
           <Link to={`/submission/${a?.["_id"]}`}>
             <StyledActionButton bg="#99E3BB" text="#156071" border="#63BA90">Resume</StyledActionButton>
           </Link>
         );
       }
-      if (role === "Fed Lead" && ["Submitted", "In Review"].includes(a.status)) {
+      if (role === "FederalLead" && ["Submitted", "In Review"].includes(a.status)) {
         return (
           <Link to={`/submission/${a?.["_id"]}`}>
             <StyledActionButton bg="#F1C6B3" text="#5F564D" border="#DB9C62">Review</StyledActionButton>
@@ -252,8 +251,7 @@ const ListingView: FC = () => {
         padding="57px 0 0 25px"
         body={(
           <StyledBannerBody direction="row" alignItems="center" justifyContent="flex-end">
-            {/* NOTE For MVP-2: Organization Owners are just Users */}
-            {user?.role === "User" && (
+            {(user?.role === "User" || user?.role === "Submitter" || user?.role === "ORG_OWNER") && (
               <StyledButton
                 type="button"
                 onClick={createApp}

--- a/src/content/questionnaire/ListView.tsx
+++ b/src/content/questionnaire/ListView.tsx
@@ -148,7 +148,7 @@ const columns: Column[] = [
           </Link>
         );
       }
-      if (role === "FederalLead" && ["Submitted", "In Review"].includes(a.status)) {
+      if (role === "Fed Lead" && ["Submitted", "In Review"].includes(a.status)) {
         return (
           <Link to={`/submission/${a?.["_id"]}`}>
             <StyledActionButton bg="#F1C6B3" text="#5F564D" border="#DB9C62">Review</StyledActionButton>

--- a/src/content/users/Controller.tsx
+++ b/src/content/users/Controller.tsx
@@ -12,7 +12,7 @@ import ProfileView from "./ProfileView";
 export default () => {
   const { userId } = useParams();
   const { user: { _id, role } } = useAuthContext();
-  const isAdministrative = role === "Admin" || role === "Org Owner";
+  const isAdministrative = role === "Admin" || role === "ORG_OWNER";
 
   // Non-admin users can only view their own profile, redirect to it
   if (userId !== _id && !isAdministrative) {

--- a/src/content/users/Controller.tsx
+++ b/src/content/users/Controller.tsx
@@ -11,8 +11,8 @@ import ProfileView from "./ProfileView";
  */
 export default () => {
   const { userId } = useParams();
-  const { user: { _id, role, organization } } = useAuthContext();
-  const isAdministrative = role === "Admin" || organization?.orgRole === "Owner";
+  const { user: { _id, role } } = useAuthContext();
+  const isAdministrative = role === "Admin" || role === "Org Owner";
 
   // Non-admin users can only view their own profile, redirect to it
   if (userId !== _id && !isAdministrative) {

--- a/src/content/users/ProfileView.tsx
+++ b/src/content/users/ProfileView.tsx
@@ -232,7 +232,7 @@ const ProfileView: FC<Props> = ({ _id } : Props) => {
               </StyledField>
               <StyledField>
                 <StyledLabel>Role</StyledLabel>
-                {user?.organization?.orgRole ?? user?.role}
+                {user?.role}
               </StyledField>
               <StyledField>
                 <StyledLabel>Account Status</StyledLabel>

--- a/src/graphql/getMyUser.ts
+++ b/src/graphql/getMyUser.ts
@@ -10,14 +10,20 @@ export const query = gql`
       role
       IDP
       email
-      createdAt
-      updateAt
       organization {
         orgID
         orgName
-        orgRole
-        orgStatus
+        createdAt
+        updateAt
       }
+      curatedOrganizations {
+        orgID
+        orgName
+        createdAt
+        updateAt
+      }
+      createdAt
+      updateAt
     }
   }
 `;

--- a/src/types/Auth.d.ts
+++ b/src/types/Auth.d.ts
@@ -2,11 +2,20 @@ type User = {
   _id: string;
   firstName: string;
   lastName: string;
-  userStatus: 'Active' | 'Inactive' | 'Disabled';
-  role: 'Admin' | 'User' | 'Curator' | 'FederalLead' | 'DC_POC' | "Owner" | "Submitter" | "Concierge";
-  organization: OrgInfo;
-  IDP: 'nih' | 'login.gov';
+  userStatus: "Active" | "Inactive" | "Disabled";
+  role:
+    | "User"
+    | "Submitter"
+    | "Org Owner"
+    | "Fed Lead"
+    | "Data Concierge"
+    | "Data Curator"
+    | "Data Commons Owner"
+    | "Admin";
+  IDP: "nih" | "login.gov";
   email: string;
+  organization: OrgInfo;
+  curatedOrganizations: OrgInfo[];
   createdAt: string; // YYYY-MM-DDTHH:mm:ss.sssZ
   updateAt: string; // YYYY-MM-DDTHH:mm:ss.sssZ
 };
@@ -16,11 +25,17 @@ type UserInput = {
   lastName: string;
 };
 
+type UserInfo = {
+  userID: string;
+  firstName: string;
+  lastName: string;
+  createdAt: string; // 2023-05-01T09:23:30Z, ISO data time format
+  updateAt: string; // 2023-05-01T09:23:30Z  ISO data time format
+};
+
 type OrgInfo = {
   orgID: string;
   orgName: string;
-  orgRole: "Owner" | "Submitter" | "Concierge"; // Concierge can only be assigned to a Curator
-  orgStatus: "Active" | "Inactive" | "Disabled";
   createdAt: string; // 2023-05-01T09:23:30Z, ISO data time format
   updateAt: string; // 2023-05-01T09:23:30Z  ISO data time format
 };

--- a/src/types/Auth.d.ts
+++ b/src/types/Auth.d.ts
@@ -3,7 +3,7 @@ type User = {
   firstName: string;
   lastName: string;
   userStatus: 'Active' | 'Inactive' | 'Disabled';
-  role: 'Admin' | 'User' | 'Curator' | 'FederalLead' | 'DC_POC';
+  role: 'Admin' | 'User' | 'Curator' | 'FederalLead' | 'DC_POC' | "Owner" | "Submitter" | "Concierge";
   organization: OrgInfo;
   IDP: 'nih' | 'login.gov';
   email: string;

--- a/src/types/Auth.d.ts
+++ b/src/types/Auth.d.ts
@@ -6,11 +6,12 @@ type User = {
   role:
     | "User"
     | "Submitter"
-    | "Org Owner"
-    | "Fed Lead"
-    | "Data Concierge"
-    | "Data Curator"
-    | "Data Commons Owner"
+    | "ORG_OWNER"
+    | "FederalLead"
+    | "Concierge"
+    | "Curator"
+    | "DC_OWNER"
+    | "DC_POC"
     | "Admin";
   IDP: "nih" | "login.gov";
   email: string;

--- a/src/utils/formModeUtils.test.ts
+++ b/src/utils/formModeUtils.test.ts
@@ -64,22 +64,9 @@ describe('getFormMode tests based on provided requirements', () => {
       });
     });
 
-    it('should be View Only for User when User belongs to an organization and is not a Submitter orgRole', () => {
-      user = { ...user, organization: { ...user.organization, orgRole: "Concierge" } };
-
-      expect(utils.getFormMode(user, { ...baseSubmission, organization: { ...baseSubmission.organization, _id: user.organization.orgID } })).toBe(utils.FormModes.VIEW_ONLY);
-    });
-
-    it('should be Unauthorized for User when User belongs to a different org than form org and is not a Submitter orgRole', () => {
-      user = { ...user, organization: { ...user.organization, orgRole: "Concierge" } };
-      const submission: Application = { ...baseSubmission, organization: { ...baseSubmission.organization, _id: "random org id" } };
-
-      expect(utils.getFormMode(user, submission)).toBe(utils.FormModes.UNAUTHORIZED);
-    });
-
     it('should be Unauthorized for User when User does not own the Submission', () => {
       user = { ...user, role: "User", organization: { ...user.organization, orgRole: "Submitter" } };
-      const submission: Application = { ...baseSubmission, applicant: { ...baseSubmission.applicant, applicantID: "user-456-another-user" } };
+      const submission: Application = { ...baseSubmission, status: "In Progress", applicant: { ...baseSubmission.applicant, applicantID: "user-456-another-user" } };
 
       expect(utils.getFormMode(user, submission)).toBe(utils.FormModes.UNAUTHORIZED);
     });
@@ -91,12 +78,6 @@ describe('getFormMode tests based on provided requirements', () => {
 
     it('should allow Submitter to edit when form status is New', () => {
       expect(utils.getFormMode(user, baseSubmission)).toBe(utils.FormModes.EDIT);
-    });
-
-    it('should be Unauthorized for Submitter when Submitter belongs to a different org than form org', () => {
-      const submission: Application = { ...baseSubmission, organization: { ...baseSubmission.organization, _id: "random org id" } };
-
-      expect(utils.getFormMode(user, submission)).toBe(utils.FormModes.UNAUTHORIZED);
     });
 
     it('should set View Only for Submitter when form is Submitted, In Review, or Approved', () => {
@@ -186,16 +167,6 @@ describe('getFormMode tests based on provided requirements', () => {
         expect(utils.getFormMode(user, { ...baseSubmission, status })).toBe(utils.FormModes.VIEW_ONLY);
       });
     });
-
-    it('should set View Only for Org Owner on other forms in his organization', () => {
-      const data: Application = {
-        ...baseSubmission,
-        applicant: { ...baseSubmission.applicant, applicantID: 'random user ID 123' },
-        organization: { ...baseSubmission.organization, _id: user.organization.orgID }
-      };
-
-      expect(utils.getFormMode(user, data)).toBe(utils.FormModes.VIEW_ONLY);
-    });
   });
 
   // Admin Tests
@@ -233,21 +204,6 @@ describe('getFormMode tests based on provided requirements', () => {
         const user: User = { ...baseUser, role, organization: null };
         statuses.forEach((status) => {
           expect(utils.getFormMode(user, { ...baseSubmission, status })).toBe(utils.FormModes.VIEW_ONLY);
-        });
-      });
-    });
-  });
-
-  // Other orgRole Tests
-  describe('getFormMode > Other orgRoles tests', () => {
-    it('should always set View Only for all other orgRoles', () => {
-      const orgRoles: OrgInfo["orgRole"][] = ['Concierge', 'A fake orgRole', 'Another fake one'] as OrgInfo["orgRole"][];
-      const statuses: ApplicationStatus[] = ['In Progress', 'Submitted', 'In Review', 'Approved', 'Rejected'];
-
-      orgRoles.forEach((orgRole) => {
-        const user: User = { ...baseUser, role: "User", organization: { ...baseUser.organization, orgRole } };
-        statuses.forEach((status) => {
-          expect(utils.getFormMode(user, { ...baseSubmission, status, organization: { ...baseSubmission.organization, _id: user.organization.orgID } })).toBe(utils.FormModes.VIEW_ONLY);
         });
       });
     });

--- a/src/utils/formModeUtils.test.ts
+++ b/src/utils/formModeUtils.test.ts
@@ -97,7 +97,7 @@ describe('getFormMode tests based on provided requirements', () => {
 
   // Federal Lead Tests
   describe('getFormMode > Fed Lead tests', () => {
-    const user: User = { ...baseUser, role: 'Fed Lead' };
+    const user: User = { ...baseUser, role: 'FederalLead' };
 
     it('should set Review mode for Fed Lead when status is Submitted or In Review', () => {
       const statuses: ApplicationStatus[] = ['Submitted', 'In Review'];
@@ -124,7 +124,7 @@ describe('getFormMode tests based on provided requirements', () => {
 
   // Org Owner Tests
   describe('getFormMode > Org Owner tests', () => {
-    const user: User = { ...baseUser, role: "Org Owner" };
+    const user: User = { ...baseUser, role: "ORG_OWNER" };
 
     it('should allow Org Owner to edit their own unsubmitted or rejected forms', () => {
       const statuses: ApplicationStatus[] = ['New', 'In Progress', 'Rejected'];

--- a/src/utils/formModeUtils.ts
+++ b/src/utils/formModeUtils.ts
@@ -102,11 +102,11 @@ export const getFormMode = (
   }
 
   switch (user.role) {
-    case "Fed Lead":
+    case "FederalLead":
       return _getFormModeForFederalLead(data);
     case "Admin":
       return FormModes.VIEW_ONLY;
-    case "Org Owner":
+    case "ORG_OWNER":
       return _getFormModeForOrgOwner(user, data);
     case "User":
     case "Submitter":

--- a/src/utils/formModeUtils.ts
+++ b/src/utils/formModeUtils.ts
@@ -22,9 +22,7 @@ const _getFormModeForUser = (
   user: User,
   data: Application
 ): FormMode => {
-  const userOrgRoleExists = user?.organization?.orgRole?.length > 0;
-  const belongsToSameOrg = user?.organization?.orgID === data?.organization?._id;
-  if (user?.role !== "User" || (userOrgRoleExists && belongsToSameOrg && user.organization?.orgRole !== "Submitter")) {
+  if (user?.role !== "User" && user?.role !== "Submitter") {
     return FormModes.UNAUTHORIZED;
   }
 
@@ -83,9 +81,7 @@ const _getFormModeForOrgOwner = (
   user: User,
   data: Application
 ): FormMode => {
-  const belongsToSameOrg = user.organization?.orgID === data?.organization?._id;
-  const orgRole = belongsToSameOrg ? user.organization?.orgRole : null;
-  if (orgRole !== "Owner") {
+  if (user.role !== "Owner") {
     return FormModes.UNAUTHORIZED;
   }
 
@@ -122,26 +118,16 @@ export const getFormMode = (
     return FormModes.UNAUTHORIZED;
   }
 
-  const userOrgRoleExists = user?.organization?.orgRole?.length > 0;
-  const belongsToSameOrg = user.organization?.orgID === data?.organization?._id;
-  const orgRole = belongsToSameOrg ? user.organization?.orgRole : null;
-
   if (user.role === "FederalLead") {
     return _getFormModeForFederalLead(user, data);
   }
   if (user.role === "Admin") {
     return FormModes.VIEW_ONLY;
   }
-  if (userOrgRoleExists && !belongsToSameOrg) {
-    return FormModes.UNAUTHORIZED;
-  }
-  if (userOrgRoleExists && orgRole === "Owner") {
+  if (user.role === "Owner") {
     return _getFormModeForOrgOwner(user, data);
   }
-  if (userOrgRoleExists && orgRole !== "Submitter") {
-    return FormModes.VIEW_ONLY;
-  }
-  if (user.role === "User" || (userOrgRoleExists && orgRole === "Submitter")) {
+  if (user.role === "User" || user.role === "Submitter") {
     return _getFormModeForUser(user, data);
   }
   // Any other authorized user


### PR DESCRIPTION
**OVERVIEW**
This PR aims to reflect changes made to Organizations. Org roles were removed and combined with user role. This updates all of the form mode considerations to only consider user roles, as well as tests. 

**TICKETS**
[CRDCDH-49](https://tracker.nci.nih.gov/browse/CRDCDH-49)

**IMPORTANT**
Make sure to pull latest from BE, AuthN, and AuthZ