### PR TITLE
CRDCDH-1083 Model Navigator `File` node missing name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7524,8 +7524,8 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/data-model-navigator": {
-      "version": "1.1.29",
-      "resolved": "git+ssh://git@github.com/CBIIT/Data-Model-Navigator.git#747af34f379e272b0077b254a1d0d04ab4a6d527",
+      "version": "1.1.30",
+      "resolved": "git+ssh://git@github.com/CBIIT/Data-Model-Navigator.git#dd58d548ec49043636989ff76b21852d41b9396c",
       "license": "ISC",
       "dependencies": {
         "@material-ui/core": "^4.12.4",
@@ -17394,7 +17394,6 @@
     },
     "node_modules/typescript": {
       "version": "5.1.3",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/src/config/DataCommons.ts
+++ b/src/config/DataCommons.ts
@@ -26,6 +26,7 @@ export const DataCommons: DataCommon[] = [
         fileType: 'pdf',
         prefix: 'CDS_',
         downloadPrefix: 'CDS_',
+        fileTransferManifestName: "CDS_Data_Loading_Template-file-manifest",
         iconSrc: logo,
         footnote: "https://hub.datacommons.cancer.gov/model-navigator/CDS",
         landscape: true,

--- a/src/types/DataModelNavigator.d.ts
+++ b/src/types/DataModelNavigator.d.ts
@@ -27,6 +27,12 @@ type ModelNavigatorConfig = {
      */
     downloadPrefix?: string;
     /**
+     * The default name for a Node file download
+     *
+     * Falls back to the `downloadPrefix` if not provided.
+     */
+    fileTransferManifestName?: string;
+    /**
      * Override default ICDC URL in PDF footers
      */
     footnote: string;


### PR DESCRIPTION
### Overview

Upgrades Model Navigator to 1.1.30 which adds a new configuration option for specifying the File Transfer Manifest filename. Per request, this is used in:

- Single template TSV for the "File" node
- All template TSV zip package

### Change Details (Specifics)

- Update Model Navigator (See https://github.com/CBIIT/Data-Model-Navigator/compare/dd58d548ec49043636989ff76b21852d41b9396c..747af34f379e272b0077b254a1d0d04ab4a6d527)
- Update type definition for the model navigator config object

### Related Ticket(s)

CRDCDH-1083
