### PR TITLE
Remove `curatedOrganizations` from FE

### DIFF
--- a/src/graphql/getMyUser.ts
+++ b/src/graphql/getMyUser.ts
@@ -16,12 +16,6 @@ export const query = gql`
         createdAt
         updateAt
       }
-      curatedOrganizations {
-        orgID
-        orgName
-        createdAt
-        updateAt
-      }
       createdAt
       updateAt
     }

--- a/src/types/Auth.d.ts
+++ b/src/types/Auth.d.ts
@@ -16,7 +16,6 @@ type User = {
   IDP: "nih" | "login.gov";
   email: string;
   organization: OrgInfo | null;
-  curatedOrganizations: OrgInfo[];
   createdAt: string; // YYYY-MM-DDTHH:mm:ss.sssZ
   updateAt: string; // YYYY-MM-DDTHH:mm:ss.sssZ
 };

--- a/src/utils/formModeUtils.test.ts
+++ b/src/utils/formModeUtils.test.ts
@@ -17,7 +17,6 @@ describe('getFormMode tests based on provided requirements', () => {
       createdAt: '2023-05-01T09:23:30Z',
       updateAt: '2023-05-02T09:23:30Z'
     },
-    curatedOrganizations: []
   };
 
   // submission created by baseUser and part of the same org


### PR DESCRIPTION
### Overview

The BE removed `curatedOrganizations` from the schema. This PR reflects that change.