### PR TITLE
Adding error msg on login fail

### DIFF
--- a/src/components/GenericAlert/index.tsx
+++ b/src/components/GenericAlert/index.tsx
@@ -1,7 +1,9 @@
-import React, { FC } from 'react';
-import { Alert, styled } from '@mui/material';
+import React, { FC, useEffect, useState } from 'react';
+import { Alert, AlertProps, styled } from '@mui/material';
 
-const StyledAlert = styled(Alert)((({ bgColor } : { bgColor?: string }) => ({
+const StyledAlert = styled(Alert, {
+  shouldForwardProp: (prop) => prop !== "bgColor"
+})((({ bgColor } : { bgColor?: string }) => ({
   color: '#ffffff',
   backgroundColor: bgColor || '#5D53F6',
   width: '535px',
@@ -20,14 +22,38 @@ const StyledAlert = styled(Alert)((({ bgColor } : { bgColor?: string }) => ({
 
 type Props = {
   open: boolean;
+  severity?: AlertProps["severity"],
   children: React.ReactNode;
 };
 
-const GenericAlert : FC<Props> = ({ open, children } : Props) => {
+const GenericAlert : FC<Props> = ({
+  open,
+  children,
+  severity = "success"
+} : Props) => {
+  const [bgColor, setBgColor] = useState<string>(null);
+
+  useEffect(() => {
+    let newBgColor;
+    switch (severity) {
+      case "success":
+        newBgColor = "#5D53F6";
+        break;
+      case "error":
+        newBgColor = "#E74040";
+        break;
+      default:
+        newBgColor = "#5D53F6";
+        break;
+    }
+
+    setBgColor(newBgColor);
+  }, [severity]);
+
   if (!open) return null;
 
   return (
-    <StyledAlert severity="success" icon={false}>
+    <StyledAlert severity={severity} bgColor={bgColor} icon={false}>
       {children}
     </StyledAlert>
   );

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,8 +1,10 @@
-import React from 'react';
+import { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import HeaderDesktop from './HeaderDesktop';
 import HeaderTabletAndMobile from './HeaderTabletAndMobile';
 import USABanner from './USABanner';
+import GenericAlert from '../GenericAlert';
+import { useAuthContext } from '../Contexts/AuthContext';
 
 const HeaderContainer = styled.div`
  @media (min-width: 1024px) {
@@ -25,16 +27,32 @@ const HeaderContainer = styled.div`
 
 `;
 
-const Header = () => (
-  <HeaderContainer>
-    <USABanner />
-    <div className="desktop">
-      <HeaderDesktop />
-    </div>
-    <div className="tabletAndMobile">
-      <HeaderTabletAndMobile />
-    </div>
-  </HeaderContainer>
-);
+const Header = () => {
+  const [showLoginError, setShowLoginError] = useState<boolean>(false);
+  const authContext = useAuthContext();
+  useEffect(() => {
+    if (authContext.error !== undefined) {
+      setShowLoginError(true);
+      setTimeout(() => setShowLoginError(false), 10000);
+    }
+  }, [authContext]);
+
+  return (
+    <>
+      <GenericAlert severity="error" open={showLoginError}>
+        {authContext.error}
+      </GenericAlert>
+      <HeaderContainer>
+        <USABanner />
+        <div className="desktop">
+          <HeaderDesktop />
+        </div>
+        <div className="tabletAndMobile">
+          <HeaderTabletAndMobile />
+        </div>
+      </HeaderContainer>
+    </>
+  );
+};
 
 export default Header;

--- a/src/components/InactivityDialog/InactivityDialog.tsx
+++ b/src/components/InactivityDialog/InactivityDialog.tsx
@@ -183,7 +183,6 @@ const InactivityDialog = () => {
     if (logoutStatus) {
       navigate("/");
       setWarning(false);
-      setTimeout(() => setShowLogoutAlert(false), 10000);
     }
   };
   const handleSignOut = async () => {


### PR DESCRIPTION
This implements ticket 433, which add a red banner error msg when the login fails.
This covers the inactive user case, but also covers every login fail.