### PR TITLE
CRDCDH-886 ICDC-specific props added to File Tran. Manifest DL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7524,8 +7524,8 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/data-model-navigator": {
-      "version": "1.1.22",
-      "resolved": "git+ssh://git@github.com/CBIIT/Data-Model-Navigator.git#ea5a199071066c26f248f630e4225698bcd9619d",
+      "version": "1.1.23",
+      "resolved": "git+ssh://git@github.com/CBIIT/Data-Model-Navigator.git#72d2b5fbbe3fa8dd1cf79bc706088989f2b2be60",
       "license": "ISC",
       "dependencies": {
         "@material-ui/core": "^4.12.4",


### PR DESCRIPTION
### Overview

This PR addresses an issue with the `Data Model Navigator` > `All Data Templates (TSV)` > `File Transfer Manifest` download including ICDC-specific columns added:

- `original_file_size`
- `original_md5sum`

### Change Details (Specifics)

- Update DMN to `v1.1.23`

### Related Ticket(s)

CRDCDH-886
