### PR TITLE
updating footer email link

### DIFF
--- a/src/config/globalFooterData.tsx
+++ b/src/config/globalFooterData.tsx
@@ -121,8 +121,8 @@ export default {
       link: 'tel:+18004226237',
     },
     {
-      text: 'cdshelpdesk@mail.nih.gov',
-      link: 'mailto:+cdshelpdesk@mail.nih.gov',
+      text: 'NCIinfo@nih.gov',
+      link: 'mailto:+NCIinfo@nih.gov',
     },
     {
       text: 'Site Feedback',


### PR DESCRIPTION
This implements ticket 370, changing this:
On the Data Hub footer, replace the "[cdshelpdesk@mail.nih.gov](mailto:+cdshelpdesk@mail.nih.gov)" email with the NCI  [NCIinfo@nih.gov](mailto:NCIinfo@nih.gov) email address.