### PR TITLE
CRDCDH-667 Clear history when populating model

### DIFF
--- a/src/content/modelNavigator/hooks/useBuildReduxStore.ts
+++ b/src/content/modelNavigator/hooks/useBuildReduxStore.ts
@@ -101,6 +101,11 @@ const useBuildReduxStore = (): [{ status: Status, store: Store }, () => void, (a
       },
     });
 
+    // MVP-2 M2 NOTE: This resets the search history to prevent the data models
+    // from overlapping on searches. A future improvement would be to isolate
+    // the localStorage history key to the data model based on a config option.
+    store.dispatch({ type: 'SEARCH_CLEAR_HISTORY' });
+
     setStatus("success");
   };
 


### PR DESCRIPTION
### Overview

This PR resets the Model Navigator search history any time the redux store is repopulated. A future solution would be to isolate the model's search history and not clear it automatically, but that will require DMN core updates.

### Change Details (Specifics)

- Dispatch the redux event `SEARCH_CLEAR_HISTORY` when populating the model redux store

### Related Ticket(s)

CRDCDH-667