### PR TITLE
Crdcdh 220 Section D UX updates

### DIFF
--- a/src/components/Questionnaire/TableFileTypeAndExtensionInput.tsx
+++ b/src/components/Questionnaire/TableFileTypeAndExtensionInput.tsx
@@ -130,8 +130,7 @@ const TableAutocompleteInput: FC<Props> = ({
   return (
     <>
       <TableCell className={classes.autocomplete}>
-        <Autocomplete
-          isOptionEqualToValue={(option, value) => option.value === value.value}
+        <StyledAutocomplete
           sx={{
           "& .MuiInputBase-input": {
             fontWeight: 400,
@@ -155,8 +154,6 @@ const TableAutocompleteInput: FC<Props> = ({
           },
           popper: {
             disablePortal: true,
-            sx: { marginTop: "8px !important" },
-            style: { width: "200% !important" },
             modifiers: [
               {
                 // disables popper from flipping above the input when out of screen room
@@ -187,8 +184,7 @@ const TableAutocompleteInput: FC<Props> = ({
         />
       </TableCell>
       <TableCell className={classes.autocomplete}>
-        <Autocomplete
-          isOptionEqualToValue={(option, value) => option.value === value.value}
+        <StyledAutocomplete
           sx={{
             "& .MuiInputBase-input": {
               fontWeight: 400,
@@ -212,7 +208,6 @@ const TableAutocompleteInput: FC<Props> = ({
             },
             popper: {
               disablePortal: true,
-              sx: { marginTop: "8px !important" },
               modifiers: [
                 {
                   // disables popper from flipping above the input when out of screen room
@@ -245,6 +240,24 @@ const TableAutocompleteInput: FC<Props> = ({
     </>
   );
 };
+
+const StyledAutocomplete = styled(Autocomplete)(({ readOnly } : { readOnly? : boolean }) => ({
+  "& .MuiInputBase-root": {
+    backgroundColor: readOnly ? "#D9DEE4" : "#FFFFFF",
+    "&.MuiAutocomplete-inputRoot.MuiInputBase-root": {
+      display: 'flex',
+      alignItems: 'center',
+      padding: 0,
+    },
+    "& .MuiInputBase-input": {
+      fontWeight: 400,
+      fontSize: "16px",
+      fontFamily: "'Nunito', 'Rubik', sans-serif",
+      padding: "10px 12px 10px 12px !important",
+      cursor: readOnly ? "not-allowed !important" : "initial",
+    },
+  },
+}));
 
 const styles = () => ({
   paper: {
@@ -286,14 +299,14 @@ const styles = () => ({
     "& .MuiAutocomplete-input:read-only": {
       backgroundColor: "#D9DEE4",
       cursor: "not-allowed",
-    }
+    },
   },
   autocomplete: {
     borderTop: "1px solid #6B7294 !important",
     borderRight: "1px solid #6B7294 !important",
     borderBottom: "none!important",
     borderLeft: "none!important",
-    padding: "10px 12px 10px 12px",
+    padding: "0",
     "& .MuiStack-root": {
       width: "auto",
     }

--- a/src/components/Questionnaire/TableFileTypeAndExtensionInput.tsx
+++ b/src/components/Questionnaire/TableFileTypeAndExtensionInput.tsx
@@ -209,7 +209,9 @@ const TableAutocompleteInput: FC<Props> = ({
             },
             popper: {
               disablePortal: true,
-              sx: { top: "-2px !important" },
+              sx: {
+                top: "-2px !important",
+              },
               modifiers: [
                 {
                   // disables popper from flipping above the input when out of screen room
@@ -287,11 +289,11 @@ const styles = () => ({
       background: "#FFFFFF"
     },
     "& .MuiAutocomplete-option:hover": {
-      backgroundColor: "#5E6787",
+      backgroundColor: "#3E7E6D",
       color: "#FFFFFF"
     },
     "& .MuiAutocomplete-option.Mui-focused": {
-      backgroundColor: "#5E6787 !important",
+      backgroundColor: "#3E7E6D !important",
       color: "#FFFFFF"
     },
   },

--- a/src/components/Questionnaire/TableFileTypeAndExtensionInput.tsx
+++ b/src/components/Questionnaire/TableFileTypeAndExtensionInput.tsx
@@ -154,6 +154,7 @@ const TableAutocompleteInput: FC<Props> = ({
           },
           popper: {
             disablePortal: true,
+            sx: { top: "-2px !important" },
             modifiers: [
               {
                 // disables popper from flipping above the input when out of screen room
@@ -208,6 +209,7 @@ const TableAutocompleteInput: FC<Props> = ({
             },
             popper: {
               disablePortal: true,
+              sx: { top: "-2px !important" },
               modifiers: [
                 {
                   // disables popper from flipping above the input when out of screen room
@@ -255,6 +257,13 @@ const StyledAutocomplete = styled(Autocomplete)(({ readOnly } : { readOnly? : bo
       fontFamily: "'Nunito', 'Rubik', sans-serif",
       padding: "10px 12px 10px 12px !important",
       cursor: readOnly ? "not-allowed !important" : "initial",
+    },
+    "& .MuiAutocomplete-endAdornment": {
+      right: "8px",
+    },
+    "&.Mui-focused": {
+      boxShadow:
+        "2px 2px 2px 1px rgba(38, 184, 147, 0.10), -2px -2px 2px 1px rgba(38, 184, 147, 0.20)",
     },
   },
 }));


### PR DESCRIPTION
This addresses ticket 220 which is UX QA for section D of the questionnaire.
Specifically addresses figma comment #13. 

- The box is now as wide as the table column, and the hover color is now #3E7E6D.

Comment #12 is due to a requirement from and the current implementation is correct.
Comment #11 is because coding wise, left is false, and right is true, and I cleared this with Hannah, the current implantation is fine.
Comment #17 is addressed on Alec's CRDC-217 branch.