### PR TITLE
CRDCDH-676 Wording Changes

### DIFF
--- a/src/content/dataSubmissions/DataSubmissionsListView.tsx
+++ b/src/content/dataSubmissions/DataSubmissionsListView.tsx
@@ -175,7 +175,7 @@ const columns: Column[] = [
     field: "dataCommons",
   },
   {
-    label: "DM Versison",
+    label: "DM Version",
     value: (a) => a.modelVersion,
     field: "modelVersion",
   },

--- a/src/content/dataSubmissions/ErrorDialog.tsx
+++ b/src/content/dataSubmissions/ErrorDialog.tsx
@@ -69,7 +69,8 @@ const StyledTitle = styled(Typography)({
   fontStyle: "normal",
   fontWeight: "900",
   lineHeight: "30px",
-  paddingBottom: "8px"
+  paddingBottom: "8px",
+  wordBreak: "break-all"
 });
 
 const StyledUploadedDate = styled(Typography)({

--- a/src/content/dataSubmissions/FileListDialog.tsx
+++ b/src/content/dataSubmissions/FileListDialog.tsx
@@ -147,7 +147,7 @@ const tableContainerSx: TableContainerProps["sx"] = {
 
 const columns: Column<BatchFileInfo>[] = [
   {
-    label: "Node Type",
+    label: "Type",
     renderValue: (data) => <StyledNodeType>{data?.nodeType}</StyledNodeType>,
     field: "nodeType",
     default: true


### PR DESCRIPTION
### Overview

Wording changes and small fixes.

### Change Details (Specifics)

- Fixed `DM Version` typo
- Updated "Node Type" to "Type" in the File List Dialog table
- Added word break to error dialog title as it was causing an overflow

### Related Ticket(s)

[CRDCDH-676](https://tracker.nci.nih.gov/browse/CRDCDH-676) (Data Model Version)
[CRDCDH-780](https://tracker.nci.nih.gov/browse/CRDCDH-780) (File List Dialog bug)
[CRDCDH-552](https://tracker.nci.nih.gov/browse/CRDCDH-552) (Error Dialog)