### PR TITLE
CRDCDH-999 Fix collapsed whitespace in Model Navigator value list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7524,8 +7524,8 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/data-model-navigator": {
-      "version": "1.1.28",
-      "resolved": "git+ssh://git@github.com/CBIIT/Data-Model-Navigator.git#fcae239c45f8f190a584591a03d29495b60f657e",
+      "version": "1.1.29",
+      "resolved": "git+ssh://git@github.com/CBIIT/Data-Model-Navigator.git#747af34f379e272b0077b254a1d0d04ab4a6d527",
       "license": "ISC",
       "dependencies": {
         "@material-ui/core": "^4.12.4",


### PR DESCRIPTION
### Overview

Minor Data Model Navigator bug fix to respect the whitespace defined in node property "Acceptable Values". This issue is present in `Table View` > `Data File` > `Image` > `license` property

Before:

<img width="371" alt="Screenshot 2024-04-02 at 4 44 28 PM" src="https://github.com/CBIIT/crdc-datahub-ui/assets/38357871/5c02ef7f-cf84-4c21-89f0-30cbd3541a8f">

After:

<img width="371" alt="Screenshot 2024-04-02 at 4 22 00 PM" src="https://github.com/CBIIT/crdc-datahub-ui/assets/38357871/a3096808-03d8-4bba-a700-40a3b1b54fb5">

### Change Details (Specifics)

- See DMN commit https://github.com/CBIIT/Data-Model-Navigator/commit/d692c5cf99b48ec25a44facd31a78dbf078d2800

### Related Ticket(s)

N/A
