### PR TITLE
fix sorting and dgbap length

### DIFF
--- a/src/content/dataSubmissions/DataSubmissionsListView.tsx
+++ b/src/content/dataSubmissions/DataSubmissionsListView.tsx
@@ -102,6 +102,7 @@ const StyledTableCell = styled(TableCell)({
   color: "#083A50 !important",
   "&.MuiTableCell-root": {
     padding: "8px 8px",
+    overflowWrap: "anywhere",
   },
   "&:last-of-type": {
     paddingRight: "4px",
@@ -579,7 +580,7 @@ const ListingView: FC = () => {
             <TextInput
               value={dbgapid}
               parentStateSetter={(newVal) => setDbgapid(newVal)}
-              maxLength={25}
+              maxLength={50}
               required
               label="dbGaP ID"
               placeholder="Input dbGaP ID"

--- a/src/content/dataSubmissions/DataSubmissionsListView.tsx
+++ b/src/content/dataSubmissions/DataSubmissionsListView.tsx
@@ -137,7 +137,7 @@ const columns: Column[] = [
   {
     label: "dbGaP ID",
     value: (a) => a.dbGaPID,
-    field: "dbGapID",
+    field: "dbGaPID",
   },
   {
     label: "Status",
@@ -579,7 +579,7 @@ const ListingView: FC = () => {
             <TextInput
               value={dbgapid}
               parentStateSetter={(newVal) => setDbgapid(newVal)}
-              maxLength={50}
+              maxLength={25}
               required
               label="dbGaP ID"
               placeholder="Input dbGaP ID"

--- a/src/content/questionnaire/sections/B.tsx
+++ b/src/content/questionnaire/sections/B.tsx
@@ -456,8 +456,8 @@ const FormSectionB: FC<FormSectionProps> = ({ SectionOption, refs }: FormSection
           name="study[dbGaPPPHSNumber]"
           value={dbGaPPPHSNumber}
           onChange={(e) => setDbGaPPPHSNumber(e.target.value || "")}
-          maxLength={25}
-          placeholder="25 characters allowed"
+          maxLength={50}
+          placeholder="50 characters allowed"
           gridWidth={12}
           readOnly={readOnlyInputs || !isDbGapRegistered}
           required={isDbGapRegistered}

--- a/src/content/questionnaire/sections/B.tsx
+++ b/src/content/questionnaire/sections/B.tsx
@@ -456,8 +456,8 @@ const FormSectionB: FC<FormSectionProps> = ({ SectionOption, refs }: FormSection
           name="study[dbGaPPPHSNumber]"
           value={dbGaPPPHSNumber}
           onChange={(e) => setDbGaPPPHSNumber(e.target.value || "")}
-          maxLength={50}
-          placeholder="50 characters allowed"
+          maxLength={25}
+          placeholder="25 characters allowed"
           gridWidth={12}
           readOnly={readOnlyInputs || !isDbGapRegistered}
           required={isDbGapRegistered}


### PR DESCRIPTION
This fixes an ticket 533 with sorting by dbGaPID on data submissions. Also wraps the table cells in data submissions table list view to fit the 50 character dbgapID.