### PR TITLE
CRDCDH-359 Update user roles to match BE

### DIFF
--- a/src/components/Header/HeaderTabletAndMobile.tsx
+++ b/src/components/Header/HeaderTabletAndMobile.tsx
@@ -198,7 +198,7 @@ const Header = () => {
     },
   ];
 
-  if (authData?.user?.role === "Admin" || authData?.user?.role === "ORG_OWNER") {
+  if (authData?.user?.role === "Admin" || authData?.user?.role === "Organization Owner") {
     navbarSublists[displayName].splice(1, 0, {
       name: 'Manage Users',
       link: '/users',

--- a/src/components/Header/components/NavbarDesktop.tsx
+++ b/src/components/Header/components/NavbarDesktop.tsx
@@ -524,7 +524,7 @@ const NavBar = () => {
                 User Profile
               </Link>
             </span>
-            {(authData?.user?.role === "Admin" || authData?.user?.role === "ORG_OWNER") && (
+            {(authData?.user?.role === "Admin" || authData?.user?.role === "Organization Owner") && (
               <span className="dropdownItem">
                 <Link id="navbar-dropdown-item-name-user-manage" to="/users" className="dropdownItem" onClick={() => setClickedTitle("")}>
                   Manage Users

--- a/src/config/AuthRoles.ts
+++ b/src/config/AuthRoles.ts
@@ -8,13 +8,14 @@
 export const Roles: User["role"][] = [
   "User",
   "Submitter",
-  "ORG_OWNER",
-  "FederalLead",
-  // "Concierge",
-  "Curator",
-  "DC_OWNER",
-  // "DC_POC",
+  "Organization Owner",
+  "Federal Lead",
+  "Data Curator",
+  "Data Commons POC",
   "Admin",
+  // TODO: Disabled in MVP-1
+  // "Concierge",
+  // "DC_OWNER",
 ];
 
 /**
@@ -25,5 +26,5 @@ export const Roles: User["role"][] = [
  */
 export const OrgRequiredRoles: User["role"][] = [
   "Submitter",
-  "ORG_OWNER",
+  "Organization Owner",
 ];

--- a/src/content/questionnaire/ListView.tsx
+++ b/src/content/questionnaire/ListView.tsx
@@ -140,14 +140,14 @@ const columns: Column[] = [
     value: (a, user) => {
       const role = user?.role;
 
-      if (((role === "User" || role === "Submitter" || role === "ORG_OWNER") && a.applicant?.applicantID === user._id) && ["New", "In Progress", "Rejected"].includes(a.status)) {
+      if (((role === "User" || role === "Submitter" || role === "Organization Owner") && a.applicant?.applicantID === user._id) && ["New", "In Progress", "Rejected"].includes(a.status)) {
         return (
           <Link to={`/submission/${a?.["_id"]}`}>
             <StyledActionButton bg="#99E3BB" text="#156071" border="#63BA90">Resume</StyledActionButton>
           </Link>
         );
       }
-      if (role === "FederalLead" && ["Submitted", "In Review"].includes(a.status)) {
+      if (role === "Federal Lead" && ["Submitted", "In Review"].includes(a.status)) {
         return (
           <Link to={`/submission/${a?.["_id"]}`}>
             <StyledActionButton bg="#F1C6B3" text="#5F564D" border="#DB9C62">Review</StyledActionButton>
@@ -251,7 +251,7 @@ const ListingView: FC = () => {
         padding="57px 0 0 25px"
         body={(
           <StyledBannerBody direction="row" alignItems="center" justifyContent="flex-end">
-            {(user?.role === "User" || user?.role === "Submitter" || user?.role === "ORG_OWNER") && (
+            {(user?.role === "User" || user?.role === "Submitter" || user?.role === "Organization Owner") && (
               <StyledButton
                 type="button"
                 onClick={createApp}

--- a/src/content/users/Controller.tsx
+++ b/src/content/users/Controller.tsx
@@ -22,7 +22,7 @@ const MemorizedProvider = memo(OrganizationProvider);
 export default () => {
   const { userId } = useParams();
   const { user: { _id, role } } = useAuthContext();
-  const isAdministrative = role === "Admin" || role === "ORG_OWNER";
+  const isAdministrative = role === "Admin" || role === "Organization Owner";
 
   // Non-admin users can only view their own profile, redirect to it
   if (userId !== _id && !isAdministrative) {

--- a/src/content/users/ListView.tsx
+++ b/src/content/users/ListView.tsx
@@ -233,7 +233,7 @@ const ListingView: FC = () => {
   };
 
   useEffect(() => {
-    if (user.role !== "ORG_OWNER") {
+    if (user.role !== "Organization Owner") {
       return;
     }
 
@@ -287,7 +287,7 @@ const ListingView: FC = () => {
               render={({ field }) => (
                 <StyledSelect
                   {...field}
-                  disabled={user.role === "ORG_OWNER"}
+                  disabled={user.role === "Organization Owner"}
                   defaultValue="All"
                   value={field.value || "All"}
                 >

--- a/src/types/Auth.d.ts
+++ b/src/types/Auth.d.ts
@@ -6,12 +6,12 @@ type User = {
   role:
     | "User"
     | "Submitter"
-    | "ORG_OWNER"
-    | "FederalLead"
+    | "Organization Owner"
+    | "Federal Lead"
     // | "Concierge"
-    | "Curator"
-    | "DC_OWNER"
-    | "DC_POC"
+    | "Data Curator"
+    // | "DC_OWNER"
+    | "Data Commons POC"
     | "Admin";
   IDP: "nih" | "login.gov";
   email: string;

--- a/src/utils/formModeUtils.test.ts
+++ b/src/utils/formModeUtils.test.ts
@@ -97,7 +97,7 @@ describe('getFormMode tests based on provided requirements', () => {
 
   // Federal Lead Tests
   describe('getFormMode > Fed Lead tests', () => {
-    const user: User = { ...baseUser, role: 'FederalLead' };
+    const user: User = { ...baseUser, role: 'Federal Lead' };
 
     it('should set Review mode for Fed Lead when status is Submitted or In Review', () => {
       const statuses: ApplicationStatus[] = ['Submitted', 'In Review'];
@@ -124,7 +124,7 @@ describe('getFormMode tests based on provided requirements', () => {
 
   // Org Owner Tests
   describe('getFormMode > Org Owner tests', () => {
-    const user: User = { ...baseUser, role: "ORG_OWNER" };
+    const user: User = { ...baseUser, role: "Organization Owner" };
 
     it('should allow Org Owner to edit their own unsubmitted or rejected forms', () => {
       const statuses: ApplicationStatus[] = ['New', 'In Progress', 'Rejected'];
@@ -171,7 +171,7 @@ describe('getFormMode tests based on provided requirements', () => {
   // Other role Tests
   describe('getFormMode > Other roles tests', () => {
     it('should always set View Only for all other roles', () => {
-      const roles: User["role"][] = ['DC_POC', "Some other role", "This role doesn't exist"] as unknown as User["role"][];
+      const roles: User["role"][] = ['Data Commons POC', "Some other role", "This role doesn't exist"] as unknown as User["role"][];
       const statuses: ApplicationStatus[] = ['New', 'In Progress', 'Submitted', 'In Review', 'Approved', 'Rejected'];
 
       roles.forEach((role) => {

--- a/src/utils/formModeUtils.ts
+++ b/src/utils/formModeUtils.ts
@@ -102,11 +102,11 @@ export const getFormMode = (
   }
 
   switch (user.role) {
-    case "FederalLead":
+    case "Federal Lead":
       return _getFormModeForFederalLead(data);
     case "Admin":
       return FormModes.VIEW_ONLY;
-    case "ORG_OWNER":
+    case "Organization Owner":
       return _getFormModeForOrgOwner(user, data);
     case "User":
     case "Submitter":

--- a/src/utils/profileUtils.test.ts
+++ b/src/utils/profileUtils.test.ts
@@ -31,12 +31,12 @@ describe("getEditableFields cases", () => {
 
   const orgOwner: User = {
     _id: '3',
-    role: 'ORG_OWNER',
+    role: 'Organization Owner',
   } as User;
 
   const federalLead: User = {
     _id: '4',
-    role: 'FederalLead',
+    role: 'Federal Lead',
   } as User;
 
   it("should allow an Admin to edit their own firstName and lastName", () => {
@@ -55,7 +55,7 @@ describe("getEditableFields cases", () => {
     expect(utils.getEditableFields(admin, orgOwner).sort()).toEqual(expected);
   });
 
-  it("should allow an Admin to edit a FederalLead's role, userStatus, and organization", () => {
+  it("should allow an Admin to edit a Federal Lead's role, userStatus, and organization", () => {
     const expected = ['role', 'userStatus', 'organization'].sort();
     expect(utils.getEditableFields(admin, federalLead).sort()).toEqual(expected);
   });
@@ -70,7 +70,7 @@ describe("getEditableFields cases", () => {
     expect(utils.getEditableFields(orgOwner, user).sort()).toEqual(expected);
   });
 
-  it("should allow FederalLead to edit their own firstName and lastName", () => {
+  it("should allow Federal Lead to edit their own firstName and lastName", () => {
     const expected = ['firstName', 'lastName'].sort();
     expect(utils.getEditableFields(federalLead, federalLead).sort()).toEqual(expected);
   });
@@ -80,7 +80,7 @@ describe("getEditableFields cases", () => {
     expect(utils.getEditableFields(user, user).sort()).toEqual(expected);
   });
 
-  it("by default, should not allow FederalLead to edit another user's fields", () => {
+  it("by default, should not allow Federal Lead to edit another user's fields", () => {
     expect(utils.getEditableFields(federalLead, admin)).toEqual([]);
     expect(utils.getEditableFields(federalLead, orgOwner)).toEqual([]);
     expect(utils.getEditableFields(federalLead, user)).toEqual([]);


### PR DESCRIPTION
### Overview

This PR introduces the renamed User Roles as described exactly in CRDCDH-178/CRDCDH-179/CRDCDH-359. This update is complementary to the backend update and should not be DEPLOYED prior to the BE approval. 