### PR TITLE
CRDCDH-951 Set default Data Submission tab when unspecified

### DIFF
--- a/src/content/dataSubmissions/DataSubmission.tsx
+++ b/src/content/dataSubmissions/DataSubmission.tsx
@@ -6,7 +6,6 @@ import {
   Button,
   Card,
   CardActions,
-  CardActionsProps,
   CardContent,
   Container,
   IconButton,
@@ -117,13 +116,10 @@ const StyledMainContentArea = styled("div")(() => ({
   padding: "21px 40px 0",
 }));
 
-const StyledCardActions = styled(CardActions, {
-  shouldForwardProp: (prop) => prop !== "isVisible"
-})<CardActionsProps & { isVisible: boolean; }>(({ isVisible }) => ({
+const StyledCardActions = styled(CardActions)(() => ({
   "&.MuiCardActions-root": {
-    visibility: isVisible ? "visible" : "hidden",
     paddingTop: 0,
-  }
+  },
 }));
 
 const StyledTabs = styled(Tabs)(() => ({
@@ -337,7 +333,7 @@ type Props = {
   tab: string;
 };
 
-const DataSubmission: FC<Props> = ({ submissionId, tab }) => {
+const DataSubmission: FC<Props> = ({ submissionId, tab = URLTabs.DATA_ACTIVITY }) => {
   usePageTitle(`Data Submission ${submissionId || ""}`);
 
   const { user } = useAuthContext();
@@ -597,7 +593,7 @@ const DataSubmission: FC<Props> = ({ submissionId, tab }) => {
               <BackButton navigateTo="/data-submissions" text="Back to Data Submissions" />
             </StyledMainContentArea>
           </StyledCardContent>
-          <StyledCardActions isVisible={tab === URLTabs.DATA_ACTIVITY}>
+          <StyledCardActions>
             <DataSubmissionActions
               submission={data?.getSubmission}
               onAction={updateSubmissionAction}


### PR DESCRIPTION
### Overview

Updated Data Submission Dashboard to default to `Data Activity` tab when the tab is missing in the URL. Also displaying workflow buttons on any tab.

### Change Details (Specifics)

- Set default tab to `Data Activity` when tab is undefined
- Updated workflow buttons to display them always, regardless of tab selected

### Related Ticket(s)

[CRDCDH-951](https://tracker.nci.nih.gov/browse/CRDCDH-951)
**NOTE:** Bug ticket to fix showing workflow buttons on any tab can't be created due to read-only Jira board, but was verbally discussed
