### PR TITLE
CRDCDH-659 Poll for file validation status

### DIFF
--- a/src/components/GenericAlert/index.tsx
+++ b/src/components/GenericAlert/index.tsx
@@ -12,7 +12,7 @@ const StyledAlert = styled(Alert, {
   borderColor: bgColor || 'none',
   boxShadow: '-4px 8px 27px 4px rgba(27,28,28,0.09)',
   justifyContent: 'center',
-  zIndex: '1100',
+  zIndex: '1200',
   position: 'fixed',
   top: '20px',
   left: '50%',

--- a/src/content/dataSubmissions/DataSubmission.tsx
+++ b/src/content/dataSubmissions/DataSubmission.tsx
@@ -258,7 +258,7 @@ const columns: Column<Batch>[] = [
     renderValue: (data) => (
       <BatchTableContext.Consumer>
         {({ handleOpenErrorDialog }) => {
-          if (data?.errors?.length === 0) {
+          if (!data?.errors?.length) {
             return null;
           }
 

--- a/src/content/dataSubmissions/DataSubmission.tsx
+++ b/src/content/dataSubmissions/DataSubmission.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useParams } from "react-router-dom";
-import { useLazyQuery, useMutation } from "@apollo/client";
+import { useLazyQuery, useMutation, useQuery } from "@apollo/client";
 import {
   Alert,
   AlertColor,
@@ -301,7 +301,10 @@ const DataSubmission = () => {
   const [openErrorDialog, setOpenErrorDialog] = useState<boolean>(false);
   const [selectedRow, setSelectedRow] = useState<Batch | null>(null);
 
-  const [getSubmission, { data, startPolling, stopPolling }] = useLazyQuery<GetSubmissionResp>(GET_SUBMISSION, {
+  const {
+    data, error: submissionError,
+    startPolling, stopPolling, refetch: getSubmission,
+  } = useQuery<GetSubmissionResp>(GET_SUBMISSION, {
     variables: { id: submissionId },
     context: { clientName: 'backend' },
     fetchPolicy: 'no-cache',
@@ -427,16 +430,10 @@ const DataSubmission = () => {
   useEffect(() => {
     if (!submissionId) {
       setError("Invalid submission ID provided.");
-      return;
+    } else if (submissionError) {
+      setError("Unable to retrieve submission data.");
     }
-
-    (async () => {
-      const { data: d, error } = await getSubmission();
-      if (error || !d?.getSubmission?._id) {
-        setError("Unable to retrieve submission data.");
-      }
-    })();
-  }, [submissionId]);
+  }, [submissionError]);
 
   useEffect(() => {
     if (data?.getSubmission?.fileValidationStatus !== "Validating" && data?.getSubmission?.metadataValidationStatus !== "Validating") {

--- a/src/graphql/getSubmission.ts
+++ b/src/graphql/getSubmission.ts
@@ -18,6 +18,8 @@ export const query = gql`
       bucketName
       rootPath
       status
+      metadataValidationStatus
+      fileValidationStatus
       history {
           status
           reviewComment

--- a/src/types/Submissions.d.ts
+++ b/src/types/Submissions.d.ts
@@ -11,12 +11,16 @@ type Submission = {
   bucketName: string; // # populated from organization
   rootPath: string; // # a submission folder will be created under this path, default is / or "" meaning root folder
   status: SubmissionStatus; // [New, In Progress, Submitted, Released, Canceled, Transferred, Completed, Archived]
+  metadataValidationStatus: ValidationStatus; // [New, Validating, Passed, Error, Warning]
+  fileValidationStatus: ValidationStatus; // [New, Validating, Passed, Error, Warning]
   history: SubmissionHistoryEvent[];
   conciergeName: string; // Concierge name
   conciergeEmail: string; // Concierge email
   createdAt: string; // ISO 8601 date time format with UTC or offset e.g., 2023-05-01T09:23:30Z
   updatedAt: string; // ISO 8601 date time format with UTC or offset e.g., 2023-05-01T09:23:30Z
 };
+
+type ValidationStatus = "New" | "Validating" | "Passed" | "Error" | "Warning";
 
 type SubmissionStatus =
   | "New"


### PR DESCRIPTION
### Overview

This PR introduces data submission polling to track the file validation status. 

> [!TIP]
> The validation API works, but no validation happens yet; thus you will need to manually update the data submission object to change `metadataValidationStatus` (sp.) or `fileValidationStatus` (sp) from "Validating" to another state in order to see the button re-enable.

### Change Details (Specifics)

- Removed the usage of states for the Data Submission and Stats so that we can use native Apollo polling directly
- Migrated from `useLazyQuery` to `useQuery` for `GET_SUBMISSION` query
  - This will auto fetch the submission on component mount so that we don't need to manually initiate it
- Fixed a 508 issue with an empty button when there are no batch errors
- Fixed GenericAlert hiding under the Navbar Dropdown container (had equal z-index)

<img width="567" alt="Screenshot 2023-12-22 at 9 35 43 AM" src="https://github.com/CBIIT/crdc-datahub-ui/assets/38357871/70f0ff25-a099-482e-8ebd-26cdca01cae4">
 
### Related Ticket(s)

CRDCDH-659

> [!IMPORTANT]  
> This ticket can be merged, but needs to go back to On Hold while we wait for the validation service.