### PR TITLE
feat: Fetch session info without `userDetails` on local

### DIFF
--- a/conf/inject.template.js
+++ b/conf/inject.template.js
@@ -6,6 +6,7 @@ window.injectedEnv = {
     REACT_APP_NIH_CLIENT_ID: '${REACT_APP_NIH_CLIENT_ID}',
     REACT_APP_NIH_AUTHORIZE_URL: '${NIH_AUTHORIZE_URL}',
     REACT_APP_NIH_REDIRECT_URL: '${REACT_APP_NIH_REDIRECT_URL}',
+    // @ts-ignore - Injected with real value during build
     REACT_APP_DEV_TIER: '${DEV_TIER}',
     REACT_APP_UPLOADER_CLI: '${REACT_APP_UPLOADER_CLI}',
 };

--- a/public/js/injectEnv.js
+++ b/public/js/injectEnv.js
@@ -2,6 +2,7 @@ window.injectedEnv = {
   REACT_APP_NIH_AUTHORIZE_URL: '',
   REACT_APP_NIH_CLIENT_ID: '',
   REACT_APP_NIH_REDIRECT_URL: '',
+  // @ts-ignore - Replaced during build
   REACT_APP_DEV_TIER: '',
   REACT_APP_UPLOADER_CLI: '',
   REACT_APP_GA_TRACKING_ID: '',

--- a/src/components/Contexts/AuthContext.tsx
+++ b/src/components/Contexts/AuthContext.tsx
@@ -152,7 +152,7 @@ export const AuthProvider: FC<ProviderProps> = ({ children }: ProviderProps) => 
   useEffect(() => {
     (async () => {
       // User had an active session, reverify with BE
-      if (cachedState) {
+      if (cachedState || env?.NODE_ENV === "development") {
         const { data, error } = await getMyUser();
         if (error || !data?.getMyUser) {
           setState({ ...initialState, status: Status.LOADED });

--- a/src/types/AppEnv.d.ts
+++ b/src/types/AppEnv.d.ts
@@ -1,5 +1,11 @@
 type AppEnv = {
   /**
+   * Current environment
+   *
+   * @note `test` is used by Jest
+   */
+  NODE_ENV: "test" | "development" | "production";
+  /**
    * NIH SSO Url
    */
   REACT_APP_NIH_AUTHORIZE_URL: string;
@@ -19,11 +25,8 @@ type AppEnv = {
   REACT_APP_BACKEND_API: string;
   /**
    * Current deployment tier
-   *
-   * @example DEV2
-   * @example PROD
    */
-  REACT_APP_DEV_TIER: string;
+  REACT_APP_DEV_TIER: "dev" | "dev2" | "qa" | "qa2" | "stage" | "prod";
   /**
    * Fully-qualified URL to the Uploader CLI zip download
    *


### PR DESCRIPTION
### Overview

This PR is a QoL update for local development until CRDCDH-591 is fixed. When going through the login process locally, a developer only needs to copy the `connect.sid` cookie from DEV/DEV2, then reload. You no longer need to copy the `userDetails` localStorage value.

### Change Details (Specifics)

- Refetch user status without `userDetails` localStorage value if running local dev server
- Add `NODE_ENV` to `AppEnv` definition (no .env updates needed)
- Add string constraints to `REACT_APP_DEV_TIER`

### Related Ticket(s)

N/A
