### PR TITLE
CRDCDH-864 Fix broken aria references and contrast issue

### DIFF
--- a/src/content/users/APITokenDialog.tsx
+++ b/src/content/users/APITokenDialog.tsx
@@ -71,7 +71,6 @@ const StyledTokenInput = styled(OutlinedInput)({
   "& .MuiOutlinedInput-notchedOutline": {
     borderRadius: "8px",
     border: "1px solid #6B7294 !important",
-
   }
 });
 
@@ -81,7 +80,6 @@ const StyledGenerateButton = styled(Button)({
   padding: "12px 7px !important",
   borderRadius: "8px !important",
   border: "1px solid #000 !important",
-  background: "#1D91AB !important",
   color: "#FFFFFF",
   textAlign: "center",
   fontFamily: "'Nunito', 'Rubik', sans-serif !important",
@@ -91,9 +89,6 @@ const StyledGenerateButton = styled(Button)({
   lineHeight: "24px !important",
   letterSpacing: "0.32px !important",
   textTransform: "none !important" as 'none',
-  "&:hover": {
-    background: "#1D91AB !important",
-  },
 });
 
 const StyledCopyTokenButton = styled(IconButton)(() => ({
@@ -222,7 +217,7 @@ const APITokenDialog: FC<Props> = ({
     <StyledDialog
       open={open}
       onClose={handleCloseDialog}
-      title=""
+      aria-labelledby="api-token-header"
       {...rest}
     >
       <GenericAlert open={!!changesAlert} severity={changesAlert?.severity} key="api-token-dialog-changes-alert">
@@ -236,10 +231,10 @@ const APITokenDialog: FC<Props> = ({
       >
         <CloseIconSvg />
       </StyledCloseDialogButton>
-      <StyledHeader id="api-token-header" variant="h3">
+      <StyledHeader id="api-token-header" variant="h1">
         API Token
       </StyledHeader>
-      <StyledTitle id="api-token-title" variant="h6">
+      <StyledTitle id="api-token-title" variant="body1">
         An API Token is required to utilize the Uploader CLI tool for file uploads.
         <br />
         <br />

--- a/src/content/users/UploaderToolDialog.tsx
+++ b/src/content/users/UploaderToolDialog.tsx
@@ -99,6 +99,7 @@ const UploaderToolDialog: FC<Props> = ({
   <StyledDialog
     open={open}
     onClose={() => onClose?.()}
+    aria-labelledby="uploader-cli-header"
     {...rest}
   >
     <StyledCloseDialogButton
@@ -107,11 +108,11 @@ const UploaderToolDialog: FC<Props> = ({
     >
       <CloseIconSvg />
     </StyledCloseDialogButton>
-    <StyledHeader id="uploader-cli-header" variant="h3">
+    <StyledHeader id="uploader-cli-header" variant="h1">
       Uploader CLI Tool
     </StyledHeader>
     <StyledDialogContent>
-      <StyledBodyText id="uploader-cli-body" variant="h6">
+      <StyledBodyText id="uploader-cli-body" variant="body1">
         The Uploader CLI is a command-line interface tool provided for directly uploading data submission files from your workstation to the Data Hub cloud storage.
         To download the tool and accompanying instructions, click on the Download button below.
       </StyledBodyText>


### PR DESCRIPTION
### Overview

This PR addresses broken aria references on the CLI Uploader Tool and CLI API Token dialogs.

### Change Details (Specifics)

- Override the default random aria-labelledby ID generated by MUI
- Replace h3/h6 headings with h1/body1 respectively (addresses a 508 warning)
- Fix button contrast issue on API Token download dialog

### Related Ticket(s)

CRDCDH-864
