### PR TITLE
CRDCDH-786 Change `file` batch type to `data file`

### DIFF
--- a/src/content/dataSubmissions/DataSubmission.tsx
+++ b/src/content/dataSubmissions/DataSubmission.tsx
@@ -249,7 +249,7 @@ const columns: Column<Batch>[] = [
   },
   {
     label: "Upload Type",
-    renderValue: (data) => (data?.type === "file" ? "-" : data?.metadataIntention),
+    renderValue: (data) => (data?.type === "data file" ? "-" : data?.metadataIntention),
     field: "metadataIntention",
   },
   {

--- a/src/content/dataSubmissions/DataSubmission.tsx
+++ b/src/content/dataSubmissions/DataSubmission.tsx
@@ -249,7 +249,7 @@ const columns: Column<Batch>[] = [
   },
   {
     label: "Upload Type",
-    renderValue: (data) => (data?.type === "data file" ? "-" : data?.metadataIntention),
+    renderValue: (data) => (data?.type !== "metadata" ? "-" : data?.metadataIntention),
     field: "metadataIntention",
   },
   {

--- a/src/types/Submissions.d.ts
+++ b/src/types/Submissions.d.ts
@@ -95,17 +95,17 @@ type BatchStatus = "Uploading" | "Uploaded" | "Failed";
 
 type MetadataIntention = "New" | "Update" | "Delete";
 
-type UploadType = "metadata" | "file";
+type UploadType = "metadata" | "data file";
 
 type Batch = {
   _id: string;
   displayID: number;
   submissionID: string; // parent
-  type: UploadType; // [metadata, file]
+  type: UploadType;
   metadataIntention: MetadataIntention; // [New, Update, Delete], Update is meant for "Update or insert", metadata only! file batches are always treated as Update
   fileCount: number; // calculated by BE
   files: BatchFileInfo[];
-  status: BatchStatus; // [New, Uploaded, Upload Failed, Loaded, Rejected] Loaded and Rejected are for metadata batch only
+  status: BatchStatus;
   errors: string[];
   createdAt: string; // ISO 8601 date time format with UTC or offset e.g., 2023-05-01T09:23:30Z
   updatedAt: string; // ISO 8601 date time format with UTC or offset e.g., 2023-05-01T09:23:30Z
@@ -116,7 +116,7 @@ type NewBatch = {
   submissionID: string; // parent
   bucketName?: string; // S3 bucket of the submission, for file batch / CLI use
   filePrefix?: string; // prefix/path within S3 bucket, for file batch / CLI use
-  type: string; // [metadata, file]
+  type: UploadType;
   metadataIntention: MetadataIntention; // [New, Update, Delete], Update is meant for "Update or insert", metadata only! file batches are always treated as Update
   fileCount: number; // calculated by BE
   files: FileURL[];
@@ -145,7 +145,7 @@ type ListLogFiles = {
 
 type LogFile = {
   fileName: string;
-  uploadType: UploadType; // [metadata, file]
+  uploadType: UploadType;
   downloadUrl: string; // s3 presigned download url of the file
   fileSize: number // size in byte
 };
@@ -175,7 +175,7 @@ type QCResults = {
 type QCResult = {
   submissionID: string;
   nodeType: string;
-  validationType: "metadata" | "file"; // [metadata, file]
+  validationType: UploadType;
   batchID: string;
   displayID: number;
   nodeID: string;


### PR DESCRIPTION
### Overview

This PR updates the FE type definitions for a Batch Type (i.e. `UploadType`) to match the new backend implementation. 

### Change Details (Specifics)

- Update `UploadType` to `metadata` and `data file`
- Replace `NewBatch`.`UploadType` from a `string` to `UploadType`
- Replace `QCResult`.`validationType` definition with `UploadType`
- Reverse logic on the Data Upload > Upload Type column for backwards compatibility (M2 submissions will still use `file` and will cause a bug in PROD)

### Related Ticket(s)

CRDCDH-786