### PR TITLE
fixing router bug

### DIFF
--- a/src/router.tsx
+++ b/src/router.tsx
@@ -26,8 +26,10 @@ const RequireAuth: FC<RequireAuthProps> = ({ component, redirectPath, redirectNa
       navigate("/", { state: { path: redirectPath, name: redirectName } });
     }
   }, [authenticated]);
-
-  return component;
+  if (authenticated) {
+    return component;
+  }
+  return null;
 };
 
 // Pages


### PR DESCRIPTION
This pr addresses the bug outlined in 568.
The bug arose because the router was rendering the page regardless of authentication status (and then navigating to home), and the data-submissions page required information that authenticated users have.
This adds logic to make sure the page is only rendered if an authenticated user is clicking on the link.