### PR TITLE
Crdcdh 401 -  Changing login page

### DIFF
--- a/src/components/Questionnaire/TableFileTypeAndExtensionInput.tsx
+++ b/src/components/Questionnaire/TableFileTypeAndExtensionInput.tsx
@@ -2,9 +2,12 @@ import React, { FC, useEffect, useState, useRef } from "react";
 import {
   Autocomplete,
   TextField,
-  TableCell } from "@mui/material";
+  TableCell,
+  Tooltip,
+  TooltipProps,
+  styled
+} from "@mui/material";
 import { WithStyles, withStyles } from "@mui/styles";
-import styled from 'styled-components';
 import dropdownArrowsIcon from "../../assets/icons/dropdown_arrows.svg";
 import { fileTypeExtensions } from "../../config/FileTypeConfig";
 import useFormMode from "../../content/questionnaire/sections/hooks/useFormMode";
@@ -31,6 +34,20 @@ type Props = {
   onChange?: (e: React.SyntheticEvent, v: string, r: string) => void;
 };
 
+const StyledTooltip = styled((props: TooltipProps) => (
+  <Tooltip classes={{ popper: props.className }} {...props} />
+))(() => ({
+  "& .MuiTooltip-tooltip": {
+    marginTop: "4px !important",
+    color: "#D54309",
+    background: "#FFFFFF",
+    border: "1px solid #2B528B",
+  },
+  "& .MuiTooltip-arrow": {
+    color: "#2B528B",
+  },
+}));
+
 /**
  * Generates a generic autocomplete select box with a label and help text
  *
@@ -54,16 +71,13 @@ const TableAutocompleteInput: FC<Props> = ({
   const [extensionVal, setExtensionVal] = useState(extensionValue);
   const fileTypeRef = useRef<HTMLInputElement>(null);
   const fileExtensionRef = useRef<HTMLInputElement>(null);
+  const [showFileTypeEror, setShowFileTypeError] = useState<boolean>(false);
+  const [showFileExtensionError, setShowFileExtensionError] = useState<boolean>(false);
 
   useEffect(() => {
-    const invalid = (e) => {
-      if (!e.target.reportValidityInProgress) {
-        e.target.reportValidityInProgress = true;
-        e.target.reportValidity();
-        e.target.reportValidityInProgress = false;
-      }
+    const invalid = () => {
+      setShowFileTypeError(true);
     };
-
     fileTypeRef.current?.addEventListener("invalid", invalid);
     return () => {
       fileTypeRef.current?.removeEventListener("invalid", invalid);
@@ -71,12 +85,8 @@ const TableAutocompleteInput: FC<Props> = ({
   }, [fileTypeRef]);
 
   useEffect(() => {
-    const invalid = (e) => {
-      if (!e.target.reportValidityInProgress) {
-        e.target.reportValidityInProgress = true;
-        e.target.reportValidity();
-        e.target.reportValidityInProgress = false;
-      }
+    const invalid = () => {
+      setShowFileExtensionError(true);
     };
 
     fileExtensionRef.current?.addEventListener("invalid", invalid);
@@ -86,11 +96,10 @@ const TableAutocompleteInput: FC<Props> = ({
   }, [fileExtensionRef]);
 
   const onTypeValChangeWrapper = (e, v, r) => {
+    setShowFileTypeError(false);
     v = v || "";
     if (v === "") {
-      setExtensionVal("");
       fileTypeRef.current.setCustomValidity("Please specify a file type");
-      fileExtensionRef.current.setCustomValidity("Please specify a file extension type");
     } else {
       fileTypeRef.current.setCustomValidity("");
     }
@@ -101,6 +110,7 @@ const TableAutocompleteInput: FC<Props> = ({
     setTypeVal(v);
   };
   const onExtensionValChangeWrapper = (e, v, r) => {
+    setShowFileExtensionError(false);
     v = v || "";
     if (v === "") {
       fileExtensionRef.current.setCustomValidity("Please specify a file extension type");
@@ -154,7 +164,10 @@ const TableAutocompleteInput: FC<Props> = ({
           },
           popper: {
             disablePortal: true,
-            sx: { top: "-2px !important" },
+            sx: {
+              top: "-2px !important",
+              zIndex: "2000"
+            },
             modifiers: [
               {
                 // disables popper from flipping above the input when out of screen room
@@ -168,18 +181,28 @@ const TableAutocompleteInput: FC<Props> = ({
           },
         }}
           renderInput={(p) => (
-            <TextField
-              {...p}
-              onChange={typeTextInputOnChange}
-              name={name.concat("[type]")}
-              required={required}
-              placeholder={rest.placeholder || "Enter or select a type"}
-              variant="standard"
-              inputRef={fileTypeRef}
-              InputProps={{ ...p.InputProps, disableUnderline: true }}
+            <StyledTooltip
+              title="Missing required field"
+              arrow
+              disableHoverListener
+              disableFocusListener
+              disableTouchListener
+              open={showFileTypeEror}
+              slotProps={{ tooltip: { style: { marginTop: "4px !important" } } }}
+            >
+              <TextField
+                {...p}
+                onChange={typeTextInputOnChange}
+                name={name.concat("[type]")}
+                required={required}
+                placeholder={rest.placeholder || "Enter or select a type"}
+                variant="standard"
+                inputRef={fileTypeRef}
+                InputProps={{ ...p.InputProps, disableUnderline: true }}
               // eslint-disable-next-line react/jsx-no-duplicate-props
-              inputProps={{ ...p.inputProps, maxLength: 30 }}
-            />
+                inputProps={{ ...p.inputProps, maxLength: 30 }}
+              />
+            </StyledTooltip>
         )}
           {...rest}
         />
@@ -211,6 +234,7 @@ const TableAutocompleteInput: FC<Props> = ({
               disablePortal: true,
               sx: {
                 top: "-2px !important",
+                zIndex: "2000"
               },
               modifiers: [
                 {
@@ -225,18 +249,27 @@ const TableAutocompleteInput: FC<Props> = ({
             },
           }}
           renderInput={(p) => (
-            <TextField
-              {...p}
-              onChange={extensionTextInputOnChange}
-              name={name.concat("[extension]")}
-              required={required}
-              placeholder={rest.placeholder || "Enter or select an extension"}
-              variant="standard"
-              inputRef={fileExtensionRef}
-              InputProps={{ ...p.InputProps, disableUnderline: true }}
+            <StyledTooltip
+              title="Missing required field"
+              arrow
+              disableHoverListener
+              disableFocusListener
+              disableTouchListener
+              open={showFileExtensionError}
+            >
+              <TextField
+                {...p}
+                onChange={extensionTextInputOnChange}
+                name={name.concat("[extension]")}
+                required={required}
+                placeholder={rest.placeholder || "Enter or select an extension"}
+                variant="standard"
+                inputRef={fileExtensionRef}
+                InputProps={{ ...p.InputProps, disableUnderline: true }}
               // eslint-disable-next-line react/jsx-no-duplicate-props
-              inputProps={{ ...p.inputProps, maxLength: 10 }}
-            />
+                inputProps={{ ...p.inputProps, maxLength: 10 }}
+              />
+            </StyledTooltip>
           )}
           options={fileTypeExtensions[typeVal] || []}
         />

--- a/src/components/Questionnaire/TableTextInput.tsx
+++ b/src/components/Questionnaire/TableTextInput.tsx
@@ -2,11 +2,13 @@ import React, { FC, useEffect, useId, useState, useRef } from "react";
 import {
   Input,
   InputProps,
+  Tooltip,
+  TooltipProps,
+  styled,
 } from "@mui/material";
 import { WithStyles, withStyles } from "@mui/styles";
 import useFormMode from "../../content/questionnaire/sections/hooks/useFormMode";
 import { updateInputValidity } from '../../utils';
-
 /*
 *Pass in a regex pattern if you want this field to have custom validation checking
 */
@@ -18,6 +20,18 @@ type Props = {
   classes: WithStyles<typeof styles>["classes"];
 } & InputProps;
 
+const StyledTooltip = styled((props: TooltipProps) => (
+  <Tooltip classes={{ popper: props.className }} {...props} />
+))(() => ({
+  "& .MuiTooltip-tooltip": {
+    color: "#D54309",
+    background: "#FFFFFF",
+    border: "1px solid #2B528B",
+  },
+  "& .MuiTooltip-arrow": {
+    color: "#2B528B",
+  },
+}));
 /**
  * Generates a generic text input with a label and help text
  *
@@ -45,13 +59,10 @@ const TableTextInput: FC<Props> = ({
   const [val, setVal] = useState(value);
   const regex = new RegExp(pattern);
   const inputRef = useRef<HTMLInputElement>(null);
+  const [showError, setShowError] = useState<boolean>(false);
   useEffect(() => {
-    const invalid = (e) => {
-      if (!e.target.reportValidityInProgress) {
-        e.target.reportValidityInProgress = true;
-        e.target.reportValidity();
-        e.target.reportValidityInProgress = false;
-      }
+    const invalid = () => {
+        setShowError(true);
     };
 
     inputRef.current?.addEventListener("invalid", invalid);
@@ -59,7 +70,9 @@ const TableTextInput: FC<Props> = ({
       inputRef.current?.removeEventListener("invalid", invalid);
     };
   }, [inputRef]);
+
   const onChange = (newVal) => {
+    setShowError(false);
     if (typeof filter === "function") {
       newVal = filter(newVal);
     }
@@ -77,20 +90,29 @@ const TableTextInput: FC<Props> = ({
   useEffect(() => {
     onChange(value.toString().trim());
   }, [value]);
-
   return (
-    <Input
-      inputRef={inputRef}
-      sx={{ width: "100%", display: "flex", alignItems: "center" }}
-      classes={{ input: classes.input }}
-      id={id}
-      size="small"
-      value={val}
-      onChange={(e) => onChange(e.target.value)}
-      {...rest}
-      disableUnderline
-      readOnly={readOnlyInputs || readOnly}
-    />
+    <StyledTooltip
+      title="Missing required field"
+      arrow
+      disableHoverListener
+      disableFocusListener
+      disableTouchListener
+      open={showError}
+    >
+      <Input
+        inputRef={inputRef}
+        sx={{ width: "100%", display: "flex", alignItems: "center" }}
+        classes={{ input: classes.input }}
+        id={id}
+        size="small"
+        value={val}
+        onChange={(e) => onChange(e.target.value)}
+        {...rest}
+        disableUnderline
+        readOnly={readOnlyInputs || readOnly}
+      />
+    </StyledTooltip>
+
   );
 };
 

--- a/src/content/index.tsx
+++ b/src/content/index.tsx
@@ -96,6 +96,8 @@ const PageContentContainer = styled.div`
     text-align: center;
     margin-top: 30px;
     color: #86E2F6;
+    margin-left: 30px;
+    margin-right: 30px;
   }
   .loginPageLoginButton{
     display: flex;
@@ -174,12 +176,10 @@ const Home: FC = () => {
           : (
             <div className="loginPageTextContainer">
               <div className="loginPageTextTitle">
-                Login to CRDC Data Hub
+                Login to CRDC
               </div>
               <div className="loginPageText">
-                Welcome to the CRDC Data Hub.
-                <br />
-                Please login to access your data submissions.
+                Please login with a Login.gov account to make a data submission request or to upload data for approved submissions
               </div>
               <Link
                 id="loginPageLoginButton"

--- a/src/content/questionnaire/sections/D.tsx
+++ b/src/content/questionnaire/sections/D.tsx
@@ -477,6 +477,8 @@ const FormSectionD: FC<FormSectionProps> = ({ SectionOption, refs }: FormSection
                       pattern="^[1-9]\d*$"
                       filter={filterPositiveIntegerString}
                       patternValidityMessage="Please enter a whole number greater than 0"
+                      maxLength={10}
+                      required
                     />
                   </TableCell>
                   <TableCell className="bottomRowMiddle">


### PR DESCRIPTION
Implements ticket 401, changing the login page text.
On the login page:
Title text "Login to CRDC DataHub" should be changed to "Login to CRDC"
Explanation text should be changed to:  "Please login with a Login.gov account to make a data submission request or to upload data for approved submissions"

