### PR TITLE
fix: Changing the name of an org breaks Org Dropdown

### DIFF
--- a/src/content/users/ListView.tsx
+++ b/src/content/users/ListView.tsx
@@ -252,7 +252,7 @@ const ListingView: FC = () => {
       return;
     }
 
-    const orgID = orgData?.find((org: Organization) => org.name === user.organization?.orgName)?._id;
+    const orgID = orgData?.find((org: Organization) => org._id === user.organization?.orgID)?._id;
     setValue("organization", orgID || "All");
   }, [user, orgData]);
 


### PR DESCRIPTION
### Overview

This resolves a bug that occurs when an organization name changes. The `orgName` was being used instead of `orgID` when determining if the org existed in the filter dropdown.

### Related Tickets

N/A