### PR TITLE
CRDCDH-652 Data Submission Delete Upload Type

### DIFF
--- a/src/components/DataSubmissions/DataSubmissionUpload.tsx
+++ b/src/components/DataSubmissions/DataSubmissionUpload.tsx
@@ -361,7 +361,7 @@ const DataSubmissionUpload = ({ submitterID, readOnly, onUpload }: Props) => {
       </StyledUploadActionWrapper>
       <StyledUploadFilesButton
         variant="contained"
-        onClick={handleUploadFiles}
+        onClick={() => (metadataIntention === "Delete" ? setOpenDeleteDialog(true) : handleUploadFiles())}
         disabled={readOnly || !selectedFiles?.length || !canUpload || isUploading}
         disableElevation
         disableRipple

--- a/src/components/DataSubmissions/DataSubmissionUpload.tsx
+++ b/src/components/DataSubmissions/DataSubmissionUpload.tsx
@@ -238,11 +238,6 @@ const DataSubmissionUpload = ({ submitterID, readOnly, onUpload }: Props) => {
       return;
     }
 
-    if (metadataIntention === "Delete") {
-      setOpenDeleteDialog(true);
-      return;
-    }
-
     setIsUploading(true);
     const newBatch: NewBatch = await createNewBatch();
     if (!newBatch) {
@@ -299,7 +294,7 @@ const DataSubmissionUpload = ({ submitterID, readOnly, onUpload }: Props) => {
         return;
       }
       // Batch upload completed successfully
-      onUpload(`${selectedFiles.length} ${selectedFiles.length > 1 ? "Files" : "File"} successfully uploaded`, "success");
+      onUpload(`${selectedFiles.length} ${selectedFiles.length > 1 ? "Files" : "File"} successfully ${metadataIntention === "Delete" ? "deleted" : "uploaded"}`, "success");
       setIsUploading(false);
       setSelectedFiles(null);
       if (uploadMetatadataInputRef.current) {
@@ -312,7 +307,7 @@ const DataSubmissionUpload = ({ submitterID, readOnly, onUpload }: Props) => {
   };
 
   const onUploadFail = (fileCount = 0) => {
-    onUpload(`${fileCount} ${fileCount > 1 ? "Files" : "File"} failed to upload`, "error");
+    onUpload(`${fileCount} ${fileCount > 1 ? "Files" : "File"} failed to ${metadataIntention === "Delete" ? "delete" : "upload"}`, "error");
     setSelectedFiles(null);
     setIsUploading(false);
     if (uploadMetatadataInputRef.current) {
@@ -326,6 +321,7 @@ const DataSubmissionUpload = ({ submitterID, readOnly, onUpload }: Props) => {
 
   const onDeleteUpload = () => {
     setOpenDeleteDialog(false);
+    handleUploadFiles();
   };
 
   return (
@@ -377,7 +373,7 @@ const DataSubmissionUpload = ({ submitterID, readOnly, onUpload }: Props) => {
       <StyledDialog
         open={openDeleteDialog}
         onClose={onCloseDeleteDialog}
-        title="Delete Metadata or Files"
+        title="Delete Data"
         actions={(
           <>
             <Button onClick={onCloseDeleteDialog} disabled={false}>Cancel</Button>

--- a/src/content/dataSubmissions/DataSubmission.tsx
+++ b/src/content/dataSubmissions/DataSubmission.tsx
@@ -241,7 +241,7 @@ const columns: Column<Batch>[] = [
   },
   {
     label: "Status",
-    renderValue: (data) => (data.status === "Rejected" ? <StyledRejectedStatus>{data.status}</StyledRejectedStatus> : data.status),
+    renderValue: (data) => <Box textTransform="capitalize">{data.status === "Rejected" ? <StyledRejectedStatus>{data.status}</StyledRejectedStatus> : data.status}</Box>,
     field: "status",
   },
   {


### PR DESCRIPTION
### Overview

This PR aims to add the "Delete" upload type option to be able to delete previously submitted data.

### Change Details (Specifics)

- Upload process is the same, except with delete as metadataIntention
- Open dialog when trying to upload
- Show banner message that successfully deleted or failed
- Add record to listBatches table (error is async and might require some refreshes)

### Related Ticket(s)

[CRDCDH-652](https://tracker.nci.nih.gov/browse/CRDCDH-652)