### PR TITLE
CRDCDH-449 Allow additional saves when duplicate Study Abbrev error

### DIFF
--- a/src/components/Contexts/FormContext.tsx
+++ b/src/components/Contexts/FormContext.tsx
@@ -154,7 +154,6 @@ export const FormProvider: FC<ProviderProps> = ({ children, id } : ProviderProps
         questionnaireData: data
       }
     };
-    setState({ ...newState, status: Status.SAVING });
 
     try {
       const { data: d, errors } = await saveApp({
@@ -175,6 +174,8 @@ export const FormProvider: FC<ProviderProps> = ({ children, id } : ProviderProps
           errorMessage: "An unknown GraphQL Error occured"
         };
       }
+
+      setState({ ...newState, status: Status.SAVING });
 
       if (d?.saveApplication?.["_id"] && data?.["_id"] === "new") {
         newState.data = {
@@ -215,19 +216,19 @@ export const FormProvider: FC<ProviderProps> = ({ children, id } : ProviderProps
         errorMessage = String(error);
       }
 
-      let newErrorState = newState;
+      let newErrorState = state;
       // If duplicate study abbrev error, then prevent section from being completed
       if (errorMessage === ErrorCodes.DUPLICATE_STUDY_ABBREVIATION) {
-        const newSections = newState?.data?.questionnaireData?.sections?.map((section) => (section.name === sectionMetadata.B.id ? {
+        const newSections = state?.data?.questionnaireData?.sections?.map((section) => (section.name === sectionMetadata.B.id ? {
           ...section,
           status: "In Progress"
         } as Section : section));
         newErrorState = {
-          ...newState,
+          ...state,
           data: {
-            ...newState?.data,
+            ...state?.data,
             questionnaireData: {
-              ...newState?.data?.questionnaireData,
+              ...state?.data?.questionnaireData,
               sections: newSections
             }
           }

--- a/src/components/Contexts/FormContext.tsx
+++ b/src/components/Contexts/FormContext.tsx
@@ -155,6 +155,8 @@ export const FormProvider: FC<ProviderProps> = ({ children, id } : ProviderProps
       }
     };
 
+    setState((prevState) => ({ ...prevState, status: Status.SAVING }));
+
     try {
       const { data: d, errors } = await saveApp({
         variables: {
@@ -174,8 +176,6 @@ export const FormProvider: FC<ProviderProps> = ({ children, id } : ProviderProps
           errorMessage: "An unknown GraphQL Error occured"
         };
       }
-
-      setState({ ...newState, status: Status.SAVING });
 
       if (d?.saveApplication?.["_id"] && data?.["_id"] === "new") {
         newState.data = {

--- a/src/content/questionnaire/FormView.tsx
+++ b/src/content/questionnaire/FormView.tsx
@@ -128,7 +128,7 @@ const FormView: FC<Props> = ({ section, classes } : Props) => {
   useEffect(() => {
     const isComplete = isAllSectionsComplete();
     setAllSectionsComplete(isComplete);
-  }, [status]);
+  }, [status, data]);
 
   useEffect(() => {
     if (hasError && errorAlertRef?.current) {


### PR DESCRIPTION
**OVERVIEW**
This PR aims to allow for additional saves to be made even when no changes have been made and the duplicate Study Abbreviation error has occurred. 

- Displays alert banner when unable to save due to duplicate Study Abbreviation
- Prevent user from navigating to another section with Next/Back buttons as well as Progress bar buttons, when user has duplicate Study Abbreviation error 
- Fixed small bug where the "Next" button in section D wouldn't enable when all sections complete in a new submission

**TICKETS**
[CRDCDH-449](https://tracker.nci.nih.gov/browse/CRDCDH-449)