### PR TITLE
Add TSV to clinical data types

### DIFF
--- a/src/config/FileTypeConfig.ts
+++ b/src/config/FileTypeConfig.ts
@@ -13,7 +13,7 @@
   export const fileTypeExtensions = {
   "Raw sequencing data": ["BAM", "FASTQ"],
     "Derived sequencing data": ["VCF", "MAF"],
-    "Clinical data": ["XML", "JSON"],
+    "Clinical data": ["XML", "JSON", "TSV"],
     "Protein expression data": ["TSV"],
     "Imaging data": ["DICOM", "SVS"],
   };


### PR DESCRIPTION
Implements ticket 384,
On the Data Types page of the Submission Request form, add "TSV" to the predefined extension list for the Clinical Data Type.

