### PR TITLE
CRDCDH-973 Fix Model Navigator `<li>` must be in a `<ul>` or `<ol>`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7524,8 +7524,8 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/data-model-navigator": {
-      "version": "1.1.27",
-      "resolved": "git+ssh://git@github.com/CBIIT/Data-Model-Navigator.git#133328d1955ca1cb9379d83076c592f2cde4e6e5",
+      "version": "1.1.28",
+      "resolved": "git+ssh://git@github.com/CBIIT/Data-Model-Navigator.git#fcae239c45f8f190a584591a03d29495b60f657e",
       "license": "ISC",
       "dependencies": {
         "@material-ui/core": "^4.12.4",


### PR DESCRIPTION
### Overview

Minor MVP-2 M3 fix for Data Model Navigator. The search result container was overriding the default `ul` component and using a `div` instead, making it a invalid DOM structure

<img width="332" alt="Screenshot 2024-04-01 at 12 36 04 PM" src="https://github.com/CBIIT/crdc-datahub-ui/assets/38357871/c3815f48-d722-4a08-beef-a7cb8d7d12dc">

### Change Details (Specifics)

- https://github.com/CBIIT/Data-Model-Navigator/commit/142be38dd19c5304232cc6105e4b88d54ca90a01

### Related Ticket(s)

CRDCDH-973
