### PR TITLE
CRDCDH-619 Fix OverlayWindow styling on DMN page

### DIFF
--- a/src/components/SystemUseWarningOverlay/OverlayWindow.tsx
+++ b/src/components/SystemUseWarningOverlay/OverlayWindow.tsx
@@ -50,7 +50,8 @@ const theme = createTheme({
                 root: {
                     color: '#000045',
                     '& p': {
-                    fontSize: '14px',
+                      fontSize: '14px',
+                      margin: '0px 0px 10px !important',
                     },
                     padding: '20px 0px 0px 0px !important',
                     '& ul': {
@@ -65,11 +66,12 @@ const theme = createTheme({
                 root: {
                     width: '133px',
                     height: '35px',
-                    backgroundColor: '#337ab7',
+                    backgroundColor: '#337ab7 !important',
                     color: '#fff',
-                    textTransform: 'none',
+                    textTransform: 'capitalize !important' as 'capitalize',
+                    boxShadow: 'none !important',
                     '&:hover': {
-                    backgroundColor: '#2e6da4',
+                      backgroundColor: '#2e6da4 !important',
                     },
                 },
             },
@@ -198,7 +200,7 @@ const OverlayWindow = () => {
         </DialogContent>
         <Divider />
         <DialogActions>
-          <Button onClick={handleClose}>
+          <Button onClick={handleClose} variant="contained">
             Continue
           </Button>
         </DialogActions>


### PR DESCRIPTION
### Overview

This PR fixes an issue where the Data Model Navigator is overriding our styling for the Government Warning Banner dialog.

To Replicate:

1. Open https://hub-dev2.datacommons.cancer.gov/model-navigator/ICDC

### Change Details (Specifics)

Before:

<img width="813" alt="Screenshot 2023-11-17 at 9 42 18 AM" src="https://github.com/CBIIT/crdc-datahub-ui/assets/38357871/ae4adfdb-cb34-4187-9b2d-0cfec8536d35">

After:

<img width="813" alt="Screenshot 2023-11-17 at 9 43 32 AM" src="https://github.com/CBIIT/crdc-datahub-ui/assets/38357871/07ffc8e4-51f3-46c5-a927-4f8000c1863d">

### Related Ticket(s)

https://tracker.nci.nih.gov/browse/CRDCDH-619