### PR TITLE
CRDCDH-857 Refresh batches for any role

### DIFF
--- a/src/content/dataSubmissions/DataSubmission.tsx
+++ b/src/content/dataSubmissions/DataSubmission.tsx
@@ -512,9 +512,6 @@ const DataSubmission: FC<Props> = ({ submissionId, tab }) => {
   }, [data?.getSubmission?.fileValidationStatus, data?.getSubmission?.metadataValidationStatus]);
 
   useEffect(() => {
-    if (user?.role !== "Submitter") {
-      return () => {};
-    }
     if (!hasUploadingBatches && batchRefreshTimeout) {
       clearInterval(batchRefreshTimeout);
       setBatchRefreshTimeout(null);


### PR DESCRIPTION
### Overview

This PR removes the logic that prevents refreshing the batch table for any non-Submitter role. The user story CRDCDH-754 was updated to clarify that any role should poll for batch updates.

### Change Details (Specifics)

N/A

### Related Ticket(s)

CRDCDH-857 (Bug)
CRDCDH-754 (Original ticket)