### PR TITLE
CRDCDH-1039 Show error when validation API call fails

### DIFF
--- a/src/components/DataSubmissions/ValidationControls.tsx
+++ b/src/components/DataSubmissions/ValidationControls.tsx
@@ -155,7 +155,7 @@ const ValidationControls: FC<Props> = ({ dataSubmission, onValidate }: Props) =>
         types: getValidationTypes(validationType),
         scope: uploadType === "New" ? "New" : "All",
       }
-    });
+    }).catch((e) => ({ errors: e?.message, data: null }));
 
     if (errors || !data?.validateSubmission?.success) {
       enqueueSnackbar("Unable to initiate validation process.", { variant: "error" });


### PR DESCRIPTION
### Overview

When `validateSubmission` API was called, it was not properly catching the errors, therefore was not showing error message and enabling the validation button after failing.

### Change Details (Specifics)

- Added a catch for API errors

### Related Ticket(s)

[CRDCDH-1039](https://tracker.nci.nih.gov/browse/CRDCDH-1039)
