### PR TITLE
CRDCDH-538 Fix Node Sorting & Partially-Visible Carousel Elements

### DIFF
--- a/src/components/Carousel/index.tsx
+++ b/src/components/Carousel/index.tsx
@@ -24,6 +24,9 @@ const StyledWrapper = styled('div')({
   "& .react-multi-carousel-list": {
     height: "206px",
   },
+  "& .react-multi-carousel-track": {
+    margin: "0 auto", // NOTE: This centers the carousel when there are fewer than 2 items
+  },
   "& .custom-carousel-item": {
     maxWidth: "200px",
     minWidth: "200px",

--- a/src/components/DataSubmissions/ValidationStatistics.tsx
+++ b/src/components/DataSubmissions/ValidationStatistics.tsx
@@ -125,7 +125,7 @@ const DataSubmissionStatistics: FC<Props> = ({ dataSubmission, statistics }: Pro
   if (!dataset?.some((s) => s.total > 0)) {
     return (
       <StyledChartArea direction="row">
-        <StyledNoData variant="h6">No data has been successfully uploaded at this time.</StyledNoData>
+        <StyledNoData variant="h6">No data has been successfully uploaded yet.</StyledNoData>
       </StyledChartArea>
     );
   }

--- a/src/components/DataSubmissions/ValidationStatistics.tsx
+++ b/src/components/DataSubmissions/ValidationStatistics.tsx
@@ -147,7 +147,7 @@ const DataSubmissionStatistics: FC<Props> = ({ dataSubmission, statistics }: Pro
           {`(${dataset.length})`}
         </StyledSectionTitle>
         <ContentCarousel partialVisible={false}>
-          <PaddingBox />
+          {dataset.length > 2 && <PaddingBox />}
           {dataset?.map((stat) => (
             <MiniPieChart
               key={stat.nodeName}

--- a/src/components/DataSubmissions/ValidationStatistics.tsx
+++ b/src/components/DataSubmissions/ValidationStatistics.tsx
@@ -1,5 +1,5 @@
-import React, { FC, useState } from 'react';
-import { isEqual } from 'lodash';
+import React, { FC, useMemo, useState } from 'react';
+import { cloneDeep, isEqual } from 'lodash';
 import { Box, Stack, Tab, Tabs, Typography, styled } from '@mui/material';
 import ContentCarousel from '../Carousel';
 import NodeTotalChart from '../NodeTotalChart';
@@ -98,7 +98,10 @@ const defaultFilters: LegendFilter[] = [
 const DataSubmissionStatistics: FC<Props> = ({ dataSubmission, statistics }: Props) => {
   const [filters, setFilters] = useState<LegendFilter[]>(defaultFilters);
   const [tabValue, setTabValue] = useState<"count" | "percentage">("count");
+
   const disabledSeries: SeriesLabel[] = filters.filter((f) => f.disabled).map((f) => f.label);
+  const dataset: SubmissionStatistic[] = useMemo(() => cloneDeep(statistics || []).sort(compareNodeStats), [statistics]);
+  const primaryChartSeries: BarChartDataset[] = useMemo(() => buildPrimaryChartSeries(dataset, disabledSeries), [dataset, disabledSeries]);
 
   const handleFilterChange = (filter: LegendFilter) => {
     const newFilters = filters.map((f) => {
@@ -111,7 +114,7 @@ const DataSubmissionStatistics: FC<Props> = ({ dataSubmission, statistics }: Pro
 
   const handleViewByChange = (_: React.SyntheticEvent, newValue: "count" | "percentage") => setTabValue(newValue);
 
-  if (!dataSubmission || !statistics) {
+  if (!dataSubmission || !dataset) {
     return (
       <StyledChartArea direction="row">
         <SuspenseLoader fullscreen={false} />
@@ -119,7 +122,7 @@ const DataSubmissionStatistics: FC<Props> = ({ dataSubmission, statistics }: Pro
     );
   }
 
-  if (!statistics?.some((s) => s.total > 0)) {
+  if (!dataset?.some((s) => s.total > 0)) {
     return (
       <StyledChartArea direction="row">
         <StyledNoData variant="h6">No data has been successfully uploaded at this time.</StyledNoData>
@@ -131,7 +134,7 @@ const DataSubmissionStatistics: FC<Props> = ({ dataSubmission, statistics }: Pro
     <StyledChartArea direction="row">
       <Stack direction="column" alignItems="center" flex={1}>
         <StyledSectionTitle variant="h6">Summary Total</StyledSectionTitle>
-        <NodeTotalChart data={buildPrimaryChartSeries(statistics, disabledSeries)} normalize={tabValue === "percentage"} />
+        <NodeTotalChart data={primaryChartSeries} normalize={tabValue === "percentage"} />
         <Tabs value={tabValue} onChange={handleViewByChange} aria-label="View chart by" centered>
           <StyledTab label="View By Count" value="count" />
           <StyledTab label="View By Percentage" value="percentage" />
@@ -141,11 +144,11 @@ const DataSubmissionStatistics: FC<Props> = ({ dataSubmission, statistics }: Pro
         <StyledSectionTitle variant="h6">
           Individual Node Types
           {" "}
-          {`(${statistics.length})`}
+          {`(${dataset.length})`}
         </StyledSectionTitle>
         <ContentCarousel partialVisible={false}>
           <PaddingBox />
-          {statistics?.sort(compareNodeStats).map((stat) => (
+          {dataset?.map((stat) => (
             <MiniPieChart
               key={stat.nodeName}
               label={stat.nodeName}


### PR DESCRIPTION
### Overview

This is a minor change to the CRDCDH-538 implementation to fix an issue noticed in the prod builds. 

<details>
  <summary>Issue 1: Inconsistent Node Sorting</summary>

Without React StrictMode, the nodes in the primary chart would appear in the order that the API sent the nodes until you switch the view type.

<img width="542" alt="Screenshot 2024-02-23 at 9 35 24 AM" src="https://github.com/CBIIT/crdc-datahub-ui/assets/38357871/c622d92f-30b1-4943-84c5-5b7dda22cdec">

<img width="542" alt="Screenshot 2024-02-23 at 9 36 02 AM" src="https://github.com/CBIIT/crdc-datahub-ui/assets/38357871/4b800daa-997e-4f5a-925d-b95929164575">
</details>

<details>
  <summary>Issue 2: Partially Visible Nodes</summary>

For small datasets (under 3 nodes), the carousel would partially overlap with the individual node charts and not provide arrows to make them visible. This is fixed now.

Cases:

- 1 Node [f30c5850-2349-4cd0-a4ef-959b8ea34ee5](http://localhost:4010/data-submission/f30c5850-2349-4cd0-a4ef-959b8ea34ee5/data-activity)
- 2 Nodes [45a25d33-86a5-4cf3-bfa2-9a557dbfeb2c](http://localhost:4010/data-submission/45a25d33-86a5-4cf3-bfa2-9a557dbfeb2c)
- 3 Nodes [7408c5bb-d8a8-470a-9d9e-88c8792a84a1](http://localhost:4010/data-submission/7408c5bb-d8a8-470a-9d9e-88c8792a84a1/data-activity)
- 7 Nodes [b80ddec8-6f0e-4189-b7c0-0a60b9fda08c](http://localhost:4010/data-submission/b80ddec8-6f0e-4189-b7c0-0a60b9fda08c/data-activity)

</details>

### Change Details (Specifics)

- Sort the dataset at the component level, prior to the primary chart rendering
- Recenter the carousel track (previously removed)
- Conditionally add the `PaddingBox` element to the carousel children
- Replace "no data..." message to conform to the user story

### Related Ticket(s)

CRDCDH-538