### PR TITLE
CRDCDH-950 Created Date using wrong date property

### DIFF
--- a/src/content/dataSubmissions/DataSubmissionsListView.tsx
+++ b/src/content/dataSubmissions/DataSubmissionsListView.tsx
@@ -207,7 +207,7 @@ const columns: Column[] = [
   },
   {
     label: "Created Date",
-    value: (a) => (a.createdAt ? FormatDate(a.updatedAt, "M/D/YYYY h:mm A") : ""),
+    value: (a) => (a.createdAt ? FormatDate(a.createdAt, "M/D/YYYY h:mm A") : ""),
     field: "createdAt",
   },
   {


### PR DESCRIPTION
### Overview

This fixes a bug with the Data Submissions list table using the `updateAt` property for the Created Date column.

### Change Details (Specifics)

N/A

### Related Ticket(s)

CRDCDH-950