### PR TITLE
CRDCDH-668 Batch File List "No Content" message update

### DIFF
--- a/src/components/DataSubmissions/GenericTable.tsx
+++ b/src/components/DataSubmissions/GenericTable.tsx
@@ -155,6 +155,7 @@ type Props<T> = {
   defaultRowsPerPage?: number;
   paginationPlacement?: CSSProperties["justifyContent"];
   containerProps?: TableContainerProps;
+  numRowsNoContent?: number;
   setItemKey?: (item: T, index: number) => string;
   onFetchData?: (params: FetchListing<T>, force: boolean) => void;
   onOrderChange?: (order: Order) => void;
@@ -172,6 +173,7 @@ const GenericTable = <T,>({
   defaultRowsPerPage = 10,
   paginationPlacement,
   containerProps,
+  numRowsNoContent = 10,
   setItemKey,
   onFetchData,
   onOrderChange,
@@ -185,7 +187,6 @@ const GenericTable = <T,>({
   );
   const [page, setPage] = useState<number>(0);
   const [perPage, setPerPage] = useState<number>(defaultRowsPerPage);
-  const numRowsNoContent = 10;
 
   useEffect(() => {
     fetchData();

--- a/src/content/dataSubmissions/FileListDialog.tsx
+++ b/src/content/dataSubmissions/FileListDialog.tsx
@@ -122,16 +122,6 @@ const StyledFileName = styled(Typography)({
   wordBreak: "break-all"
 });
 
-const StyledNoFiles = styled(Typography)({
-  color: "#595959",
-  fontFamily: "'Nunito Sans', 'Rubik', sans-serif",
-  fontSize: "16px",
-  fontStyle: "normal",
-  fontWeight: "400",
-  marginTop: "8px",
-  marginBottom: "40px"
-});
-
 const tableContainerSx: TableContainerProps["sx"] = {
   "& .MuiTableHead-root .MuiTableCell-root:first-of-type": {
     paddingLeft: "26px",
@@ -237,22 +227,20 @@ const FileListDialog = ({
         {`${batch?.fileCount || 0} FILES`}
       </StyledNumberOfFiles>
 
-      {batch?.fileCount === 0 ? (
-        <StyledNoFiles variant="body1">No files were uploaded.</StyledNoFiles>
-      ) : (
-        <GenericTable
-          columns={columns}
-          data={batchFiles}
-          total={batch?.fileCount || 0}
-          loading={loading}
-          defaultOrder="asc"
-          defaultRowsPerPage={20}
-          paginationPlacement="center"
-          onFetchData={handleFetchBatchFiles}
-          setItemKey={(item, idx) => `${idx}_${item.fileName}_${item.createdAt}`}
-          containerProps={{ sx: tableContainerSx }}
-        />
-      )}
+      <GenericTable
+        columns={columns}
+        data={batchFiles}
+        total={batch?.fileCount || 0}
+        loading={loading}
+        defaultOrder="asc"
+        defaultRowsPerPage={20}
+        paginationPlacement="center"
+        noContentText="No files were uploaded."
+        numRowsNoContent={5}
+        onFetchData={handleFetchBatchFiles}
+        setItemKey={(item, idx) => `${idx}_${item.fileName}_${item.createdAt}`}
+        containerProps={{ sx: tableContainerSx }}
+      />
 
       <StyledCloseButton
         id="file-list-dialog-close-button"

--- a/src/content/dataSubmissions/FileListDialog.tsx
+++ b/src/content/dataSubmissions/FileListDialog.tsx
@@ -122,6 +122,16 @@ const StyledFileName = styled(Typography)({
   wordBreak: "break-all"
 });
 
+const StyledNoFiles = styled(Typography)({
+  color: "#595959",
+  fontFamily: "'Nunito Sans', 'Rubik', sans-serif",
+  fontSize: "16px",
+  fontStyle: "normal",
+  fontWeight: "400",
+  marginTop: "8px",
+  marginBottom: "40px"
+});
+
 const tableContainerSx: TableContainerProps["sx"] = {
   "& .MuiTableHead-root .MuiTableCell-root:first-of-type": {
     paddingLeft: "26px",
@@ -227,18 +237,22 @@ const FileListDialog = ({
         {`${batch?.fileCount || 0} FILES`}
       </StyledNumberOfFiles>
 
-      <GenericTable
-        columns={columns}
-        data={batchFiles}
-        total={batch?.fileCount || 0}
-        loading={loading}
-        defaultOrder="asc"
-        defaultRowsPerPage={20}
-        paginationPlacement="center"
-        onFetchData={handleFetchBatchFiles}
-        setItemKey={(item, idx) => `${idx}_${item.fileName}_${item.createdAt}`}
-        containerProps={{ sx: tableContainerSx }}
-      />
+      {batch?.fileCount === 0 ? (
+        <StyledNoFiles variant="body1">No files were uploaded.</StyledNoFiles>
+      ) : (
+        <GenericTable
+          columns={columns}
+          data={batchFiles}
+          total={batch?.fileCount || 0}
+          loading={loading}
+          defaultOrder="asc"
+          defaultRowsPerPage={20}
+          paginationPlacement="center"
+          onFetchData={handleFetchBatchFiles}
+          setItemKey={(item, idx) => `${idx}_${item.fileName}_${item.createdAt}`}
+          containerProps={{ sx: tableContainerSx }}
+        />
+      )}
 
       <StyledCloseButton
         id="file-list-dialog-close-button"

--- a/src/types/Submissions.d.ts
+++ b/src/types/Submissions.d.ts
@@ -73,6 +73,11 @@ type UploadResult = {
   fileName: string;
   succeeded: boolean;
   errors: string[];
+  /**
+   * Applies to Data File uploads only. Indicates whether the file was skipped
+   * intentionally during the upload process.
+   */
+  skipped?: boolean;
 };
 
 type BatchFileInfo = {


### PR DESCRIPTION
### Overview

This PR slightly modifies the FE implementation of the Batch File List by changing the table's no-content message to conform to the user story. 

> [!NOTE]
> To test this, use the uploader CLI and upload a set of files twice with the config option `overwrite` set to false. 
> Or you can use the DEV submission `3e568f16-f135-47e2-ba69-87d0f707bc01`

### Change Details (Specifics)

- Update the `UploadResult` type definition to include the `skipped` property
- Add a `numRowsNoContent` prop to the generic table
- Replace the default no-content message with the one from the user story

### Related Ticket(s)

CRDCDH-668