### PR TITLE
CRDCDH-1080 Updated Submission Name input validation to trim whitespace

### DIFF
--- a/src/content/dataSubmissions/DataSubmissionsListView.tsx
+++ b/src/content/dataSubmissions/DataSubmissionsListView.tsx
@@ -639,6 +639,7 @@ const ListingView: FC = () => {
               required
               label="Submission Name"
               placeholder="25 characters allowed"
+              validate={(v: string) => v?.trim()?.length > 0}
             />
           </form>
 


### PR DESCRIPTION
### Overview

Updated the validation for the "Submission Name" input field to trim the whitespace first.

### Change Details (Specifics)

> [!Note]
> This will require a different implementation in `3.0.0` branch since it was refactored and updated to use `react-hook-form`.
> PMVP fix implemented in #355 

### Related Ticket(s)

[CRDCDH-1080](https://tracker.nci.nih.gov/browse/CRDCDH-1080)
