### PR TITLE
CRDCDH-618 Added missed call to open release dialog

### DIFF
--- a/src/content/dataSubmissions/DataSubmissionActions.tsx
+++ b/src/content/dataSubmissions/DataSubmissionActions.tsx
@@ -230,7 +230,7 @@ const DataSubmissionActions = ({ submission, onAction }: Props) => {
       {canShowAction("Release") ? (
         <StyledReleaseButton
           variant="contained"
-          onClick={() => handleOnAction("Release")}
+          onClick={() => onOpenDialog("Release")}
           loading={action === "Release"}
           disabled={action && action !== "Release"}
           disableElevation


### PR DESCRIPTION
### Overview

This PR aims to update the Submission Actions so that the release button opens a dialog. I had already created it, I simply forgot to call it.

### Change Details (Specifics)

- Instead of Releasing on button click, it will first open a dialog to confirm

### Related Ticket(s)

[CRDCDH-618](https://tracker.nci.nih.gov/browse/CRDCDH-618)