### PR TITLE
CRCDH-308 Prevent past date being entered manually

### DIFF
--- a/src/components/Questionnaire/DatePickerInput.tsx
+++ b/src/components/Questionnaire/DatePickerInput.tsx
@@ -129,6 +129,7 @@ const DatePickerInput: FC<Props> = ({
   infoText,
   tooltipText,
   errorText,
+  disablePast,
   onChange,
   readOnly,
   ...rest
@@ -141,9 +142,10 @@ const DatePickerInput: FC<Props> = ({
   const inputRef = useRef<HTMLInputElement>(null);
 
   const processValue = (inputVal: Dayjs) => {
+    const isInvalidDay = !inputVal?.isValid() || (disablePast && inputVal?.isBefore(dayjs(new Date()).startOf("day")));
     if (required && !inputVal) {
       updateInputValidity(inputRef, errorMsg);
-    } else if (!inputVal.isValid()) {
+    } else if (isInvalidDay) {
       updateInputValidity(inputRef, "The date is invalid. Please enter a date in the format MM/DD/YYYY");
     } else {
       updateInputValidity(inputRef);
@@ -186,6 +188,7 @@ const DatePickerInput: FC<Props> = ({
           value={val}
           onChange={(value: Dayjs) => onChangeWrapper(value)}
           inputRef={inputRef}
+          disablePast={disablePast}
           readOnly={readOnly}
           slots={{ openPickerIcon: CalendarIcon }}
           slotProps={{


### PR DESCRIPTION
**OVERVIEW**
This PR aims to create an error when a past date is entered manually through typing in DatePickerInput. Previously, it was only disabled in the calendar popup selection.

**TICKETS**
[CRDCDH-308](https://tracker.nci.nih.gov/browse/CRDCDH-308)