### PR TITLE
fix: Handle sorting for null attributes

### DIFF
--- a/src/content/organizations/ListView.tsx
+++ b/src/content/organizations/ListView.tsx
@@ -151,7 +151,7 @@ const columns: Column[] = [
   {
     label: "Primary Contact",
     value: (a) => a.conciergeName,
-    comparator: (a, b) => a?.conciergeName?.localeCompare(b?.conciergeName),
+    comparator: (a, b) => (a?.conciergeName || "").localeCompare(b?.conciergeName || ""),
   },
   {
     label: "Studies",
@@ -186,7 +186,7 @@ const columns: Column[] = [
   {
     label: "Status",
     value: (a) => a.status,
-    comparator: (a, b) => a.status.localeCompare(b.status),
+    comparator: (a, b) => (a?.status || "").localeCompare(b?.status || ""),
   },
   {
     label: "Action",


### PR DESCRIPTION
### Overview

Fixes issues identified by @Alejandro-Vega:

- In the case that the organization does not have a `status` (e.g. flawed data), we should not crash the app when sorting by that field

To resolve the above issue locally:

> use crdc-datahub
> db.organization.updateMany({}, { $set: { "status": "Active" }})

Other issues:

- Sorting by Primary Contact did not handle `null` values as expected (nulls sorted before values)

Did not address:

- The placeholder for the table view uses the term "users" instead of "organizations". This was updated in #156  