### PR TITLE
fix: Random AuthContext test case failing in CI

### DIFF
--- a/src/components/Contexts/AuthContext.test.tsx
+++ b/src/components/Contexts/AuthContext.test.tsx
@@ -145,10 +145,11 @@ describe("AuthContext > AuthProvider Tests", () => {
 
     const screen = render(<TestParent mocks={mocks} />);
 
-    await waitFor(() => expect(screen.getByTestId("first-name").textContent).toEqual("The API updated my first name"));
-
-    const cachedUser = JSON.parse(localStorage.getItem("userDetails"));
-    expect(cachedUser.firstName).toEqual("The API updated my first name");
+    await waitFor(() => expect(screen.getByTestId("first-name").textContent).toEqual(mocks[0].result.data.getMyUser.firstName));
+    await waitFor(() => {
+      const cachedUser = JSON.parse(localStorage.getItem("userDetails"));
+      expect(cachedUser.firstName).toEqual(mocks[0].result.data.getMyUser.firstName);
+    }, { timeout: 1000 });
   });
 
   it("should logout the user if the BE API call fails", async () => {


### PR DESCRIPTION
### Overview

This PR aims to fix the random failures of the `should update the localStorage cache when the user is verified` test case for the AuthContext. It appears to be caused by a race condition.

e.g. https://github.com/CBIIT/crdc-datahub-ui/actions/runs/8100132739/job/22137439227

### Change Details (Specifics)

- Wrap the localStorage expectation in a Jest waitFor action which will continue to "re-test" the expect for up to 1 second before failing

### Related Ticket(s)

N/A
