### PR TITLE
CRDCDH-854 Revert #199 and add Adobe Analytics

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -14,15 +14,11 @@
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <title>CRDC DataHub</title>
-
-    <script src="https://cbiit.github.io/crdc-alert-elements/components/include-html.js"></script>
     <script src="%PUBLIC_URL%/injectEnv.js"></script>
     <script src="%PUBLIC_URL%/js/session.js"></script>
+    <script src="https://assets.adobedtm.com/6a4249cd0a2c/785de09de161/launch-70d67a6a40a8.min.js" async></script>
   </head>
   <body>
-    <header aria-label="government shutdown banner">
-      <include-html src="https://cbiit.github.io/crdc-alert-elements/banners/government-shutdown.html"></include-html>
-    </header>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
   </body>


### PR DESCRIPTION
### Overview

This PR reverts the custom government shutdown banner introduced in #199 and replaces it with a custom CBIIT solution.

> [!NOTE]
> - To test the shutdown banner, add the query string `?show_launch_banner=true` to the URL, it should appear
> - We don't have access to any analytic reporting to verify the installation beyond the banner

### Change Details (Specifics)

N/A

### Related Ticket(s)

CRDCDH-854