### PR TITLE
CRDCDH-765 Data Submissions UI Improvements

### DIFF
--- a/src/components/DataSubmissions/DataSubmissionUpload.tsx
+++ b/src/components/DataSubmissions/DataSubmissionUpload.tsx
@@ -13,6 +13,7 @@ import RadioInput from "./RadioInput";
 import { CREATE_BATCH, CreateBatchResp, UPDATE_BATCH, UpdateBatchResp } from "../../graphql";
 import { useAuthContext } from "../Contexts/AuthContext";
 import DeleteDialog from "../../content/dataSubmissions/DeleteDialog";
+import FlowWrapper from './FlowWrapper';
 
 const StyledUploadTypeText = styled(Typography)(() => ({
   color: "#083A50",
@@ -48,7 +49,6 @@ const StyledUploadFilesButton = styled(Button)(() => ({
   textTransform: "none",
   "&.MuiButtonBase-root": {
     marginLeft: "auto",
-    marginRight: "21.5px",
     minWidth: "137px",
   }
 }));
@@ -92,11 +92,6 @@ const StyledFilesSelected = styled(Typography)(() => ({
   minWidth: "135px",
 }));
 
-const StyledUploadWrapper = styled(Stack)(() => ({
-  paddingLeft: "24px",
-  marginBottom: "19px"
-}));
-
 const StyledUploadActionWrapper = styled(Stack)(() => ({
   "&.MuiStack-root": {
     justifyContent: "center",
@@ -126,7 +121,7 @@ const DataSubmissionUpload = ({ submitterID, readOnly, onCreateBatch, onUpload }
   const [selectedFiles, setSelectedFiles] = useState<FileList | null>(null);
   const [isUploading, setIsUploading] = useState<boolean>(false);
   const [openDeleteDialog, setOpenDeleteDialog] = useState<boolean>(false);
-  const uploadMetatadataInputRef = useRef<HTMLInputElement>(null);
+  const uploadMetadataInputRef = useRef<HTMLInputElement>(null);
   const isSubmissionOwner = submitterID === user?._id;
   const canUpload = UploadRoles.includes(user?.role) || isSubmissionOwner;
   const acceptedExtensions = [".tsv", ".txt"];
@@ -166,7 +161,7 @@ const DataSubmissionUpload = ({ submitterID, readOnly, onCreateBatch, onUpload }
     if (!canUpload || readOnly) {
       return;
     }
-    uploadMetatadataInputRef?.current?.click();
+    uploadMetadataInputRef?.current?.click();
   };
 
   const handleChooseFiles = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -284,8 +279,8 @@ const DataSubmissionUpload = ({ submitterID, readOnly, onCreateBatch, onUpload }
       onUpload(`${selectedFiles.length} ${selectedFiles.length > 1 ? "Files" : "File"} successfully ${metadataIntention === "Delete" ? "deleted" : "uploaded"}`, "success");
       setIsUploading(false);
       setSelectedFiles(null);
-      if (uploadMetatadataInputRef.current) {
-        uploadMetatadataInputRef.current.value = "";
+      if (uploadMetadataInputRef.current) {
+        uploadMetadataInputRef.current.value = "";
       }
     } catch (err) {
       // Unable to let BE know of upload result so all fail
@@ -297,8 +292,8 @@ const DataSubmissionUpload = ({ submitterID, readOnly, onCreateBatch, onUpload }
     onUpload(`${fileCount} ${fileCount > 1 ? "Files" : "File"} failed to ${metadataIntention === "Delete" ? "delete" : "upload"}`, "error");
     setSelectedFiles(null);
     setIsUploading(false);
-    if (uploadMetatadataInputRef.current) {
-      uploadMetatadataInputRef.current.value = "";
+    if (uploadMetadataInputRef.current) {
+      uploadMetadataInputRef.current.value = "";
     }
   };
 
@@ -312,57 +307,59 @@ const DataSubmissionUpload = ({ submitterID, readOnly, onCreateBatch, onUpload }
   };
 
   return (
-    <StyledUploadWrapper direction="row" alignItems="center" spacing={1.25}>
-      <RadioInput
-        id="data-submission-dashboard-upload-type"
-        label="Upload Type"
-        value={metadataIntention}
-        onChange={(_event, value: MetadataIntention) => !readOnly && setMetadataIntention(value)}
-        options={metadataIntentionOptions}
-        gridWidth={4}
-        readOnly={readOnly}
-        inline
-        row
-      />
-      <StyledUploadActionWrapper direction="row">
-        <StyledMetadataText variant="body2">Metadata Files</StyledMetadataText>
-        <VisuallyHiddenInput
-          ref={uploadMetatadataInputRef}
-          type="file"
-          accept={acceptedExtensions.toString()}
-          aria-label="Upload metadata files"
-          onChange={handleChooseFiles}
+    <FlowWrapper title="Upload Data" borderColor="#8FC8D5" hoverColor="#92E7FA">
+      <Stack direction="row" alignItems="center" spacing={1.25}>
+        <RadioInput
+          id="data-submission-dashboard-upload-type"
+          label="Upload Type:"
+          value={metadataIntention}
+          onChange={(_event, value: MetadataIntention) => !readOnly && setMetadataIntention(value)}
+          options={metadataIntentionOptions}
+          gridWidth={4}
           readOnly={readOnly}
-          multiple
+          inline
+          row
         />
-        <StyledChooseFilesButton
-          variant="outlined"
-          onClick={handleChooseFilesClick}
-          disabled={readOnly || isUploading || !canUpload}
+        <StyledUploadActionWrapper direction="row">
+          <StyledMetadataText variant="body2">Metadata Files</StyledMetadataText>
+          <VisuallyHiddenInput
+            ref={uploadMetadataInputRef}
+            type="file"
+            accept={acceptedExtensions.toString()}
+            aria-label="Upload metadata files"
+            onChange={handleChooseFiles}
+            readOnly={readOnly}
+            multiple
+          />
+          <StyledChooseFilesButton
+            variant="outlined"
+            onClick={handleChooseFilesClick}
+            disabled={readOnly || isUploading || !canUpload}
+          >
+            Choose Files
+          </StyledChooseFilesButton>
+          <StyledFilesSelected variant="body1">
+            {selectedFiles?.length ? `${selectedFiles.length} ${selectedFiles.length > 1 ? "files" : "file"} selected` : "No files selected"}
+          </StyledFilesSelected>
+        </StyledUploadActionWrapper>
+        <StyledUploadFilesButton
+          variant="contained"
+          onClick={() => (metadataIntention === "Delete" ? setOpenDeleteDialog(true) : handleUploadFiles())}
+          disabled={readOnly || !selectedFiles?.length || !canUpload || isUploading}
+          disableElevation
+          disableRipple
+          disableTouchRipple
         >
-          Choose Files
-        </StyledChooseFilesButton>
-        <StyledFilesSelected variant="body1">
-          {selectedFiles?.length ? `${selectedFiles.length} ${selectedFiles.length > 1 ? "files" : "file"} selected` : "No files selected"}
-        </StyledFilesSelected>
-      </StyledUploadActionWrapper>
-      <StyledUploadFilesButton
-        variant="contained"
-        onClick={() => (metadataIntention === "Delete" ? setOpenDeleteDialog(true) : handleUploadFiles())}
-        disabled={readOnly || !selectedFiles?.length || !canUpload || isUploading}
-        disableElevation
-        disableRipple
-        disableTouchRipple
-      >
-        {isUploading ? "Uploading..." : "Upload"}
-      </StyledUploadFilesButton>
+          {isUploading ? "Uploading..." : "Upload"}
+        </StyledUploadFilesButton>
 
-      <DeleteDialog
-        open={openDeleteDialog}
-        onClose={onCloseDeleteDialog}
-        onConfirm={onDeleteUpload}
-      />
-    </StyledUploadWrapper>
+        <DeleteDialog
+          open={openDeleteDialog}
+          onClose={onCloseDeleteDialog}
+          onConfirm={onDeleteUpload}
+        />
+      </Stack>
+    </FlowWrapper>
   );
 };
 

--- a/src/components/DataSubmissions/FlowWrapper.tsx
+++ b/src/components/DataSubmissions/FlowWrapper.tsx
@@ -13,10 +13,10 @@ const StyledBox = styled(Box, {
 })<Pick<Props, "borderColor" | "hoverColor">>(({ borderColor, hoverColor }) => ({
   border: `2px solid ${borderColor}`,
   borderRadius: "8px",
-  paddingLeft: "34px",
-  paddingTop: "18px",
+  paddingLeft: "35px",
+  paddingTop: "24px",
   paddingRight: "26px",
-  paddingBottom: "29px",
+  paddingBottom: "26px",
   margin: "31px",
   "&:hover": {
     borderColor: hoverColor,

--- a/src/components/DataSubmissions/FlowWrapper.tsx
+++ b/src/components/DataSubmissions/FlowWrapper.tsx
@@ -1,0 +1,43 @@
+import { Box, Typography, styled } from '@mui/material';
+import { CSSProperties, FC } from "react";
+
+type Props = {
+  title: string;
+  borderColor: CSSProperties["borderColor"];
+  hoverColor: CSSProperties["borderColor"];
+  children: React.ReactNode;
+};
+
+const StyledBox = styled(Box, {
+  shouldForwardProp: (prop) => prop !== "borderColor" && prop !== "hoverColor"
+})<Pick<Props, "borderColor" | "hoverColor">>(({ borderColor, hoverColor }) => ({
+  border: `2px solid ${borderColor}`,
+  borderRadius: "8px",
+  paddingLeft: "34px",
+  paddingTop: "18px",
+  paddingRight: "26px",
+  paddingBottom: "29px",
+  margin: "31px",
+  "&:hover": {
+    borderColor: hoverColor,
+    boxShadow: "0px 0px 10px 5px #00000026",
+  },
+}));
+
+const StyledTitle = styled(Typography)({
+  fontFamily: "Nunito Sans",
+  fontSize: "13px",
+  fontWeight: 600,
+  letterSpacing: "0.5px",
+  color: "#187A90",
+  textTransform: "uppercase",
+});
+
+const FlowWrapper: FC<Props> = ({ title, borderColor, hoverColor, children }) => (
+  <StyledBox borderColor={borderColor} hoverColor={hoverColor}>
+    <StyledTitle variant="h3">{title}</StyledTitle>
+    {children}
+  </StyledBox>
+);
+
+export default FlowWrapper;

--- a/src/components/DataSubmissions/RadioInput.tsx
+++ b/src/components/DataSubmissions/RadioInput.tsx
@@ -52,6 +52,7 @@ const StyledFormLabel = styled("label")(() => ({
   lineHeight: "19.6px",
   minHeight: "20px",
   color: "#083A50",
+  marginRight: "10px",
 }));
 
 const StyledAsterisk = styled("span")(() => ({

--- a/src/components/DataSubmissions/ValidationControls.tsx
+++ b/src/components/DataSubmissions/ValidationControls.tsx
@@ -1,12 +1,13 @@
 import { FC, useEffect, useMemo, useState } from 'react';
 import { useMutation } from '@apollo/client';
-import { FormControlLabel, RadioGroup, styled } from '@mui/material';
+import { FormControlLabel, RadioGroup, Stack, styled } from '@mui/material';
 import { LoadingButton } from '@mui/lab';
 import { useSnackbar } from 'notistack';
 import { useAuthContext } from '../Contexts/AuthContext';
 import StyledRadioButton from "../Questionnaire/StyledRadioButton";
 import { VALIDATE_SUBMISSION, ValidateSubmissionResp } from '../../graphql';
 import { getDefaultValidationType, getValidationTypes } from '../../utils';
+import FlowWrapper from './FlowWrapper';
 
 type Props = {
   /**
@@ -41,38 +42,18 @@ const StyledValidateButton = styled(LoadingButton)({
   lineHeight: "16px",
   letterSpacing: "0.32px",
   textTransform: "none",
-  border: "1.5px solid #136071",
   "&.MuiButtonBase-root": {
     height: "fit-content",
     marginLeft: "auto",
-    marginRight: "21.5px",
     minWidth: "137px",
-  },
-  "&.MuiButtonBase-root:disabled": {
-    height: "fit-content",
-    marginLeft: "auto",
-    marginRight: "21.5px",
-    minWidth: "137px",
-    background: "#949494",
-    color: "#CBCBCB",
   },
   "&.MuiButtonBase-root:hover": {
     background: "#496065",
-    height: "fit-content",
-    marginLeft: "auto",
-    marginRight: "21.5px",
-    minWidth: "137px",
   }
 });
 
-const StyledFileValidationSection = styled("div")({
-  borderRadius: 0,
-  minHeight: "147px",
-  padding: "21px 40px 0",
-  background: "#F0FBFD",
-  gridAutoFlow: "row",
-  gridTemplateColumns: "2.5fr 0.5fr",
-  display: "grid",
+const StyledFileValidationSection = styled(Stack)({
+  marginTop: "5px",
   ".headerText": {
     fontFamily: "Nunito",
     color: "#083A50",
@@ -222,63 +203,65 @@ const ValidationControls: FC<Props> = ({ dataSubmission, onValidate }: Props) =>
   }, [dataSubmission]);
 
   return (
-    <StyledFileValidationSection>
-      <div className="fileValidationLeftSide">
-        <div className="fileValidationLeftSideTopRow">
-          <div className="headerText">Validation Type:</div>
-          <div className="fileValidationRadioButtonGroup">
-            <RadioGroup value={validationType} onChange={(e, val: ValidationType) => setValidationType(val)} row>
-              <StyledRadioControl
-                value="Metadata"
-                control={<StyledRadioButton readOnly={false} />}
-                label="Validate Metadata"
-                disabled={!canValidateMetadata}
-              />
-              <StyledRadioControl
-                value="Files"
-                control={<StyledRadioButton readOnly={false} />}
-                label="Validate Data Files"
-                disabled={!canValidateFiles}
-              />
-              <StyledRadioControl
-                value="All"
-                control={<StyledRadioButton readOnly={false} />}
-                label="Both"
-                disabled={!canValidateFiles || !canValidateMetadata}
-              />
-            </RadioGroup>
+    <FlowWrapper title="Validate Data" borderColor="#8E9AD5" hoverColor="#869AFF">
+      <StyledFileValidationSection direction="row">
+        <div className="fileValidationLeftSide">
+          <div className="fileValidationLeftSideTopRow">
+            <div className="headerText">Validation Type:</div>
+            <div className="fileValidationRadioButtonGroup">
+              <RadioGroup value={validationType} onChange={(e, val: ValidationType) => setValidationType(val)} row>
+                <StyledRadioControl
+                  value="Metadata"
+                  control={<StyledRadioButton readOnly={false} />}
+                  label="Validate Metadata"
+                  disabled={!canValidateMetadata}
+                />
+                <StyledRadioControl
+                  value="Files"
+                  control={<StyledRadioButton readOnly={false} />}
+                  label="Validate Data Files"
+                  disabled={!canValidateFiles}
+                />
+                <StyledRadioControl
+                  value="All"
+                  control={<StyledRadioButton readOnly={false} />}
+                  label="Both"
+                  disabled={!canValidateFiles || !canValidateMetadata}
+                />
+              </RadioGroup>
+            </div>
+          </div>
+          <div className="fileValidationLeftSideBottomRow">
+            <div className="headerText">Validation Target:</div>
+            <div className="fileValidationRadioButtonGroup">
+              <RadioGroup value={uploadType} onChange={(event, val: ValidationTarget) => setUploadType(val)} row>
+                <StyledRadioControl
+                  value="New"
+                  control={<StyledRadioButton readOnly={false} />}
+                  label="New Uploaded Data"
+                  disabled={!canValidateFiles && !canValidateMetadata}
+                />
+                <StyledRadioControl
+                  value="All"
+                  control={<StyledRadioButton readOnly={false} />}
+                  label="All Uploaded Data"
+                  disabled={!canValidateFiles && !canValidateMetadata}
+                />
+              </RadioGroup>
+            </div>
           </div>
         </div>
-        <div className="fileValidationLeftSideBottomRow">
-          <div className="headerText">Validation Target:</div>
-          <div className="fileValidationRadioButtonGroup">
-            <RadioGroup value={uploadType} onChange={(event, val: ValidationTarget) => setUploadType(val)} row>
-              <StyledRadioControl
-                value="New"
-                control={<StyledRadioButton readOnly={false} />}
-                label="New Uploaded Data"
-                disabled={!canValidateFiles && !canValidateMetadata}
-              />
-              <StyledRadioControl
-                value="All"
-                control={<StyledRadioButton readOnly={false} />}
-                label="All Uploaded Data"
-                disabled={!canValidateFiles && !canValidateMetadata}
-              />
-            </RadioGroup>
-          </div>
-        </div>
-      </div>
-      <StyledValidateButton
-        variant="contained"
-        disableElevation
-        disabled={(!canValidateFiles && !canValidateMetadata) || isValidating}
-        loading={isLoading}
-        onClick={handleValidateFiles}
-      >
-        {isValidating ? "Validating..." : "Validate"}
-      </StyledValidateButton>
-    </StyledFileValidationSection>
+        <StyledValidateButton
+          variant="contained"
+          disableElevation
+          disabled={(!canValidateFiles && !canValidateMetadata) || isValidating}
+          loading={isLoading}
+          onClick={handleValidateFiles}
+        >
+          {isValidating ? "Validating..." : "Validate"}
+        </StyledValidateButton>
+      </StyledFileValidationSection>
+    </FlowWrapper>
   );
 };
 

--- a/src/components/DataSubmissions/ValidationStatistics.tsx
+++ b/src/components/DataSubmissions/ValidationStatistics.tsx
@@ -99,6 +99,13 @@ const StyledSecondaryTitle = styled(Typography)({
   color: "#187A90",
 });
 
+const StyledNoData = styled(Typography)({
+  fontSize: "13px",
+  fontWeight: 600,
+  textTransform: "uppercase",
+  color: "#083A50",
+});
+
 const defaultFilters: LegendFilter[] = [
   { label: "New", color: "#4D90D3", disabled: false },
   { label: "Passed", color: "#32E69A", disabled: false },
@@ -131,8 +138,13 @@ const DataSubmissionStatistics: FC<Props> = ({ dataSubmission, statistics }: Pro
   };
 
   // If there is no data submission or no items uploaded, do not render
+  // NOTE: This does not conform to CRDCDH-538 requirements currently
   if (!dataSubmission || !statistics?.some((s) => s.total > 0)) {
-    return null;
+    return (
+      <StyledChartArea direction="row">
+        <StyledNoData variant="h6">New Data Submission. No data has been uploaded yet.</StyledNoData>
+      </StyledChartArea>
+    );
   }
 
   return (

--- a/src/content/dataSubmissions/DataSubmission.tsx
+++ b/src/content/dataSubmissions/DataSubmission.tsx
@@ -122,7 +122,6 @@ const StyledCardActions = styled(CardActions, {
 }));
 
 const StyledTabs = styled(Tabs)(() => ({
-  background: "#F0FBFD",
   position: 'relative',
   "& .MuiTabs-flexContainer": {
     justifyContent: "center"
@@ -130,7 +129,6 @@ const StyledTabs = styled(Tabs)(() => ({
   "& .MuiTabs-indicator": {
     display: "none !important"
   },
-
   '&::before': {
     content: '""',
     position: 'absolute',
@@ -321,7 +319,7 @@ const columns: Column<Batch>[] = [
 ];
 
 const URLTabs = {
-  DATA_UPLOAD: "data-upload",
+  DATA_ACTIVITY: "data-activity",
   VALIDATION_RESULTS: "validation-results"
 };
 
@@ -540,14 +538,26 @@ const DataSubmission = () => {
               </StyledAlert>
             )}
             <DataSubmissionSummary dataSubmission={data?.getSubmission} />
-            <DataSubmissionStatistics dataSubmission={data?.getSubmission} statistics={data?.submissionStats?.stats} />
-            <ValidationControls dataSubmission={data?.getSubmission} onValidate={handleOnValidate} />
-            <StyledTabs value={isValidTab ? tab : URLTabs.DATA_UPLOAD}>
+            <DataSubmissionStatistics
+              dataSubmission={data?.getSubmission}
+              statistics={data?.submissionStats?.stats}
+            />
+            <DataSubmissionUpload
+              submitterID={data?.getSubmission?.submitterID}
+              readOnly={submissionLockedStatuses.includes(data?.getSubmission?.status)}
+              onCreateBatch={refreshBatchTable}
+              onUpload={handleOnUpload}
+            />
+            <ValidationControls
+              dataSubmission={data?.getSubmission}
+              onValidate={handleOnValidate}
+            />
+            <StyledTabs value={isValidTab ? tab : URLTabs.DATA_ACTIVITY}>
               <LinkTab
-                value={URLTabs.DATA_UPLOAD}
-                label="Data Upload"
-                to={`/data-submission/${submissionId}/${URLTabs.DATA_UPLOAD}`}
-                selected={tab === URLTabs.DATA_UPLOAD}
+                value={URLTabs.DATA_ACTIVITY}
+                label="Data Activity"
+                to={`/data-submission/${submissionId}/${URLTabs.DATA_ACTIVITY}`}
+                selected={tab === URLTabs.DATA_ACTIVITY}
               />
               <LinkTab
                 value={URLTabs.VALIDATION_RESULTS}
@@ -558,14 +568,8 @@ const DataSubmission = () => {
             </StyledTabs>
 
             <StyledMainContentArea>
-              {tab === URLTabs.DATA_UPLOAD ? (
+              {tab === URLTabs.DATA_ACTIVITY ? (
                 <BatchTableContext.Provider value={providerValue}>
-                  <DataSubmissionUpload
-                    submitterID={data?.getSubmission?.submitterID}
-                    readOnly={submissionLockedStatuses.includes(data?.getSubmission?.status)}
-                    onCreateBatch={refreshBatchTable}
-                    onUpload={handleOnUpload}
-                  />
                   <GenericTable
                     ref={tableRef}
                     columns={columns}
@@ -579,7 +583,7 @@ const DataSubmission = () => {
               ) : <QualityControl />}
             </StyledMainContentArea>
           </StyledCardContent>
-          <StyledCardActions isVisible={tab === URLTabs.DATA_UPLOAD}>
+          <StyledCardActions isVisible={tab === URLTabs.DATA_ACTIVITY}>
             <DataSubmissionActions
               submission={data?.getSubmission}
               onAction={updateSubmissionAction}

--- a/src/content/dataSubmissions/DataSubmissionsListView.tsx
+++ b/src/content/dataSubmissions/DataSubmissionsListView.tsx
@@ -161,7 +161,7 @@ const StyledSelect = styled(Select)(baseTextFieldStyles);
 const columns: Column[] = [
   {
     label: "Submission Name",
-    value: (a) => <Link to={`/data-submission/${a._id}/data-upload`}>{a.name}</Link>,
+    value: (a) => <Link to={`/data-submission/${a._id}/data-activity`}>{a.name}</Link>,
     field: "name",
   },
   {


### PR DESCRIPTION
### Overview

This ticket changes the flow of the Data Submission UI to:

1. Statistics
2. Upload Metadata
3. Validation

to accommodate the typical user flow. Additionally, it introduces minor changes to the Data Upload tab and validation stats.

> [!Warning]
> This PR does NOT modify the design of the "Upload" or "Validate" buttons to avoid conflicts with CRDCDH-747

### Change Details (Specifics)

- Reorganize Data Submission page (see above)
- Rename Data Upload to Data Activity
- Add placeholder to submission stats when there are no stats yet
- Rename a variable typo `uploadMetatadataInputRef` to `uploadMetadataInputRef`

### Related Ticket(s)

CRDCDH-765