### PR TITLE
CRDCDH-336 Monitor for freeSolo input

### DIFF
--- a/src/components/Questionnaire/AdditionalContact.tsx
+++ b/src/components/Questionnaire/AdditionalContact.tsx
@@ -87,6 +87,7 @@ const AdditionalContact: FC<Props> = ({ idPrefix = "", index, contact, readOnly,
           value={institution || ""}
           options={institutionConfig}
           placeholder="Enter or Select an Institution"
+          validate={(v: string) => v?.trim()?.length > 0}
           required
           disableClearable
           freeSolo

--- a/src/components/Questionnaire/AutocompleteInput.tsx
+++ b/src/components/Questionnaire/AutocompleteInput.tsx
@@ -189,6 +189,14 @@ const AutocompleteInput = <T,>({
     setError(false);
   };
 
+  const onInputChangeWrapper = (
+    event: SyntheticEvent,
+    newValue: string,
+  ): void => {
+    processValue(newValue as unknown as T);
+    setError(false);
+  };
+
   useEffect(() => {
     const invalid = () => setError(true);
 
@@ -213,6 +221,7 @@ const AutocompleteInput = <T,>({
         <StyledAutocomplete
           value={val}
           onChange={onChangeWrapper}
+          onInputChange={onInputChangeWrapper}
           options={options}
           readOnly={readOnly}
           forcePopupIcon

--- a/src/content/questionnaire/sections/A.tsx
+++ b/src/content/questionnaire/sections/A.tsx
@@ -162,6 +162,7 @@ const FormSectionA: FC<FormSectionProps> = ({ SectionOption, refs }: FormSection
           value={pi?.institution || ""}
           options={institutionConfig}
           placeholder="Enter or Select an Institution"
+          validate={(v: string) => v?.trim()?.length > 0}
           required
           disableClearable
           freeSolo
@@ -261,6 +262,7 @@ const FormSectionA: FC<FormSectionProps> = ({ SectionOption, refs }: FormSection
               options={institutionConfig}
               placeholder="Enter or Select an Institution"
               readOnly={readOnlyInputs}
+              validate={(v: string) => v?.trim()?.length > 0}
               disableClearable
               required
               freeSolo


### PR DESCRIPTION
### Overview

This PR fixes bug [CRDCDH-336](https://tracker.nci.nih.gov/browse/CRDCDH-336) which causes any `AutocompleteInput` to not validate custom user input.

To replicate the bug:

1. Find a autocomplete input with no value currently set (Important)
2. Type custom text into the field
3. Save
4. See the validation error

The fix:

- Updated the autocomplete input to watch for input within the text field. Any changes in the text field triggers the existing processValue function.