### PR TITLE
CRDCDH-660 Shorter Batch IDs

### DIFF
--- a/src/content/dataSubmissions/DataSubmission.tsx
+++ b/src/content/dataSubmissions/DataSubmission.tsx
@@ -225,6 +225,11 @@ const StyledErrorDetailsButton = styled(Button)(() => ({
 
 const columns: Column<Batch>[] = [
   {
+    label: "Batch ID",
+    renderValue: (data) => data.displayID,
+    field: "displayID",
+  },
+  {
     label: "Upload Type",
     renderValue: (data) => (data?.type === "file" ? "-" : data?.metadataIntention),
     field: "metadataIntention",

--- a/src/content/dataSubmissions/QualityControl.tsx
+++ b/src/content/dataSubmissions/QualityControl.tsx
@@ -46,8 +46,8 @@ const columns: Column<QCResult>[] = [
   },
   {
     label: "Batch ID",
-    renderValue: (data) => data?.batchID,
-    field: "batchID",
+    renderValue: (data) => data?.displayID,
+    field: "displayID",
   },
   {
     label: "Node ID",

--- a/src/graphql/listBatches.ts
+++ b/src/graphql/listBatches.ts
@@ -18,6 +18,7 @@ export const query = gql`
       total
       batches {
         _id
+        displayID
         submissionID
         type
         metadataIntention

--- a/src/graphql/submissionQCResults.ts
+++ b/src/graphql/submissionQCResults.ts
@@ -20,6 +20,7 @@ export const query = gql`
         submissionID
         nodeType
         batchID
+        displayID
         nodeID
         CRDC_ID
         severity

--- a/src/types/Submissions.d.ts
+++ b/src/types/Submissions.d.ts
@@ -87,6 +87,7 @@ type UploadType = "metadata" | "file";
 
 type Batch = {
   _id: string;
+  displayID: string;
   submissionID: string; // parent
   type: UploadType; // [metadata, file]
   metadataIntention: MetadataIntention; // [New, Update, Delete], Update is meant for "Update or insert", metadata only! file batches are always treated as Update
@@ -163,6 +164,7 @@ type QCResult = {
   submissionID: string;
   nodeType: string;
   batchID: string;
+  displayID: string;
   nodeID: string;
   CRDC_ID: string;
   severity: "Error" | "Warning"; // [Error, Warning]


### PR DESCRIPTION
### Overview

This PR aims to use the shorter Batch ID from both the listBatches API and submissionQCResults API for the tables.

### Change Details (Specifics)

- Added displayID to listBatches API
- Added displayID to submissionQCResults API
- Used displayID for columns in Batch and QC tables
NOTE: Awaiting BE Implementation

### Related Ticket(s)

[CRDCDH-660](https://tracker.nci.nih.gov/browse/CRDCDH-660)