### PR TITLE
CRDCDH-689 Warn on removal of study with active data submission

### DIFF
--- a/src/components/Organizations/ConfirmDialog.tsx
+++ b/src/components/Organizations/ConfirmDialog.tsx
@@ -1,0 +1,122 @@
+import { FC } from "react";
+import {
+  Button, Dialog, DialogActions, DialogContent, DialogProps,
+  IconButton, Typography, styled,
+} from "@mui/material";
+import { ReactComponent as CloseIconSvg } from "../../assets/icons/close_icon.svg";
+
+const StyledDialog = styled(Dialog)({
+  "& .MuiDialog-paper": {
+    maxWidth: "none",
+    borderRadius: "8px",
+    width: "755px !important",
+    padding: "47px 59px 71px 54px",
+    border: "2px solid #0B7F99",
+    background: "linear-gradient(0deg, #F2F6FA 0%, #F2F6FA 100%), #2E4D7B",
+    boxShadow: "0px 4px 45px 0px rgba(0, 0, 0, 0.40)",
+  },
+});
+
+const StyledDialogContent = styled(DialogContent)({
+  padding: 0,
+});
+
+const StyledBodyText = styled(Typography)({
+  fontFamily: "'Nunito', 'Rubik', sans-serif !important",
+  fontSize: "16px !important",
+  fontStyle: "normal",
+  fontWeight: "400 !important",
+  lineHeight: "19.6px !important",
+  marginBottom: "28px !important",
+  letterSpacing: "unset !important",
+});
+
+const StyledDialogActions = styled(DialogActions)({
+  padding: "0 !important",
+  justifyContent: "center",
+});
+
+const StyledCloseDialogButton = styled(IconButton)(() => ({
+  position: 'absolute !important' as 'absolute',
+  right: "21px",
+  top: "11px",
+  padding: "10px",
+  "& svg": {
+    color: "#44627C"
+  }
+}));
+
+const StyledActionButton = styled(Button)({
+  minWidth: "128px",
+  height: "42px",
+  padding: "12px !important",
+  borderRadius: "8px !important",
+  border: "1px solid #000 !important",
+  color: "#000 !important",
+  textAlign: "center",
+  fontFamily: "'Nunito', 'Rubik', sans-serif !important",
+  fontSize: "16px !important",
+  fontStyle: "normal",
+  fontWeight: "700 !important",
+  lineHeight: "24px !important",
+  letterSpacing: "0.32px",
+  textTransform: "none !important" as 'none',
+  alignSelf: "center",
+  margin: "0 15px !important",
+  marginTop: "45px !important",
+  "&:hover": {
+    background: "transparent !important",
+  }
+});
+
+type Props = {
+  onClose?: () => void;
+  onSubmit?: () => void;
+} & Omit<DialogProps, "onClose">;
+
+const ConfirmDialog: FC<Props> = ({
+  title,
+  onClose,
+  onSubmit,
+  open,
+  ...rest
+}) => (
+  <StyledDialog
+    open={open}
+    onClose={() => onClose?.()}
+    {...rest}
+  >
+    <StyledCloseDialogButton
+      aria-label="close"
+      onClick={() => onClose?.()}
+    >
+      <CloseIconSvg />
+    </StyledCloseDialogButton>
+    <StyledDialogContent>
+      <StyledBodyText id="confirm-dialog-body" variant="h6">
+        Currently, there are active data submissions for this study within this organization.
+        {" "}
+        Are you sure you want to remove this study from the organization?
+      </StyledBodyText>
+    </StyledDialogContent>
+    <StyledDialogActions>
+      <StyledActionButton
+        id="uploader-cli-submit-button"
+        variant="outlined"
+        sx={{ width: "186px" }}
+        onClick={onSubmit}
+      >
+        Confirm to Remove
+      </StyledActionButton>
+      <StyledActionButton
+        id="uploader-cli-cancel-button"
+        variant="outlined"
+        onClick={onClose}
+      >
+        Cancel
+      </StyledActionButton>
+    </StyledDialogActions>
+  </StyledDialog>
+);
+
+export default ConfirmDialog;

--- a/src/content/organizations/OrganizationView.tsx
+++ b/src/content/organizations/OrganizationView.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, useState } from 'react';
+import { FC, useEffect, useMemo, useState } from 'react';
 import { useLazyQuery, useMutation, useQuery } from '@apollo/client';
 import { LoadingButton } from '@mui/lab';
 import {
@@ -18,8 +18,9 @@ import {
   EDIT_ORG, EditOrgResp,
   GET_ORG, GetOrgResp,
   LIST_APPROVED_STUDIES, ListApprovedStudiesResp,
-  LIST_CURATORS, ListCuratorsResp
+  LIST_CURATORS, ListCuratorsResp,
 } from '../../graphql';
+import ConfirmDialog from '../../components/Organizations/ConfirmDialog';
 
 type Props = {
   _id: Organization["_id"] | "new";
@@ -143,6 +144,11 @@ const StyledTitleBox = styled(Box)({
 });
 
 /**
+ * Data Submission statuses that reflect an inactive submission
+ */
+const inactiveSubmissionStatus: SubmissionStatus[] = ["Completed", "Archived"];
+
+/**
  * Edit/Create Organization View Component
  *
  * @param {Props} props
@@ -152,9 +158,24 @@ const OrganizationView: FC<Props> = ({ _id }: Props) => {
   const navigate = useNavigate();
 
   const [organization, setOrganization] = useState<Organization | null>(null);
+  const [dataSubmissions, setDataSubmissions] = useState<Partial<Submission>[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState<boolean>(false);
+  const [confirmOpen, setConfirmOpen] = useState<boolean>(false);
   const [changesAlert, setChangesAlert] = useState<string>("");
+
+  const assignedStudies: string[] = useMemo(() => {
+    const activeStudies = {};
+    const activeSubs = dataSubmissions?.filter((ds) => !inactiveSubmissionStatus.includes(ds?.status));
+
+    organization?.studies?.forEach((s) => {
+      if (activeSubs?.some((ds) => ds?.studyAbbreviation === s?.studyAbbreviation)) {
+        activeStudies[s?.studyAbbreviation] = true;
+      }
+    });
+
+    return Object.keys(activeStudies) || [];
+  }, [organization, dataSubmissions]);
 
   const { handleSubmit, register, reset, control } = useForm<FormInput>();
   const editableFields: (keyof FormInput)[] = [
@@ -166,12 +187,12 @@ const OrganizationView: FC<Props> = ({ _id }: Props) => {
 
   const { data: activeCurators } = useQuery<ListCuratorsResp>(LIST_CURATORS, {
     context: { clientName: 'backend' },
-    fetchPolicy: "no-cache",
+    fetchPolicy: "cache-and-network",
   });
 
   const { data: approvedStudies } = useQuery<ListApprovedStudiesResp>(LIST_APPROVED_STUDIES, {
     context: { clientName: 'backend' },
-    fetchPolicy: "no-cache",
+    fetchPolicy: "cache-and-network",
   });
 
   const [getOrganization] = useLazyQuery<GetOrgResp>(GET_ORG, {
@@ -188,6 +209,29 @@ const OrganizationView: FC<Props> = ({ _id }: Props) => {
     context: { clientName: 'backend' },
     fetchPolicy: 'no-cache'
   });
+
+  const handleBypassWarning = () => {
+    setConfirmOpen(false);
+    handleSubmit(onSubmit)();
+  };
+
+  const handlePreSubmit = (data: FormInput) => {
+    if (_id !== "new") {
+      const previousStudies = organization?.studies?.map((s) => s?.studyAbbreviation) || [];
+      const removedActiveStudies = previousStudies
+        .filter((s) => !data.studies?.includes(s))
+        .filter((s) => assignedStudies.includes(s))
+        .length;
+
+      // If there are active submissions for a study being removed, show a warning
+      if (removedActiveStudies) {
+        setConfirmOpen(true);
+        return;
+      }
+    }
+
+    onSubmit(data);
+  };
 
   const onSubmit = async (data: FormInput) => {
     setSaving(true);
@@ -213,6 +257,7 @@ const OrganizationView: FC<Props> = ({ _id }: Props) => {
       }
 
       setOrganization(null);
+      setDataSubmissions(null);
       setChangesAlert("This organization has been successfully added.");
       reset();
     } else {
@@ -253,6 +298,7 @@ const OrganizationView: FC<Props> = ({ _id }: Props) => {
 
     if (_id === "new") {
       setOrganization(null);
+      setDataSubmissions(null);
       setFormValues({
         name: "",
         conciergeID: "",
@@ -263,7 +309,7 @@ const OrganizationView: FC<Props> = ({ _id }: Props) => {
     }
 
     (async () => {
-      const { data, error } = await getOrganization({ variables: { orgID: _id } });
+      const { data, error } = await getOrganization({ variables: { orgID: _id, organization: _id } });
 
       if (error || !data?.getOrganization) {
         navigate("/organizations", { state: { error: "Unable to fetch organization" } });
@@ -271,6 +317,7 @@ const OrganizationView: FC<Props> = ({ _id }: Props) => {
       }
 
       setOrganization(data?.getOrganization);
+      setDataSubmissions(data?.listSubmissions?.submissions);
       setFormValues({
         ...data?.getOrganization,
         studies: data?.getOrganization?.studies?.filter((s) => !!s?.studyName && !!s?.studyAbbreviation).map(({ studyAbbreviation }) => studyAbbreviation) || [],
@@ -315,7 +362,7 @@ const OrganizationView: FC<Props> = ({ _id }: Props) => {
               </StyledPageTitle>
             </StyledTitleBox>
 
-            <form onSubmit={handleSubmit(onSubmit)}>
+            <form onSubmit={handleSubmit(handlePreSubmit)}>
               {error && (
                 <Alert sx={{ mb: 2, p: 2, width: "100%" }} severity="error">
                   {error || "An unknown API error occurred."}
@@ -414,6 +461,11 @@ const OrganizationView: FC<Props> = ({ _id }: Props) => {
           </StyledContentStack>
         </Stack>
       </StyledContainer>
+      <ConfirmDialog
+        open={confirmOpen}
+        onSubmit={handleBypassWarning}
+        onClose={() => setConfirmOpen(false)}
+      />
     </>
   );
 };

--- a/src/graphql/getOrganization.ts
+++ b/src/graphql/getOrganization.ts
@@ -1,7 +1,7 @@
 import gql from 'graphql-tag';
 
 export const query = gql`
-  query getOrganization($orgID: ID!) {
+  query getOrganizationData($orgID: ID!, $organization: String) {
     getOrganization(orgID: $orgID) {
       _id
       name
@@ -13,9 +13,25 @@ export const query = gql`
         studyAbbreviation
       }
     }
+    listSubmissions(first: -1, offset: 0, orderBy: "updatedAt", sortDirection: "ASC", organization: $organization, status: "All") {
+      submissions {
+        _id
+        studyAbbreviation
+        status
+      }
+    }
   }
 `;
 
 export type Response = {
+  /**
+   * The organization that was requested
+   */
   getOrganization: Organization;
+  /**
+   * Data Submissions for the organization
+   */
+  listSubmissions: {
+    submissions: Pick<Submission, "_id" | "status" | "studyAbbreviation">[];
+  };
 };


### PR DESCRIPTION
### Overview

This PR adds a confirmation dialog when an Admin attempts to remove a study currently tied to an active data submission.

### Change Details (Specifics)

- Implement confirmation dialog based on API Token / Uploader CLI dialog (per K.C. request)
- Modify getOrganization query to also fetch current data submissions tied to an org
  - NOTE: `getOrganization` is only used by this page. If we ever use it elsewhere, we will need to refactor it to not ALWAYS include the data submissions

### Related Ticket(s)

CRDCDH-689