### PR TITLE
CRDCDH-754 Poll for Batch Status Updates

### DIFF
--- a/src/content/dataSubmissions/DataSubmission.tsx
+++ b/src/content/dataSubmissions/DataSubmission.tsx
@@ -502,7 +502,7 @@ const DataSubmission = () => {
   }, [data?.getSubmission?.fileValidationStatus, data?.getSubmission?.metadataValidationStatus]);
 
   useEffect(() => {
-    if (user?.role !== "Submitter" || data?.getSubmission?.submitterID !== user?._id) {
+    if (user?.role !== "Submitter") {
       console.warn("Non-submitter user or non-owner. Ignoring batch refresh timeout.");
       return () => {};
     }

--- a/src/content/dataSubmissions/DataSubmission.tsx
+++ b/src/content/dataSubmissions/DataSubmission.tsx
@@ -504,18 +504,20 @@ const DataSubmission = () => {
   }, [data?.getSubmission?.fileValidationStatus, data?.getSubmission?.metadataValidationStatus]);
 
   useEffect(() => {
+    if (user?.role !== "Submitter" || data?.getSubmission?.submitterID !== user?._id) {
+      console.warn("Non-submitter user or non-owner. Ignoring batch refresh timeout.");
+      return () => {};
+    }
     if (!hasUploadingBatches) {
-      console.log("Has no uploading batches. Clearing batch refresh timeout.");
+      console.log("Has no uploading batches, clearing batch refresh timeout.");
       clearInterval(batchRefreshTimeout);
     } else if (!batchRefreshTimeout) {
-      console.warn("Has uploading batches. Setting batch refresh timeout.");
+      console.warn("Has uploading batches, setting the batch refresh timeout.");
       // TODO: increase interval to 60 seconds
       setBatchRefreshTimeout(setInterval(refreshBatchTable, 10000));
     }
 
-    return () => {
-      clearInterval(batchRefreshTimeout);
-    };
+    return () => clearInterval(batchRefreshTimeout);
   }, [hasUploadingBatches]);
 
   return (

--- a/src/content/dataSubmissions/DataSubmission.tsx
+++ b/src/content/dataSubmissions/DataSubmission.tsx
@@ -503,16 +503,14 @@ const DataSubmission = () => {
 
   useEffect(() => {
     if (user?.role !== "Submitter") {
-      console.warn("Non-submitter user or non-owner. Ignoring batch refresh timeout.");
       return () => {};
     }
-    if (!hasUploadingBatches) {
-      console.log("Has no uploading batches, clearing batch refresh timeout.");
+    if (!hasUploadingBatches && batchRefreshTimeout) {
       clearInterval(batchRefreshTimeout);
-    } else if (!batchRefreshTimeout) {
-      console.warn("Has uploading batches, setting the batch refresh timeout.");
-      // TODO: increase interval to 60 seconds
-      setBatchRefreshTimeout(setInterval(refreshBatchTable, 10000));
+      setBatchRefreshTimeout(null);
+      getSubmission();
+    } else if (!batchRefreshTimeout && hasUploadingBatches) {
+      setBatchRefreshTimeout(setInterval(refreshBatchTable, 60000));
     }
 
     return () => clearInterval(batchRefreshTimeout);

--- a/src/graphql/listBatches.ts
+++ b/src/graphql/listBatches.ts
@@ -39,9 +39,17 @@ export const query = gql`
         updatedAt
       }
     }
+    fullStatusList: listBatches(submissionID: $submissionID, first: -1) {
+      batches {
+        status
+      }
+    }
   }
 `;
 
 export type Response = {
   listBatches: ListBatches;
+  fullStatusList: {
+    batches: Pick<Batch, 'status'>[];
+  };
 };

--- a/src/types/Submissions.d.ts
+++ b/src/types/Submissions.d.ts
@@ -80,7 +80,7 @@ type BatchFileInfo = {
   updatedAt: string // ISO 8601 date time format with UTC or offset e.g., 2023-05-01T09:23:30Z
 };
 
-type BatchStatus = "New" | "Uploaded" | "Upload Failed" | "Loaded" | "Rejected";
+type BatchStatus = "Uploading" | "Uploaded" | "Failed";
 
 type MetadataIntention = "New" | "Update" | "Delete";
 


### PR DESCRIPTION
### Overview

This PR updates the `BatchStatus` type to conform to the current definition from CRDCDH-736 and implements listBatch polling if there are any batches in the Uploading state.

### Change Details (Specifics)

- Update TypeScript definition of BatchStatus per CRDCDH-736
- Modify listBatches GraphQL to query for full list of batch statuses
- Poll listBatches until there are no batches uploading, when there are no batches, update the data submission to retrieve latest stats

### Related Ticket(s)

CRDCDH-754