### PR TITLE
CRDCDH-369 Allow managing of own role and status

### DIFF
--- a/src/components/Contexts/AuthContext.tsx
+++ b/src/components/Contexts/AuthContext.tsx
@@ -60,7 +60,7 @@ export type ContextState = {
   user: User;
   error?: string;
   logout?: () => Promise<boolean>;
-  setData?: (data: UserInput) => void;
+  setData?: (data: Partial<User>) => void;
 };
 
 export enum Status {
@@ -142,10 +142,16 @@ export const AuthProvider: FC<ProviderProps> = ({ children } : ProviderProps) =>
     return status;
   };
 
-  const setData = (data: UserInput): void => {
+  const setData = (data: Partial<User>): void => {
     if (!state.isLoggedIn) return;
 
-    setState((prev) => ({ ...prev, user: { ...prev.user, ...data } }));
+    // Remove any nested objects that are null
+    const newUser = { ...state.user, ...data };
+    if (!data?.organization) {
+      delete newUser.organization;
+    }
+
+    setState((prev) => ({ ...prev, user: newUser }));
   };
 
   useEffect(() => {

--- a/src/components/Header/HeaderTabletAndMobile.tsx
+++ b/src/components/Header/HeaderTabletAndMobile.tsx
@@ -186,7 +186,7 @@ const Header = () => {
   navbarSublists[displayName] = [
     {
       name: 'User Profile',
-      link: `/users/${authData?.user?._id}`,
+      link: `/profile/${authData?.user?._id}`,
       id: 'navbar-dropdown-item-user-profile',
       className: 'navMobileSubItem',
     },

--- a/src/components/Header/components/NavbarDesktop.tsx
+++ b/src/components/Header/components/NavbarDesktop.tsx
@@ -520,7 +520,7 @@ const NavBar = () => {
         <NameDropdownContainer>
           <div className="dropdownList">
             <span className="dropdownItem">
-              <Link id="navbar-dropdown-item-name-user-profile" to={`/users/${authData?.user?._id}`} className="dropdownItem" onClick={() => setClickedTitle("")}>
+              <Link id="navbar-dropdown-item-name-user-profile" to={`/profile/${authData?.user?._id}`} className="dropdownItem" onClick={() => setClickedTitle("")}>
                 User Profile
               </Link>
             </span>

--- a/src/content/users/Controller.tsx
+++ b/src/content/users/Controller.tsx
@@ -5,6 +5,10 @@ import { OrganizationProvider } from '../../components/Contexts/OrganizationList
 import ListView from "./ListView";
 import ProfileView from "./ProfileView";
 
+type Props = {
+  type: "users" | "profile";
+};
+
 /**
  * A memoized version of OrganizationProvider
  * which caches data between ListView and ProfileView
@@ -16,17 +20,35 @@ const MemorizedProvider = memo(OrganizationProvider);
 /**
  * Renders the correct view based on the URL and permissions-tier
  *
- * @param {void} props - React props
+ * Implementation details:
+ *
+ * There are two types `ProfileView` "views": `users` and `profile`,
+ * and based on the view type, the authenticated user will see slightly different content.
+ *
+ *   - `users` aka Edit User view:
+ *     - allows editing `Role`, `Status`, and `Organization` for Admins,
+ *       but allows Org Owners to only see that profile.
+ *   - `profile` aka User Profile view:
+ *     - is only shown to the authenticated user, and allows editing
+ *       of `First Name` and `Last Name` only
+ *
+ * Most of the underlying logic is the same, hence the combination of
+ * these two views into a single component. There's also a `ListView`
+ * which is shown to Admins and Org Owners, and allows them to see
+ * the list of users.
+ *
+ * @param {Props} props - React props
  * @returns {FC} - React component
  */
-export default () => {
+export default ({ type } : Props) => {
   const { userId } = useParams();
-  const { user: { _id, role } } = useAuthContext();
+  const { user } = useAuthContext();
+  const { _id, role } = user || {};
   const isAdministrative = role === "Admin" || role === "Organization Owner";
 
-  // Non-admin users can only view their own profile, redirect to it
-  if (userId !== _id && !isAdministrative) {
-    return <Navigate to={`/users/${_id}`} />;
+  // Accounts can only view their own "profile", redirect to it
+  if ((type === "profile" && userId !== _id) || (type === "users" && !isAdministrative)) {
+    return <Navigate to={`/profile/${_id}`} />;
   }
 
   // Show list of users to Admin or Org Owner
@@ -38,10 +60,10 @@ export default () => {
     );
   }
 
-  // Viewing own profile or Admin/Org Owner viewing another user's profile
+  // Admin or Org Owner viewing a user's "Edit User" page or their own "Edit User" page
   return (
-    <MemorizedProvider preload={isAdministrative}>
-      <ProfileView _id={userId} />
+    <MemorizedProvider preload={isAdministrative && type === "users"}>
+      <ProfileView _id={userId} viewType={type} />
     </MemorizedProvider>
   );
 };

--- a/src/content/users/ListView.tsx
+++ b/src/content/users/ListView.tsx
@@ -252,7 +252,6 @@ const ListingView: FC = () => {
       .filter((u: T) => (orgFilter && orgFilter !== "All" ? u.organization?.orgID === orgFilter : true))
       .filter((u: T) => (roleFilter && roleFilter !== "All" ? u.role === roleFilter : true))
       .filter((u: T) => (statusFilter && statusFilter !== "All" ? u.userStatus === statusFilter : true))
-      .filter((u: T) => u._id !== user._id)
       .sort((a, b) => orderBy?.comparator(a, b) || 0);
 
     if (order === "desc") {

--- a/src/graphql/editUser.ts
+++ b/src/graphql/editUser.ts
@@ -3,19 +3,18 @@ import gql from 'graphql-tag';
 export const mutation = gql`
   mutation editUser($userID: String, $organization: String, $status: String, $role: String) {
     editUser(userID: $userID, organization: $organization, status: $status, role: $role) {
-      _id
-      firstName
-      lastName
       userStatus
       role
       organization {
         orgID
         orgName
+        createdAt
+        updateAt
       }
     }
   }
 `;
 
 export type Response = {
-  editUser: User;
+  editUser: Pick<User, 'userStatus' | 'role' | 'organization'>;
 };

--- a/src/graphql/getUser.ts
+++ b/src/graphql/getUser.ts
@@ -15,6 +15,8 @@ export const query = gql`
       organization {
         orgID
         orgName
+        createdAt
+        updateAt
       }
     }
   }

--- a/src/graphql/updateMyUser.ts
+++ b/src/graphql/updateMyUser.ts
@@ -3,11 +3,20 @@ import gql from 'graphql-tag';
 export const mutation = gql`
   mutation updateMyUser ($userInfo: UpdateUserInput!) {
     updateMyUser(userInfo: $userInfo) {
-      _id
+      firstName
+      lastName
+      userStatus
+      role
+      organization {
+        orgID
+        orgName
+        createdAt
+        updateAt
+      }
     }
   }
 `;
 
 export type Response = {
-  updateMyUser: User["_id"];
+  updateMyUser: Pick<User, 'firstName' | 'lastName' | 'userStatus' | 'role' | 'organization'>;
 };

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -68,7 +68,11 @@ const routes: RouteObject[] = [
       },
       {
         path: '/users/:userId?',
-        element: <RequireAuth component={<Users />} redirectPath="/users" redirectName="User Management" />
+        element: <RequireAuth component={<Users key="users-view" type="users" />} redirectPath="/users" redirectName="User Management" />
+      },
+      {
+        path: '/profile/:userId?',
+        element: <RequireAuth component={<Users key="profile-view" type="profile" />} redirectPath="/profile" redirectName="User Profile" />
       },
       {
         path: '/sitesearch/:keyword',

--- a/src/utils/profileUtils.test.ts
+++ b/src/utils/profileUtils.test.ts
@@ -41,56 +41,56 @@ describe("getEditableFields cases", () => {
 
   it("should allow an Admin to edit their own firstName and lastName", () => {
     const expected = ['firstName', 'lastName'].sort();
-    expect(utils.getEditableFields(admin, admin).sort()).toEqual(expected);
+    expect(utils.getEditableFields(admin, admin, "profile").sort()).toEqual(expected);
   });
 
   it("should allow an Admin to edit a Admin's role, organization, userStatus", () => {
     const expected = ['role', 'organization', 'userStatus'].sort();
-    expect(utils.getEditableFields(admin, { ...admin, _id: "AAA-123-19291" }).sort()).toEqual(expected);
+    expect(utils.getEditableFields(admin, { ...admin, _id: "AAA-123-19291" }, "users").sort()).toEqual(expected);
   });
 
   it("should allow an Admin to edit a User's role, organization, userStatus", () => {
     const expected = ['role', 'organization', 'userStatus'].sort();
-    expect(utils.getEditableFields(admin, user).sort()).toEqual(expected);
-    expect(utils.getEditableFields(admin, orgOwner).sort()).toEqual(expected);
+    expect(utils.getEditableFields(admin, user, "users").sort()).toEqual(expected);
+    expect(utils.getEditableFields(admin, orgOwner, "users").sort()).toEqual(expected);
   });
 
   it("should allow an Admin to edit a Federal Lead's role, userStatus, and organization", () => {
     const expected = ['role', 'userStatus', 'organization'].sort();
-    expect(utils.getEditableFields(admin, federalLead).sort()).toEqual(expected);
+    expect(utils.getEditableFields(admin, federalLead, "users").sort()).toEqual(expected);
   });
 
   it("should allow an Org Owner to edit their own firstName and lastName", () => {
     const expected = ['firstName', 'lastName'].sort();
-    expect(utils.getEditableFields(orgOwner, orgOwner).sort()).toEqual(expected);
+    expect(utils.getEditableFields(orgOwner, orgOwner, "profile").sort()).toEqual(expected);
   });
 
   it("should allow an Org Owner to view only", () => {
     const expected = [].sort();
-    expect(utils.getEditableFields(orgOwner, user).sort()).toEqual(expected);
+    expect(utils.getEditableFields(orgOwner, user, "users").sort()).toEqual(expected);
   });
 
   it("should allow Federal Lead to edit their own firstName and lastName", () => {
     const expected = ['firstName', 'lastName'].sort();
-    expect(utils.getEditableFields(federalLead, federalLead).sort()).toEqual(expected);
+    expect(utils.getEditableFields(federalLead, federalLead, "profile").sort()).toEqual(expected);
   });
 
   it("should allow User's to edit their own firstName and lastName", () => {
     const expected = ['firstName', 'lastName'].sort();
-    expect(utils.getEditableFields(user, user).sort()).toEqual(expected);
+    expect(utils.getEditableFields(user, user, "profile").sort()).toEqual(expected);
   });
 
   it("by default, should not allow Federal Lead to edit another user's fields", () => {
-    expect(utils.getEditableFields(federalLead, admin)).toEqual([]);
-    expect(utils.getEditableFields(federalLead, orgOwner)).toEqual([]);
-    expect(utils.getEditableFields(federalLead, user)).toEqual([]);
-    expect(utils.getEditableFields(federalLead, { ...federalLead, _id: "ABC-NOT-MY-ID" })).toEqual([]);
+    expect(utils.getEditableFields(federalLead, admin, "users")).toEqual([]);
+    expect(utils.getEditableFields(federalLead, orgOwner, "users")).toEqual([]);
+    expect(utils.getEditableFields(federalLead, user, "users")).toEqual([]);
+    expect(utils.getEditableFields(federalLead, { ...federalLead, _id: "ABC-NOT-MY-ID" }, "users")).toEqual([]);
   });
 
   it("by default, should not allow User to edit another user's fields", () => {
-    expect(utils.getEditableFields(user, admin)).toEqual([]);
-    expect(utils.getEditableFields(user, orgOwner)).toEqual([]);
-    expect(utils.getEditableFields(user, federalLead)).toEqual([]);
-    expect(utils.getEditableFields(user, { ...user, _id: "ABC-NOT-MY-ID" })).toEqual([]);
+    expect(utils.getEditableFields(user, admin, "users")).toEqual([]);
+    expect(utils.getEditableFields(user, orgOwner, "users")).toEqual([]);
+    expect(utils.getEditableFields(user, federalLead, "users")).toEqual([]);
+    expect(utils.getEditableFields(user, { ...user, _id: "ABC-NOT-MY-ID" }, "users")).toEqual([]);
   });
 });

--- a/src/utils/profileUtils.ts
+++ b/src/utils/profileUtils.ts
@@ -21,22 +21,24 @@ export const formatIDP = (idp: User["IDP"]): string => {
  * NOTE:
  * - The `organization` field means organization assignment in general,
  *   it does not mean modifying the actual organization
- * - When a `organization` is assigned, the `User.role` should be
- *   switched to `User` on save if it's not already
  *
  * @param current the authenticated user
  * @param profileOf the user whose profile is being viewed
+ * @param viewType the page where the user originated from
  * @return array of editable fields derived from User type keys
  */
-export const getEditableFields = (current: User, profileOf: User): (keyof User)[] => {
+export const getEditableFields = (current: User, profileOf: User, viewType: "users" | "profile"): (keyof User)[] => {
   const fields: (keyof User)[] = [];
   const isSelf: boolean = current._id === profileOf?._id;
 
-  if (current.role === "Admin" && !isSelf) {
-    fields.push("userStatus", "role", "organization");
-  }
-  if (isSelf) {
+  // Only allowed if a user is viewing their own profile
+  if (isSelf && viewType === "profile") {
     fields.push("firstName", "lastName");
+  }
+
+  // Only allowed if an Admin is coming from Manage Users
+  if (current.role === "Admin" && viewType === "users") {
+    fields.push("userStatus", "role", "organization");
   }
 
   return fields;


### PR DESCRIPTION
### Overview

This PR resolves bug [CRDCDH-369](https://tracker.nci.nih.gov/browse/CRDCDH-369) and fixes a styling issue with the save error introduced in [CRDCDH-349](https://tracker.nci.nih.gov/browse/CRDCDH-349).

Specifics:

- A Admin/Org Owner will now see their own account in the Manage Users table
- Separated "Edit Profile" (Admin) and "User Profile" (User) routing to prevent confusion
  - Edit Profile is routed under `/users/{userid}`
  - User Profile is routed under `/profile/{userid}`
- When viewing User Profile, you can edit First name and Last name only
- When viewing Edit Profile, you can edit Role, Organization, and Account Status (if permissions allow it)
- Fixed a issue with the error message placement (being overlapped)