### PR TITLE
CRDCDH-826 Submission Request Auto Save

### DIFF
--- a/src/components/Questionnaire/UnsavedChangesDialog.tsx
+++ b/src/components/Questionnaire/UnsavedChangesDialog.tsx
@@ -31,7 +31,7 @@ const UnsavedChangesDialog: FC<Props> = ({
     title={title || "Unsaved Changes"}
     message={
       message
-      || "You have unsaved changes. Your changes will be lost if you leave this section without saving. Do you want to save your data?"
+      || "Validation errors have been detected. Do you wish to save your changes or discard them before leaving this page?"
     }
     actions={(
       <>


### PR DESCRIPTION
### Overview

This PR introduces auto-saving a Submission Request form when navigating away from the current page. It also migrates the `GenericAlert` component to Notistack.

### Change Details (Specifics)

- If there are no form errors, save the submission request on navigate instead of showing an alert
- Migrate FormView usage of GenericAlert to Notistack
- Update verbiage in Unsaved Changes dialog

### Related Ticket(s)

CRDCDH-826
