### PR TITLE
CRDCDH-633 508 color contrast on Error/Failed statuses

### DIFF
--- a/src/content/dataSubmissions/DataSubmission.tsx
+++ b/src/content/dataSubmissions/DataSubmission.tsx
@@ -165,7 +165,7 @@ const StyledCardContent = styled(CardContent)({
 });
 
 const StyledRejectedStatus = styled("div")(() => ({
-  color: "#E25C22",
+  color: "#B54717",
   fontWeight: 600
 }));
 

--- a/src/content/dataSubmissions/QualityControl.tsx
+++ b/src/content/dataSubmissions/QualityControl.tsx
@@ -130,7 +130,7 @@ const columns: Column<QCResult>[] = [
   },
   {
     label: "Severity",
-    renderValue: (data) => <StyledSeverity color={data?.severity === "Error" ? "#E25C22" : "#8D5809"}>{data?.severity}</StyledSeverity>,
+    renderValue: (data) => <StyledSeverity color={data?.severity === "Error" ? "#B54717" : "#8D5809"}>{data?.severity}</StyledSeverity>,
     field: "severity",
   },
   {


### PR DESCRIPTION
### Overview

Simple PR to address an additional 508 issue with the color contrast of the "Error" or upload "Failed" states on the Data Submissions QC or Data Activity tables.

### Change Details (Specifics)

N/A

### Related Ticket(s)

CRDCDH-633