### PR TITLE
Restore Create a Data Submission Intention spacing

### DIFF
--- a/src/content/dataSubmissions/CreateDataSubmissionDialog.tsx
+++ b/src/content/dataSubmissions/CreateDataSubmissionDialog.tsx
@@ -177,6 +177,7 @@ const StyledRadioInput = styled(RadioInput)(() => ({
   },
   "& .MuiFormControlLabel-root": {
     marginRight: "0 !important",
+    paddingRight: "10px !important",
   },
 }));
 
@@ -546,7 +547,6 @@ const CreateDataSubmissionDialog: FC<Props> = ({ organizations, onCreate }) => {
         <StyledButton
           type="button"
           onClick={handleOpenDialog}
-          loading={creatingSubmission}
           sx={{ bottom: "30px", right: "50px" }}
           disabled={!hasOrganizationAssigned}
         >


### PR DESCRIPTION
### Overview

This is a PR to restore the original spacing between the radio inputs on the "Create Data Submission" dialog, which was messed up by #340 – See below

<details><summary>Previous (bad)</summary>
<p>
<img width="601" alt="Screenshot 2024-04-29 at 10 21 26 AM" src="https://github.com/CBIIT/crdc-datahub-ui/assets/38357871/c57f4625-52d1-48a4-82f1-73785655eb8e">
</p>
</details> 

<details><summary>Restored (correct)</summary>
<p>
<img width="601" alt="Screenshot 2024-04-29 at 10 15 34 AM" src="https://github.com/CBIIT/crdc-datahub-ui/assets/38357871/786cf6fe-bcc4-4790-93a1-ef16908d90e9">
</p>
</details> 

Also remove the MUI loading indicator that appears when the create submission dialog is open, which shouldn't be implemented. See below

<details><summary>Before</summary>
<p>
<img width="601" alt="Screenshot 2024-04-29 at 10 21 57 AM" src="https://github.com/CBIIT/crdc-datahub-ui/assets/38357871/f5afb14f-5137-422f-8adc-3254111366fd">
</p>
</details> 

<details><summary>After</summary>
<p>
<img width="601" alt="Screenshot 2024-04-29 at 10 21 35 AM" src="https://github.com/CBIIT/crdc-datahub-ui/assets/38357871/e9c00cd8-393e-424e-9724-ea3e03059c11">
</p>
</details> 

### Change Details (Specifics)

- Override Data Submission RadioInput styling for the create submission dialog
- Remove dynamic loading attribute from "Create a Data Submission" button

### Related Ticket(s)

N/A 
