### PR TITLE
Hotfix: Added uploadType and dataSubmission to deps array for validate button

### DIFF
--- a/src/components/DataSubmissions/ValidationControls.tsx
+++ b/src/components/DataSubmissions/ValidationControls.tsx
@@ -173,8 +173,7 @@ const ValidationControls: FC<Props> = ({ dataSubmission, onValidate }: Props) =>
       </StyledValidateButton>
     ),
     [
-      validationType,
-      uploadType,
+      handleValidateFiles,
       dataSubmission,
       canValidateFiles,
       canValidateMetadata,

--- a/src/components/DataSubmissions/ValidationControls.tsx
+++ b/src/components/DataSubmissions/ValidationControls.tsx
@@ -172,7 +172,15 @@ const ValidationControls: FC<Props> = ({ dataSubmission, onValidate }: Props) =>
         {isValidating ? "Validating..." : "Validate"}
       </StyledValidateButton>
     ),
-    [validationType, canValidateFiles, canValidateMetadata, isValidating, isLoading]
+    [
+      validationType,
+      uploadType,
+      dataSubmission,
+      canValidateFiles,
+      canValidateMetadata,
+      isValidating,
+      isLoading,
+    ]
   );
 
   useEffect(() => {


### PR DESCRIPTION
### Overview

Added additional `uploadType` and `dataSubmission` to deps of the memoized validate button. Please double check that I didn't miss any additional missing deps.

### Change Details (Specifics)

N/A

### Related Ticket(s)

N/A
