### PR TITLE
CRDCDH-835 Failed batch has no Node Types for files

### DIFF
--- a/src/content/dataSubmissions/FileListDialog.tsx
+++ b/src/content/dataSubmissions/FileListDialog.tsx
@@ -140,7 +140,7 @@ const tableContainerSx: TableContainerProps["sx"] = {
 const columns: Column<BatchFileInfo>[] = [
   {
     label: "Type",
-    renderValue: (data) => <StyledNodeType>{data?.nodeType}</StyledNodeType>,
+    renderValue: (data) => <StyledNodeType>{data?.nodeType || "N/A"}</StyledNodeType>,
     field: "nodeType",
     default: true
   },


### PR DESCRIPTION
### Overview

Minor bug fix to use a fallback placeholder for files without a node type. This occurs during `Uploading` or sometimes `Failed` Batch states.
 
### Change Details (Specifics)

- Use `N/A` when there is no nodeType associated with a file

### Related Ticket(s)

CRDCDH-835