### PR TITLE
change concierge to conciergeName

### DIFF
--- a/src/components/DataSubmissions/DataSubmissionSummary.tsx
+++ b/src/components/DataSubmissions/DataSubmissionSummary.tsx
@@ -141,7 +141,7 @@ const DataSubmissionSummary: FC<Props> = ({ dataSubmission }) => {
 
     return color;
   };
-
+  console.log(dataSubmission);
   return (
     <StyledSummaryWrapper>
       <Stack
@@ -208,9 +208,9 @@ const DataSubmissionSummary: FC<Props> = ({ dataSubmission }) => {
             value={(
               <Stack direction="row" alignItems="center" spacing={1.375}>
                 <StyledSubmitterName>
-                  {dataSubmission?.concierge}
+                  {dataSubmission?.conciergeName}
                 </StyledSubmitterName>
-                {dataSubmission?.concierge && (
+                {dataSubmission?.conciergeName && (
                   <a
                     href={`mailto:${dataSubmission?.conciergeEmail}`}
                     aria-label="Email Primary Contact"

--- a/src/content/dataSubmissions/DataSubmissionsListView.tsx
+++ b/src/content/dataSubmissions/DataSubmissionsListView.tsx
@@ -146,8 +146,8 @@ const columns: Column[] = [
   },
   {
     label: "Primary Contact",
-    value: (a) => a.concierge,
-    field: "concierge",
+    value: (a) => a.conciergeName,
+    field: "conciergeName",
   },
   {
     label: "Created Date",

--- a/src/graphql/listSubmissions.ts
+++ b/src/graphql/listSubmissions.ts
@@ -16,7 +16,7 @@ export const query = gql`
         studyAbbreviation
         dbGaPID
         status
-        concierge
+        conciergeName
         createdAt
         updatedAt
       }

--- a/src/types/Submissions.d.ts
+++ b/src/types/Submissions.d.ts
@@ -12,7 +12,7 @@ type Submission = {
   rootPath: string; // # a submission folder will be created under this path, default is / or "" meaning root folder
   status: DataSubmissionStatus; // [New, In Progress, Submitted, Released, Canceled, Transferred, Completed, Archived]
   history: DataSubmissionHistoryEvent[]
-  concierge: string; // # Concierge name
+  conciergeName: string; // # Concierge name
   conciergeEmail: string; // # Concierge email (MIGHT CHANGE)
   createdAt: string; // # ISO 8601 date time format with UTC or offset e.g., 2023-05-01T09:23:30Z
   updatedAt: string; // # ISO 8601 date time format with UTC or offset e.g., 2023-05-01T09:23:30Z


### PR DESCRIPTION
This follows a backend PR to change concierge to conciergeName in the submissions type object since we need conciergeEmail in the type as well.
Merge after: https://github.com/CBIIT/crdc-datahub-backend/pull/124 