### PR TITLE
Hotfix: Fixed validate button missing dep

### DIFF
--- a/src/components/DataSubmissions/ValidationControls.tsx
+++ b/src/components/DataSubmissions/ValidationControls.tsx
@@ -172,7 +172,7 @@ const ValidationControls: FC<Props> = ({ dataSubmission, onValidate }: Props) =>
         {isValidating ? "Validating..." : "Validate"}
       </StyledValidateButton>
     ),
-    [canValidateFiles, canValidateMetadata, isValidating, isLoading]
+    [validationType, canValidateFiles, canValidateMetadata, isValidating, isLoading]
   );
 
   useEffect(() => {


### PR DESCRIPTION
### Overview

The `validationType` was showing as null resulting in validation never happening. Memoization was missing dependency.

### Change Details (Specifics)

N/A

### Related Ticket(s)

N/A
