### PR TITLE
CRDCDH-1137 Allow validation in Submitted state

### DIFF
--- a/src/utils/dataValidationUtils.ts
+++ b/src/utils/dataValidationUtils.ts
@@ -19,11 +19,26 @@ export const getValidationTypes = (validationType: ValidationType): string[] => 
  * Determines the default "Validation Type" for the given data submission.
  *
  * @param dataSubmission The data submission to get the default validation type for.
+ * @param user The current user.
+ * @param permissionMap The map of permissions for each submission status.
  * @returns The default validation type for the given data submission.
  */
-export const getDefaultValidationType = (dataSubmission: Submission): ValidationType => {
-  const { metadataValidationStatus, fileValidationStatus } = dataSubmission || {};
+export const getDefaultValidationType = (
+  dataSubmission: Submission,
+  user: User,
+  permissionMap: Partial<Record<Submission["status"], User["role"][]>>
+): ValidationType => {
+  const { role } = user || {};
+  const { status, metadataValidationStatus, fileValidationStatus } = dataSubmission || {};
 
+  if (
+    status === "Submitted"
+    && permissionMap["Submitted"]?.includes(role)
+    && metadataValidationStatus
+    && fileValidationStatus
+  ) {
+    return "All";
+  }
   if (metadataValidationStatus !== null) {
     return "Metadata";
   }
@@ -32,4 +47,26 @@ export const getDefaultValidationType = (dataSubmission: Submission): Validation
   }
 
   return "Metadata";
+};
+
+/**
+ * Determines the default Validation Target.
+ *
+ * @param dataSubmission The data submission to get the default validation type for.
+ * @param user The current user.
+ * @param permissionMap The map of permissions for each submission status.
+ */
+export const getDefaultValidationTarget = (
+  dataSubmission: Submission,
+  user: User,
+  permissionMap: Partial<Record<Submission["status"], User["role"][]>>
+): ValidationTarget => {
+  const { role } = user || {};
+  const { status } = dataSubmission || {};
+
+  if (status === "Submitted" && permissionMap["Submitted"]?.includes(role)) {
+    return "All";
+  }
+
+  return "New";
 };


### PR DESCRIPTION
### Overview

This PR covers a missing requirement that Data Curators or Admins should be able to validate a Submitted data submission. These changes should only effect Data Curators and Admins for a Data Submission in the "Submitted" state – Nothing else should change...

> [!NOTE]
> When migrating to v3.0.0, I have test coverage for these changes written already, I just need to migrate them.

### Change Details (Specifics)

- Rewrite the validate permission map to be a simplified object.
  - `Key`: Submission Status
  - `Value`: List of Roles that can validate
- Create a util to determine what the default Validation Target should be, we had one for the Validation Type already
- Disable "New" validation target if the submission is Submitted
  - This is already disabled in statuses beyond "Submitted"

### Related Ticket(s)

CRDCDH-1137
