### PR TITLE
CRDCDH-974 Auto refresh Validation Results table on validate complete

### DIFF
--- a/src/content/dataSubmissions/DataSubmission.tsx
+++ b/src/content/dataSubmissions/DataSubmission.tsx
@@ -481,6 +481,8 @@ const DataSubmission: FC<Props> = ({ submissionId, tab = URLTabs.DATA_ACTIVITY }
       return;
     }
 
+    // NOTE: Immediately update submission object to get "Validating" status
+    getSubmission();
     startPolling(60000);
   };
 
@@ -583,7 +585,7 @@ const DataSubmission: FC<Props> = ({ submissionId, tab = URLTabs.DATA_ACTIVITY }
                     containerProps={{ sx: { marginBottom: "8px" } }}
                   />
                 </BatchTableContext.Provider>
-              ) : <QualityControl />}
+              ) : <QualityControl submission={data?.getSubmission} />}
 
               {/* Return to Data Submission List Button */}
               <BackButton navigateTo="/data-submissions" text="Back to Data Submissions" />

--- a/src/content/dataSubmissions/QualityControl.tsx
+++ b/src/content/dataSubmissions/QualityControl.tsx
@@ -153,7 +153,11 @@ const columns: Column<QCResult>[] = [
   },
 ];
 
-const QualityControl: FC = () => {
+type Props = {
+  submission: Submission;
+};
+
+const QualityControl: FC<Props> = ({ submission }: Props) => {
   const { submissionId } = useParams();
   const { watch, control } = useForm<FilterForm>();
 
@@ -252,6 +256,10 @@ const QualityControl: FC = () => {
   useEffect(() => {
     tableRef.current?.setPage(0, true);
   }, [watch("nodeType"), watch("batchID"), watch("severity")]);
+
+  useEffect(() => {
+    tableRef.current?.refresh();
+  }, [submission?.metadataValidationStatus, submission?.fileValidationStatus]);
 
   return (
     <>


### PR DESCRIPTION
### Overview

MVP-2.1.0 PR to auto refresh the Validation Results table upon starting or finishing the validation process. Also includes a bug fix for the Validation button itself, where it would never change from "Validating..." if the metadata/file validation status remained the same.

e.g. You validate one time and `metadataValidationStatus` is `Error`. You validate again, without uploading anything new, the status quickly becomes `Error` again and the button never sees any change from `Error` -> `Validating` -> `Error` so it just stays `Validating`

### Change Details (Specifics)

- Force immediate Data Submission refetch on validate (bug)
- Refresh QC Results table any time the validation properties update (linked ticket)

### Related Ticket(s)

CRDCDH-974
