### PR TITLE
CRDCDH-1125 Fix Active Submissions Dialog

### DIFF
--- a/src/content/organizations/OrganizationView.tsx
+++ b/src/content/organizations/OrganizationView.tsx
@@ -219,10 +219,16 @@ const OrganizationView: FC<Props> = ({ _id }: Props) => {
 
   const handlePreSubmit = (data: FormInput) => {
     if (_id !== "new") {
+      const studyMap: { [_id: string]: ApprovedStudy["studyAbbreviation"] } = {};
+      approvedStudies?.listApprovedStudies?.forEach(({ _id, studyAbbreviation }) => {
+        studyMap[_id] = studyAbbreviation;
+      });
+
+      const newStudies = data.studies.map((_id) => studyMap[_id]);
       const previousStudies = organization?.studies?.map((s) => s?.studyAbbreviation) || [];
       const removedActiveStudies = previousStudies
-        .filter((s) => !data.studies?.includes(s))
-        .filter((s) => assignedStudies.includes(s))
+        .filter((studyAbbr) => !newStudies?.includes(studyAbbr))
+        .filter((studyAbbr) => assignedStudies.includes(studyAbbr))
         .length;
 
       // If there are active submissions for a study being removed, show a warning


### PR DESCRIPTION
### Overview

This PR addresses an issue with the active data submissions dialog that appears when removing a study from an organization. Some refactoring in M3 caused the logic to break, always showing the confirmation dialog, even when no studies were removed. 

### Change Details (Specifics)

- Map the form selectbox input from a Study ID back to a Study Abbreviation before comparing whether or not a study was removed

### Related Ticket(s)

CRDCDH-1125 (Bug)
CRDCDH-860 (Broke the feature)
CRDCDH-689 (Original Feature)
