### PR TITLE
CRDCDH-619 Switch from Session Storage to Cookies

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -24,7 +24,7 @@ module.exports = {
     }
   },
   root: true,
-  ignorePatterns: ["injectEnv.js"],
+  ignorePatterns: ["public/injectEnv.js", "public/js/session.js"],
   rules: {
     // Note: you must disable the base rule as it can report incorrect errors
     "react/jsx-filename-extension": [1, { extensions: [".js", ".jsx", ".tsx", ".ts"] }],

--- a/public/index.html
+++ b/public/index.html
@@ -52,4 +52,5 @@
     -->
   </body>
   <script src="%PUBLIC_URL%/injectEnv.js"></script>
+  <script src="%PUBLIC_URL%/js/session.js"></script>
 </html>

--- a/public/injectEnv.js
+++ b/public/injectEnv.js
@@ -1,4 +1,3 @@
-/* eslint-disable */
 window.injectedEnv = {
   NIH_AUTHORIZE_URL: '',
   NIH_CLIENT_ID: '',

--- a/public/js/session.js
+++ b/public/js/session.js
@@ -1,0 +1,34 @@
+const sessionStorageTransfer = (event) => {
+  let $event = event;
+  if (!$event) {
+    $event = window.event;
+  } // ie suq
+  if (!$event.newValue) return; // do nothing if no value to work with
+  if ($event.key === 'getSessionStorage') {
+    // another tab asked for the sessionStorage -> send it
+    localStorage.setItem('sessionStorage', JSON.stringify(sessionStorage));
+    // the other tab should now have it, so we're done with it.
+    localStorage.removeItem('sessionStorage'); // <- could do short timeout as well.
+  } else if ($event.key === 'sessionStorage' && !sessionStorage.length) {
+    // another tab sent data <- get it
+    const data = JSON.parse($event.newValue);
+    Object.keys(data).forEach((key) => {
+      sessionStorage.setItem(key, data[key]);
+    });
+  } else if ($event.key === 'logout') {
+    sessionStorage.clear();
+  }
+};
+
+// listen for changes to localStorage
+if (window.addEventListener) {
+  window.addEventListener('storage', sessionStorageTransfer, false);
+} else {
+  window.addEventListener('onstorage', sessionStorageTransfer);
+}
+
+// Ask other tabs for session storage (this is ONLY to trigger 'storage' event)
+if (!sessionStorage.length) {
+  localStorage.setItem('getSessionStorage', 'true');
+  localStorage.removeItem('getSessionStorage');
+}

--- a/src/components/SystemUseWarningOverlay/OverlayWindow.tsx
+++ b/src/components/SystemUseWarningOverlay/OverlayWindow.tsx
@@ -149,23 +149,24 @@ const OverlayWindow = () => {
 
   const handleClose = () => {
     setOpen(false);
-    sessionStorage.setItem('overlayLoad', 'true');
+    document.cookie = 'overlayLoad=true; path=/';
   };
 
   useEffect(() => {
-    if (!sessionStorage.length) {
+    if (document.cookie.indexOf('overlayLoad') === -1) {
       setOpen(true);
     }
   }, [open]);
 
-    const content = text.content.map((item, index) => {
-        const textKey = `key_${index}`;
-        return (
-          <DialogContentText key={textKey} id="alert-dialog-description">
-            {item}
-          </DialogContentText>
-        );
-    });
+  const content = text.content.map((item, index) => {
+      const textKey = `key_${index}`;
+      return (
+        <DialogContentText key={textKey} id="alert-dialog-description">
+          {item}
+        </DialogContentText>
+      );
+  });
+
   const list = text.list.map((item, index) => {
     const listKey = `key_${index}`;
     return (
@@ -177,8 +178,8 @@ const OverlayWindow = () => {
           {item}
         </ListItemText>
       </ListItem>
-  );
-});
+    );
+  });
 
   return (
     <ThemeProvider theme={theme}>

--- a/src/components/SystemUseWarningOverlay/OverlayWindow.tsx
+++ b/src/components/SystemUseWarningOverlay/OverlayWindow.tsx
@@ -149,24 +149,23 @@ const OverlayWindow = () => {
 
   const handleClose = () => {
     setOpen(false);
-    document.cookie = 'overlayLoad=true; path=/';
+    sessionStorage.setItem('overlayLoad', 'true');
   };
 
   useEffect(() => {
-    if (document.cookie.indexOf('overlayLoad') === -1) {
+    if (!sessionStorage.length) {
       setOpen(true);
     }
   }, [open]);
 
-  const content = text.content.map((item, index) => {
-      const textKey = `key_${index}`;
-      return (
-        <DialogContentText key={textKey} id="alert-dialog-description">
-          {item}
-        </DialogContentText>
-      );
-  });
-
+    const content = text.content.map((item, index) => {
+        const textKey = `key_${index}`;
+        return (
+          <DialogContentText key={textKey} id="alert-dialog-description">
+            {item}
+          </DialogContentText>
+        );
+    });
   const list = text.list.map((item, index) => {
     const listKey = `key_${index}`;
     return (
@@ -178,8 +177,8 @@ const OverlayWindow = () => {
           {item}
         </ListItemText>
       </ListItem>
-    );
-  });
+  );
+});
 
   return (
     <ThemeProvider theme={theme}>


### PR DESCRIPTION
### Overview

This PR adds the missing sessionStorage data sync functionality that Bento apps have implemented. The mission functionality causes the Government Warning Banner to appear on every new tab you open, instead of just the first one opened.

### Change Details (Specifics)

- Sync session storage data between open tabs using window storage event listener
- Copied approach from Bento [public/js/session.js](https://github.com/CBIIT/bento-frontend/blob/ce808c12a22a1f111fe94be7112154ccb624cc50/packages/bento-frontend/public/js/session.js#L1-L2)

### Related Ticket(s)

https://tracker.nci.nih.gov/browse/CRDCDH-619
https://tracker.nci.nih.gov/browse/CRDCDH-144