### PR TITLE
CRDCDH-396 Program "Other" bug fix

### DIFF
--- a/src/config/InitialValues.ts
+++ b/src/config/InitialValues.ts
@@ -12,7 +12,7 @@ export const InitialApplication: Omit<Application, "questionnaireData"> = {
 };
 
 export const InitialQuestionnaire: QuestionnaireData = {
-sections: [],
+  sections: [],
   pi: {
     firstName: "",
     lastName: "",
@@ -35,7 +35,8 @@ sections: [],
     name: "",
     abbreviation: "",
     description: "",
-    notApplicable: false
+    notApplicable: false,
+    isCustom: false
   },
   study: {
     name: "",

--- a/src/config/ProgramConfig.ts
+++ b/src/config/ProgramConfig.ts
@@ -11,6 +11,7 @@ export const OptionalProgram : ProgramOption = {
   abbreviation: null,
   editable: true,
   notApplicable: false,
+  isCustom: true
 };
 
 /**
@@ -25,7 +26,8 @@ export const NotApplicableProgram : ProgramOption = {
   name: "Not Applicable",
   abbreviation: null,
   editable: false,
-  notApplicable: true
+  notApplicable: true,
+  isCustom: false,
 };
 
 /**
@@ -40,24 +42,28 @@ const options: ProgramOption[] = [
     abbreviation: "CCDI",
     description: "NCI's Childhood Cancer Data Initiative (CCDI) is building a community centered around childhood cancer care and research data.",
     notApplicable: false,
+    isCustom: false,
   },
   {
     name: "Clinical Proteomic Tumor Analysis Consortium",
     abbreviation: "CPTAC",
     description: "The National Cancer Institute's Clinical Proteomic Tumor Analysis Consortium (CPTAC) is a national effort to accelerate the understanding of the molecular basis of cancer through the application of large-scale proteome and genome analysis, or proteogenomics.",
     notApplicable: false,
+    isCustom: false,
   },
   {
     name: "Division of Cancer Control and Population Sciences",
     abbreviation: "DCCPS",
     description: "The Division of Cancer Control and Population Sciences (DCCPS) plays a unique role in reducing the burden of cancer in America acting as NCI’s bridge to public health research, practice, and policy. DCCPS, an extramural division, has the lead responsibility at NCI for supporting research in surveillance, epidemiology, health services, behavioral science, and cancer survivorship.",
     notApplicable: false,
+    isCustom: false,
   },
   {
     name: "Human Tumor Atlas Network",
     abbreviation: "HTAN",
     description: "HTAN is a collaborative network of Research Centers and a central Data Coordinating Center are constructing 3-dimensional atlases of the cellular, morphological, and molecular features of human cancers as they evolve from precancerous lesions to advanced disease. ",
     notApplicable: false,
+    isCustom: false,
   },
   // NOTE: These are special program options that are used
   // ADD NEW PROGRAMS ABOVE THIS LINE

--- a/src/content/questionnaire/sections/B.tsx
+++ b/src/content/questionnaire/sections/B.tsx
@@ -137,7 +137,7 @@ const FormSectionB: FC<FormSectionProps> = ({ SectionOption, refs }: FormSection
 
     // if not applicable, clear fields and set notApplicable property
     if (newProgram?.name === NotApplicableProgram?.name) {
-      setProgram({ name: "", abbreviation: "", description: "", notApplicable: true });
+      setProgram({ name: "", abbreviation: "", description: "", notApplicable: true, isCustom: false });
       return;
     }
 
@@ -147,7 +147,8 @@ const FormSectionB: FC<FormSectionProps> = ({ SectionOption, refs }: FormSection
         name: "",
         abbreviation: "",
         description: "",
-        notApplicable: false
+        notApplicable: false,
+        isCustom: true
       });
       return;
     }
@@ -157,7 +158,8 @@ const FormSectionB: FC<FormSectionProps> = ({ SectionOption, refs }: FormSection
       name: newProgram?.name || "",
       abbreviation: newProgram?.abbreviation || "",
       description: newProgram?.description || "",
-      notApplicable: false
+      notApplicable: false,
+      isCustom: false
     });
   };
 
@@ -328,6 +330,16 @@ const FormSectionB: FC<FormSectionProps> = ({ SectionOption, refs }: FormSection
           onChange={() => { }}
           className="input"
           name="program[notApplicable]"
+          type="checkbox"
+          data-type="boolean"
+          checked
+          readOnly={readOnlyProgram}
+        />
+        <StyledProxyCheckbox
+          value={program?.isCustom?.toString()}
+          onChange={() => { }}
+          className="input"
+          name="program[isCustom]"
           type="checkbox"
           data-type="boolean"
           checked

--- a/src/types/Application.d.ts
+++ b/src/types/Application.d.ts
@@ -95,6 +95,7 @@ type Program = {
   abbreviation?: string;
   description?: string;
   notApplicable?: boolean;
+  isCustom?: boolean;
 };
 
 type Study = {

--- a/src/utils/formUtils.ts
+++ b/src/utils/formUtils.ts
@@ -86,6 +86,9 @@ export const findProgram = (program: Program): ProgramOption => {
   if (program.notApplicable || program.name === NotApplicableProgram.name) {
     return NotApplicableProgram;
   }
+  if (program.isCustom) {
+    return OptionalProgram;
+  }
   const newProgram: ProgramOption = programOptions.find((option) => option.name === program.name);
   if (!newProgram && (program.name?.length || program.abbreviation?.length || program.description?.length)) {
     return OptionalProgram;


### PR DESCRIPTION
**OVERVIEW**
This PR aims to fix a bug where if you select "Other" as an option, but leave the title, abbrev, and desc as empty, then on refresh it will reset to an empty select dropdown. I added "isCustom" property to Program so that it may keep track of this properly and not rely on the values of the program fields below it.

**TICKETS**
[CRDCDH-396](https://tracker.nci.nih.gov/browse/CRDCDH-396)