### PR TITLE
fix: Submission Name validation not allowing submit

### DIFF
--- a/src/content/dataSubmissions/CreateDataSubmissionDialog.tsx
+++ b/src/content/dataSubmissions/CreateDataSubmissionDialog.tsx
@@ -365,7 +365,7 @@ const CreateDataSubmissionDialog: FC<Props> = ({ organizations, onCreate }) => {
     setValue("dbGaPID", approvedStudiesMapToDbGaPID[value]);
   };
 
-  const validateEmpty = (value: string) => (!value?.trim() ? "This field is required" : "");
+  const validateEmpty = (value: string) => (!value?.trim() ? "This field is required" : null);
 
   return (
     <>


### PR DESCRIPTION
### Overview

This PR fixes an issue with creating a submission, where the createSubmission API is never called. 

To verify:

- Fill out the form WITHOUT causing any validation issues
- it should now send the API request

I wasn't able to replicate this when originally testing #355, so it's possible there's an issue beyond this – But this solution is working locally.

### Change Details (Specifics)

- Return `null` from the `validateEmpty` function if there's no issue

### Related Ticket(s)

N/A
