### PR TITLE
CRDCDH-623 Upload Type for file Batch Type

### DIFF
--- a/src/content/dataSubmissions/DataSubmission.tsx
+++ b/src/content/dataSubmissions/DataSubmission.tsx
@@ -200,7 +200,7 @@ const StyledCopyIDButton = styled(IconButton)(() => ({
 const columns: Column<Batch>[] = [
   {
     label: "Upload Type",
-    value: (data) => data?.metadataIntention,
+    value: (data) => (data?.type === "file" ? "-" : data?.metadataIntention),
     field: "metadataIntention",
   },
   {


### PR DESCRIPTION
### Overview

This PR aims to display a "-" for the Upload Type column in the batch table when the Batch Type is "file". Currently, you can only upload a "file" Batch Type by using CLI.

### Change Details (Specifics)

N/A

### Related Ticket(s)

[CRDCDH-623](https://tracker.nci.nih.gov/browse/CRDCDH-623)