### PR TITLE
CRDCDH-715 Admin Submit justification, CRDCDH-728 Updates

### DIFF
--- a/src/content/dataSubmissions/DataSubmissionActions.tsx
+++ b/src/content/dataSubmissions/DataSubmissionActions.tsx
@@ -267,6 +267,7 @@ const DataSubmissionActions = ({ submission, submitActionButton, onAction, onErr
 
   const onCloseDialog = () => {
     setCurrentDialog(null);
+    setReviewComment("");
   };
 
   const returnToSubmissionList = () => {

--- a/src/content/dataSubmissions/DataSubmissionActions.tsx
+++ b/src/content/dataSubmissions/DataSubmissionActions.tsx
@@ -196,7 +196,7 @@ const actionConfig: Record<ActionKey, ActionConfig> = {
 };
 
 type SubmitActionButton = {
-  label: string;
+  label: "Submit" | "Admin Submit";
   disable: boolean;
 };
 
@@ -258,6 +258,7 @@ const DataSubmissionActions = ({ submission, submitActionButton, onAction, onErr
       await onAction(action, reviewComment || null);
     }
     setAction(null);
+    setReviewComment("");
   };
 
   const onOpenDialog = (dialog: ActiveDialog) => {
@@ -392,7 +393,7 @@ const DataSubmissionActions = ({ submission, submitActionButton, onAction, onErr
 
       {/* Submit Dialog */}
       <StyledDialog
-        open={currentDialog === "Submit"}
+        open={currentDialog === "Submit" && submitActionButton.label === "Submit"}
         onClose={onCloseDialog}
         title="Submit Data Submission"
         actions={(
@@ -413,6 +414,39 @@ const DataSubmissionActions = ({ submission, submitActionButton, onAction, onErr
           This action will lock your submission and it will no longer accept updates
           to the data. Are you sure you want to proceed?
         </StyledDialogText>
+      </StyledDialog>
+
+      {/* Admin Submit Dialog */}
+      <StyledDialog
+        open={currentDialog === "Submit" && submitActionButton.label === "Admin Submit"}
+        onClose={onCloseDialog}
+        title="Admin Submit Data Submission"
+        actions={(
+          <Stack direction="row" marginTop="24px">
+            <Button onClick={onCloseDialog} disabled={!!action} color="error">Cancel</Button>
+            <LoadingButton
+              onClick={() => handleOnAction("Submit")}
+              loading={!!action}
+              disabled={reviewComment?.trim()?.length <= 0}
+              autoFocus
+            >
+              Confirm to Submit
+            </LoadingButton>
+          </Stack>
+        )}
+      >
+        <StyledOutlinedInput
+          value={reviewComment}
+          onChange={handleCommentChange}
+          placeholder="500 characters allowed*"
+          inputProps={{ "aria-label": "Admin override justification" }}
+          slotProps={{ input: { minLength: 1, maxLength: 500 } }}
+          minRows={2}
+          maxRows={2}
+          multiline
+          fullWidth
+          required
+        />
       </StyledDialog>
 
       {/* Release Dialog */}

--- a/src/content/dataSubmissions/DataSubmissionActions.tsx
+++ b/src/content/dataSubmissions/DataSubmissionActions.tsx
@@ -424,7 +424,7 @@ const DataSubmissionActions = ({ submission, submitActionButton, onAction, onErr
         title="Admin Submit Data Submission"
         actions={(
           <Stack direction="row" marginTop="24px">
-            <Button onClick={onCloseDialog} disabled={!!action} color="error">Cancel</Button>
+            <Button onClick={onCloseDialog} disabled={!!action}>Cancel</Button>
             <LoadingButton
               onClick={() => handleOnAction("Submit")}
               loading={!!action}
@@ -439,11 +439,11 @@ const DataSubmissionActions = ({ submission, submitActionButton, onAction, onErr
         <StyledOutlinedInput
           value={reviewComment}
           onChange={handleCommentChange}
-          placeholder="500 characters allowed*"
+          placeholder="Enter comments here. Max of 500 characters"
           inputProps={{ "aria-label": "Admin override justification" }}
           slotProps={{ input: { minLength: 1, maxLength: 500 } }}
-          minRows={2}
-          maxRows={2}
+          minRows={4}
+          maxRows={4}
           multiline
           fullWidth
           required
@@ -529,7 +529,7 @@ const DataSubmissionActions = ({ submission, submitActionButton, onAction, onErr
       <StyledDialog
         open={currentDialog === "Reject"}
         onClose={onCloseDialog}
-        title="Reject Data Submission *"
+        title="Reject Data Submission"
         actions={(
           <Stack direction="row" marginTop="24px">
             <Button onClick={onCloseDialog} disabled={!!action}>Cancel</Button>
@@ -548,10 +548,11 @@ const DataSubmissionActions = ({ submission, submitActionButton, onAction, onErr
         <StyledOutlinedInput
           value={reviewComment}
           onChange={handleCommentChange}
-          placeholder="500 characters allowed"
-          minRows={2}
-          maxRows={2}
+          placeholder="Enter comments here. Max of 500 characters"
+          inputProps={{ "aria-label": "Reject justification" }}
           slotProps={{ input: { minLength: 1, maxLength: 500 } }}
+          minRows={4}
+          maxRows={4}
           multiline
           fullWidth
           required

--- a/src/graphql/submissionAction.ts
+++ b/src/graphql/submissionAction.ts
@@ -4,19 +4,10 @@ export const mutation = gql`
   mutation submissionAction($submissionID: ID!, $action: String!, $comment: String) {
     submissionAction(submissionID: $submissionID, action: $action, comment: $comment) {
       _id
-      status
-      history {
-        status
-        reviewComment
-        dateTime
-        userID
-      }
-      createdAt
-      updatedAt
     }
   }
 `;
 
 export type Response = {
-  submissionAction: Submission;
+  submissionAction: Pick<Submission, "_id">;
 };


### PR DESCRIPTION
### Overview

This PR builds off CRDCDH-728 by requiring a comment when performing an administrative submit of a Data Submission.

### Change Details (Specifics)

- Add a Admin Submit dialog that's enabled only when the Submit Button label is "Admin Submit"
- Clear review comment text anytime the dialog is closed (cancel or submit actions)
- Update CRDCDH-728 for latest requirements (comment placeholder)

### Related Ticket(s)

CRDCDH-715
CRDCDH-728