### PR TITLE
Updating Questionnaire Status Bar to always display last updated date

### DIFF
--- a/src/components/StatusBar/StatusBar.test.tsx
+++ b/src/components/StatusBar/StatusBar.test.tsx
@@ -16,6 +16,7 @@ import Approved from './icons/Approved.svg';
 import Rejected from './icons/Rejected.svg';
 import Submitted from './icons/Submitted.svg';
 import UnderReview from './icons/UnderReview.svg';
+import { FormatDate } from "../../utils";
 
 type Props = {
   data: object;
@@ -79,7 +80,7 @@ describe("StatusBar > General Tests", () => {
     expect(btn).toHaveAttribute("aria-label", "Review Comments");
   });
 
-  it("defaults the last updated to N/A for new applications", () => {
+  it("new applications should still display the correct last updated date", () => {
     const data = {
       status: "New",
       updatedAt: "2023-06-20T09:13:58Z",
@@ -87,7 +88,7 @@ describe("StatusBar > General Tests", () => {
 
     const { getByTestId } = render(<BaseComponent data={data} />);
 
-    expect(getByTestId("status-bar-last-updated")).toHaveTextContent("N/A");
+    expect(getByTestId("status-bar-last-updated")).toHaveTextContent(FormatDate(data.updatedAt, "M/D/YYYY", "N/A"));
   });
 
   const invalidDates = ["", " ", "0-0-0", "YYYY-06-20T09:13:58", "-06-12T09:13:58.000Z", "12023-06-20T09:13:58"];

--- a/src/components/StatusBar/components/HistorySection.tsx
+++ b/src/components/StatusBar/components/HistorySection.tsx
@@ -206,7 +206,7 @@ const StyledCloseButton = styled(Button)({
  */
 const HistorySection: FC = () => {
   const {
-    data: { status, updatedAt, history },
+    data: { updatedAt, history },
   } = useFormContext();
   const [open, setOpen] = useState<boolean>(false);
   const sortedHistory = useMemo(() => SortHistory(history), [history]);

--- a/src/components/StatusBar/components/HistorySection.tsx
+++ b/src/components/StatusBar/components/HistorySection.tsx
@@ -214,7 +214,7 @@ const HistorySection: FC = () => {
   return (
     <>
       <StyledDate data-testid="status-bar-last-updated">
-        {status === "New" ? "N/A" : FormatDate(updatedAt, "M/D/YYYY", "N/A")}
+        {FormatDate(updatedAt, "M/D/YYYY", "N/A")}
       </StyledDate>
 
       {history && history.length > 0 && (

--- a/src/content/questionnaire/ListView.tsx
+++ b/src/content/questionnaire/ListView.tsx
@@ -132,7 +132,6 @@ const columns: Column[] = [
   },
   {
     label: "Last Updated Date",
-    // eslint-disable-next-line no-nested-ternary
     value: (a) => (a.updatedAt ? FormatDate(a.updatedAt, "M/D/YYYY h:mm A") : ""),
     field: "updatedAt",
   },

--- a/src/content/questionnaire/ListView.tsx
+++ b/src/content/questionnaire/ListView.tsx
@@ -111,12 +111,12 @@ const columns: Column[] = [
   },
   {
     label: "Study",
-    value: (a) => a.studyAbbreviation || "N/A",
+    value: (a) => a.studyAbbreviation || "NA",
     field: "studyAbbreviation",
   },
   {
     label: "Program",
-    value: (a) => a.programName || "N/A",
+    value: (a) => a.programName || "NA",
     field: "programName",
   },
   {

--- a/src/content/questionnaire/ListView.tsx
+++ b/src/content/questionnaire/ListView.tsx
@@ -111,12 +111,12 @@ const columns: Column[] = [
   },
   {
     label: "Study",
-    value: (a) => a.studyAbbreviation || "NA",
+    value: (a) => a.studyAbbreviation || "N/A",
     field: "studyAbbreviation",
   },
   {
     label: "Program",
-    value: (a) => a.programName || "NA",
+    value: (a) => a.programName || "N/A",
     field: "programName",
   },
   {
@@ -132,7 +132,8 @@ const columns: Column[] = [
   },
   {
     label: "Last Updated Date",
-    value: (a) => (a.updatedAt ? FormatDate(a.updatedAt, "M/D/YYYY h:mm A") : ""),
+    // eslint-disable-next-line no-nested-ternary
+    value: (a) => (a.status === "New" ? "N/A" : (a.updatedAt ? FormatDate(a.updatedAt, "M/D/YYYY h:mm A") : "")),
     field: "updatedAt",
   },
   {

--- a/src/content/questionnaire/ListView.tsx
+++ b/src/content/questionnaire/ListView.tsx
@@ -133,7 +133,7 @@ const columns: Column[] = [
   {
     label: "Last Updated Date",
     // eslint-disable-next-line no-nested-ternary
-    value: (a) => (a.status === "New" ? "N/A" : (a.updatedAt ? FormatDate(a.updatedAt, "M/D/YYYY h:mm A") : "")),
+    value: (a) => (a.updatedAt ? FormatDate(a.updatedAt, "M/D/YYYY h:mm A") : ""),
     field: "updatedAt",
   },
   {


### PR DESCRIPTION
This fixes ticket 334 so that the status bar in the questionnaire always displays the last updated date, even if the status is "New".
Also changes status and program columns in the submission table to "N/A" instead of "NA" for consistency.