### PR TITLE
CRDCDH-855 Display Data Model Version in DMN

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7524,8 +7524,8 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/data-model-navigator": {
-      "version": "1.1.25",
-      "resolved": "git+ssh://git@github.com/CBIIT/Data-Model-Navigator.git#fe8959edd0a9abf1499b5050724ad9373740d9bc",
+      "version": "1.1.26",
+      "resolved": "git+ssh://git@github.com/CBIIT/Data-Model-Navigator.git#519debd4ddbefe99818f1ca26885557e0cc48630",
       "license": "ISC",
       "dependencies": {
         "@material-ui/core": "^4.12.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7524,8 +7524,8 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/data-model-navigator": {
-      "version": "1.1.23",
-      "resolved": "git+ssh://git@github.com/CBIIT/Data-Model-Navigator.git#72d2b5fbbe3fa8dd1cf79bc706088989f2b2be60",
+      "version": "1.1.25",
+      "resolved": "git+ssh://git@github.com/CBIIT/Data-Model-Navigator.git#fe8959edd0a9abf1499b5050724ad9373740d9bc",
       "license": "ISC",
       "dependencies": {
         "@material-ui/core": "^4.12.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7525,7 +7525,7 @@
     },
     "node_modules/data-model-navigator": {
       "version": "1.1.26",
-      "resolved": "git+ssh://git@github.com/CBIIT/Data-Model-Navigator.git#519debd4ddbefe99818f1ca26885557e0cc48630",
+      "resolved": "git+ssh://git@github.com/CBIIT/Data-Model-Navigator.git#e34fc0d1fcff499a4224df5a5ec51f2b8e1c1cf2",
       "license": "ISC",
       "dependencies": {
         "@material-ui/core": "^4.12.4",


### PR DESCRIPTION
### Overview

This PR embeds the data model version in the Data Model Navigator header if the `Version` property is set in the model-desc file.

<img width="388" alt="Screenshot 2024-03-06 at 9 17 18 AM" src="https://github.com/CBIIT/crdc-datahub-ui/assets/38357871/178b6e76-680b-4763-b297-b0f3190b3ed6">

> [!note]
> The actual styling differs slightly from Figma to the implementation. Namely the font/font-size.

### Change Details (Specifics)

N/A

### Related Ticket(s)

CRDCDH-855