### PR TITLE
Data submission tabs alignment Hotfix

### DIFF
--- a/src/content/dataSubmissions/DataSubmission.tsx
+++ b/src/content/dataSubmissions/DataSubmission.tsx
@@ -127,20 +127,22 @@ const StyledCardActions = styled(CardActions, {
 }));
 
 const StyledTabs = styled(Tabs)(() => ({
-  position: 'relative',
+  position: "relative",
+  display: "flex",
+  alignItems: "flex-end",
   "& .MuiTabs-flexContainer": {
-    justifyContent: "center"
+    justifyContent: "center",
   },
   "& .MuiTabs-indicator": {
-    display: "none !important"
+    display: "none !important",
   },
-  '&::before': {
+  "&::before": {
     content: '""',
-    position: 'absolute',
+    position: "absolute",
     bottom: 0,
     left: 0,
     right: 0,
-    borderBottom: '1.25px solid #6CACDA',
+    borderBottom: "1.25px solid #6CACDA",
     zIndex: 1,
   },
 }));


### PR DESCRIPTION
### Overview

Fixed alignment of tabs not always being flush with the section under it causing the border from the section under it to show. The problem was only visible in certain scenarios such as zoomed in browsers or different screens.

### Change Details (Specifics)

- Updated alignment to flex-end so that it is always flush with the lower section

![Screenshot 2024-03-01 at 4 44 09 PM](https://github.com/CBIIT/crdc-datahub-ui/assets/70384003/6ac9ecc1-45a5-4d05-bb8c-a4252ab60cfe)
![Screenshot 2024-03-01 at 4 44 28 PM](https://github.com/CBIIT/crdc-datahub-ui/assets/70384003/62328eeb-8ecc-4371-867f-c531ee180fc9)


### Related Ticket(s)

N/A
