### PR TITLE
fix: Data File not appearing in Node Type column

### DIFF
--- a/src/content/dataSubmissions/QualityControl.tsx
+++ b/src/content/dataSubmissions/QualityControl.tsx
@@ -110,7 +110,7 @@ const columns: Column<QCResult>[] = [
   },
   {
     label: "Node Type",
-    renderValue: (data) => <StyledNodeType>{data?.nodeType}</StyledNodeType>,
+    renderValue: (data) => <StyledNodeType>{data.validationType === "metadata" ? data?.nodeType : "Data File"}</StyledNodeType>,
     field: "nodeType",
   },
   {


### PR DESCRIPTION
### Overview

This is a quick fix for CRDCDH-810, where the "Data File" value wouldn't appear in the Node Type column properly.

> [!NOTE]
> This submission can be used to observe the issue `8a6368a2-9066-4326-b4b2-3f845db83e68`

### Change Details (Specifics)

- Override nodeType property for validationType `data file`

### Related Ticket(s)

CRDCDH-810