### PR TITLE
DX: Enable TypeScript Lib Check (d.ts) Files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
         "eslint-config-airbnb-typescript": "^17.0.0",
         "eslint-plugin-jsx-a11y": "^6.8.0",
         "jest-axe": "^8.0.0",
-        "typescript": "^5.0.4"
+        "typescript": "^5.4.3"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -17451,9 +17451,10 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.1.3",
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.3.tgz",
+      "integrity": "sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==",
       "dev": true,
-      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "web-vitals": "^2.1.4"
   },
   "overrides": {
-    "typescript": "^5.0.4"
+    "typescript": "^5.4.3"
   },
   "scripts": {
     "start": "react-scripts start",
@@ -87,6 +87,6 @@
     "eslint-config-airbnb-typescript": "^17.0.0",
     "eslint-plugin-jsx-a11y": "^6.8.0",
     "jest-axe": "^8.0.0",
-    "typescript": "^5.0.4"
+    "typescript": "^5.4.3"
   }
 }

--- a/src/types/ProgramConfig.d.ts
+++ b/src/types/ProgramConfig.d.ts
@@ -1,5 +1,5 @@
 type ProgramOption = Program & {
-  editable?: boolean = false;
+  editable?: boolean;
 };
 
 type StudyOption = Omit<Study, "description" | "publications" | "plannedPublications" | "repositories" | "funding" | "isDbGapRegistered" | "dbGaPPPHSNumber"> & {

--- a/src/types/Submissions.d.ts
+++ b/src/types/Submissions.d.ts
@@ -56,16 +56,6 @@ type SubmissionIntention =
   | "Update"
   | "Delete";
 
-type FileInfo = {
-  filePrefix: string; // prefix/path within S3 bucket
-  fileName: string;
-  size: number;
-  status: string; // [New, Uploaded, Failed]
-  errors: string[];
-  createdAt: string; // ISO 8601 date time format with UTC or offset e.g., 2023-05-01T09:23:30Z
-  updatedAt: string; // ISO 8601 date time format with UTC or offset e.g., 2023-05-01T09:23:30Z
-};
-
 type FileInput = {
   fileName: string;
   size: number;
@@ -168,7 +158,7 @@ type S3FileInfo = {
   updatedAt: string;
 };
 
-type ParentNode = {
+type RecordParentNode = {
   parentType: string; // node type of the parent node, e.g. "study"
   parentIDPropName: string; // ID property name can be used to identify parent node, e.g., "study_id"
   parentIDValue: string; // Value for above ID property, e.g. "CDS-study-007"
@@ -212,7 +202,7 @@ type DataRecord = {
   nodeType: string; // type of the node, in "type" column of the file
   nodeID: string; // ID of the node, for example: "cds-case-99907"
   // props: Properties; // properties of the node
-  parents: ParentNode[];
+  parents: RecordParentNode[];
   // relationshipProps: [RelationshipProperty] # for future use
   // rawData: RawData
   s3FileInfo: S3FileInfo; // only for "file" types, should be null for other nodes

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     ],
     "allowJs": true,
     "checkJs": true,
-    "skipLibCheck": true,
+    "skipLibCheck": false,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "strict": false,


### PR DESCRIPTION
### Overview

This PR is tangentially related to #262 and enables checking of library (d.ts) files in TypeScript. Enabling this check identified the following issues in our definitions:

> Error: src/types/Application.d.ts(133,6): error TS2300: Duplicate identifier 'FileInfo'.
> Error: src/types/ProgramConfig.d.ts(2,24): error TS1247: A type literal property cannot have an initializer.
> Error: src/types/Submissions.d.ts(59,6): error TS2300: Duplicate identifier 'FileInfo'.
> Error: src/types/Submissions.d.ts(171,6): error TS2300: Duplicate identifier 'ParentNode'.

This change will also enable us to identify any future unresolved types or invalid syntax. e.g.

![Screenshot 2024-04-03 at 10 40 34 AM](https://github.com/CBIIT/crdc-datahub-ui/assets/38357871/b1f96205-b2a0-41c9-8d0b-61bd23bae673)

![Screenshot 2024-04-03 at 10 40 08 AM](https://github.com/CBIIT/crdc-datahub-ui/assets/38357871/12d3ecd7-6bb0-477f-aa0e-10c0a5cfc2a0)


### Change Details (Specifics)

- Upgrade TypeScript to v5.4.3 – This should have no breaking changes for us ([source](https://github.com/microsoft/TypeScript/wiki/API-Breaking-Changes))
- Remove unused `FileInfo` definition for Submissions.d.ts (identical to BatchFileInfo) ([source](https://github.com/CBIIT/crdc-datahub-backend/blob/3.0.0/resources/graphql/crdc-datahub.graphql))
- Remove invalid initializer on `ProgramOption`
- Rename `ParentNode` to `RecordParentNode`

### Related Ticket(s)

N/A
