### PR TITLE
fix: AuthCtx expectation failing

### DIFF
--- a/src/components/Contexts/AuthContext.test.tsx
+++ b/src/components/Contexts/AuthContext.test.tsx
@@ -179,7 +179,8 @@ describe("AuthContext > AuthProvider Tests", () => {
 
     await waitFor(() => expect(screen.getByTestId("isLoggedIn").textContent).toEqual("false"));
 
-    expect(screen.getByTestId("isLoggedIn").textContent).toEqual("false");
-    expect(localStorage.getItem("userDetails")).toBeNull();
+    await waitFor(() => {
+      expect(localStorage.getItem("userDetails")).toBeNull();
+    }, { timeout: 1000 });
   });
 });


### PR DESCRIPTION
### Overview

Another PR to fix incorrectly written assertion in the AuthContext. This one has never failed in CI but just failed locally. See #309 for the same fix applied to a different case.

![Screenshot 2024-03-18 at 12 53 21 PM](https://github.com/CBIIT/crdc-datahub-ui/assets/38357871/b30bf714-c19f-4981-afb5-495172c1b3e3)

### Change Details (Specifics)

- Wrap localStorage accessing in a Jest waitFor stmt
- Remove duplicate expectation 

### Related Ticket(s)

N/A
