### PR TITLE
CRDCDH-1138 Reduce Data Submission polling from 60s to 1s

### DIFF
--- a/src/components/DataSubmissions/BackButton.tsx
+++ b/src/components/DataSubmissions/BackButton.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import React, { FC } from 'react';
 import { useNavigate } from 'react-router-dom';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import { Button, ButtonProps, styled } from '@mui/material';
@@ -49,4 +49,4 @@ const BackButton: FC<Props> = ({ text = "Back", navigateTo }) => {
   );
 };
 
-export default BackButton;
+export default React.memo(BackButton);

--- a/src/components/DataSubmissions/DataSubmissionSummary.tsx
+++ b/src/components/DataSubmissions/DataSubmissionSummary.tsx
@@ -6,7 +6,8 @@ import {
   Typography,
   styled,
 } from "@mui/material";
-import { FC, useEffect, useMemo, useRef, useState } from "react";
+import React, { FC, useEffect, useMemo, useRef, useState } from "react";
+import { isEqual } from "lodash";
 import SubmissionHeaderProperty, {
   StyledValue,
 } from "./SubmissionHeaderProperty";
@@ -331,4 +332,4 @@ const DataSubmissionSummary: FC<Props> = ({ dataSubmission }) => {
   );
 };
 
-export default DataSubmissionSummary;
+export default React.memo<Props>(DataSubmissionSummary, (prevProps, nextProps) => isEqual(prevProps, nextProps));

--- a/src/components/DataSubmissions/DataSubmissionUpload.tsx
+++ b/src/components/DataSubmissions/DataSubmissionUpload.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useMutation } from "@apollo/client";
 import { useParams } from "react-router-dom";
 import { LoadingButton } from "@mui/lab";
+import { isEqual } from "lodash";
 import { VariantType } from "notistack";
 import {
   Button,
@@ -347,4 +348,4 @@ const DataSubmissionUpload = ({ submission, readOnly, onCreateBatch, onUpload }:
   );
 };
 
-export default DataSubmissionUpload;
+export default React.memo<Props>(DataSubmissionUpload, (prevProps, nextProps) => isEqual(prevProps, nextProps));

--- a/src/components/DataSubmissions/LinkTab.tsx
+++ b/src/components/DataSubmissions/LinkTab.tsx
@@ -1,5 +1,5 @@
 import { Tab, TabProps, styled } from "@mui/material";
-import { ElementType } from "react";
+import React, { ElementType } from "react";
 import { Link, LinkProps } from "react-router-dom";
 
 const StyledTab = styled(Tab, {
@@ -62,4 +62,4 @@ const LinkTab = ({ label, value, to, selected }: Props) => (
   />
 );
 
-export default LinkTab;
+export default React.memo(LinkTab);

--- a/src/components/DataSubmissions/ValidationControls.tsx
+++ b/src/components/DataSubmissions/ValidationControls.tsx
@@ -1,7 +1,8 @@
-import { FC, useEffect, useMemo, useState } from 'react';
+import React, { FC, useEffect, useMemo, useState } from 'react';
 import { useMutation } from '@apollo/client';
 import { FormControlLabel, RadioGroup, Stack, styled } from '@mui/material';
 import { LoadingButton } from '@mui/lab';
+import { isEqual } from 'lodash';
 import { useSnackbar } from 'notistack';
 import { useAuthContext } from '../Contexts/AuthContext';
 import StyledRadioButton from "../Questionnaire/StyledRadioButton";
@@ -12,21 +13,6 @@ import {
   getValidationTypes,
 } from "../../utils";
 import FlowWrapper from './FlowWrapper';
-
-type Props = {
-  /**
-   * The data submission to display validation controls for.
-   *
-   * NOTE: Initially null during the loading state.
-   */
-  dataSubmission?: Submission;
-  /**
-   * Callback function called when the validating is initiated.
-   *
-   * @param success whether the validation was successfully initiated
-   */
-  onValidate: (success: boolean) => void;
-};
 
 const StyledValidateButton = styled(LoadingButton)({
   padding: "10px",
@@ -114,6 +100,21 @@ const ValidateMap: Partial<Record<Submission["status"], User["role"][]>> = {
   Withdrawn: BaseValidateRoles,
   Rejected: BaseValidateRoles,
   Submitted: ["Data Curator", "Admin"],
+};
+
+type Props = {
+  /**
+   * The data submission to display validation controls for.
+   *
+   * NOTE: Initially null during the loading state.
+   */
+  dataSubmission?: Submission;
+  /**
+   * Callback function called when the validating is initiated.
+   *
+   * @param success whether the validation was successfully initiated
+   */
+  onValidate: (success: boolean) => void;
 };
 
 /**
@@ -291,4 +292,4 @@ const ValidationControls: FC<Props> = ({ dataSubmission, onValidate }: Props) =>
   );
 };
 
-export default ValidationControls;
+export default React.memo<Props>(ValidationControls, (prevProps, nextProps) => isEqual(prevProps, nextProps));

--- a/src/content/dataSubmissions/DataSubmission.tsx
+++ b/src/content/dataSubmissions/DataSubmission.tsx
@@ -37,7 +37,7 @@ import QualityControl from "./QualityControl";
 import { ReactComponent as CopyIconSvg } from "../../assets/icons/copy_icon_2.svg";
 import ErrorDialog from "./ErrorDialog";
 import BatchTableContext from "./Contexts/BatchTableContext";
-import DataSubmissionStatistics from '../../components/DataSubmissions/ValidationStatistics';
+import ValidationStatistics from '../../components/DataSubmissions/ValidationStatistics';
 import ValidationControls from '../../components/DataSubmissions/ValidationControls';
 import { useAuthContext } from "../../components/Contexts/AuthContext";
 import FileListDialog from "./FileListDialog";
@@ -343,17 +343,30 @@ const DataSubmission: FC<Props> = ({ submissionId, tab = URLTabs.DATA_ACTIVITY }
   const [totalBatches, setTotalBatches] = useState<number>(0);
   const [hasUploadingBatches, setHasUploadingBatches] = useState<boolean>(false);
   const [prevBatchFetch, setPrevBatchFetch] = useState<FetchListing<Batch>>(null);
-  const [batchRefreshTimeout, setBatchRefreshTimeout] = useState<NodeJS.Timeout>(null);
   const [error, setError] = useState<string>(null);
   const [loading, setLoading] = useState<boolean>(false);
   const [openErrorDialog, setOpenErrorDialog] = useState<boolean>(false);
   const [openFileListDialog, setOpenFileListDialog] = useState<boolean>(false);
   const [selectedRow, setSelectedRow] = useState<Batch | null>(null);
+  const [startBatchPolling, setStartBatchPolling] = useState<((pollInterval: number) => void) | null>(null);
+  const [stopBatchPolling, setStopBatchPolling] = useState<(() => void) | null>(null);
+  const [lastValidationTime, setLastValidationTime] = useState(Date.now());
+
+  const onRetrieveSubmission = () => {
+    setLastValidationTime(Date.now());
+    if (data?.getSubmission?.fileValidationStatus !== "Validating" && data?.getSubmission?.metadataValidationStatus !== "Validating") {
+      stopPolling();
+    } else {
+      startPolling(1000);
+    }
+  };
 
   const {
     data, error: submissionError,
     startPolling, stopPolling, refetch: getSubmission,
   } = useQuery<GetSubmissionResp>(GET_SUBMISSION, {
+    notifyOnNetworkStatusChange: true,
+    onCompleted: onRetrieveSubmission,
     variables: { id: submissionId },
     context: { clientName: 'backend' },
     fetchPolicy: 'no-cache',
@@ -373,7 +386,15 @@ const DataSubmission: FC<Props> = ({ submissionId, tab = URLTabs.DATA_ACTIVITY }
     [data?.getSubmission, user, hasUploadingBatches]
   );
 
+  const onRetrievebatches = (data: ListBatchesResp) => {
+    setBatches(data.listBatches.batches);
+    setTotalBatches(data.listBatches.total);
+    setHasUploadingBatches(data.fullStatusList.batches.some((b) => b.status === "Uploading"));
+  };
+
   const [listBatches] = useLazyQuery<ListBatchesResp>(LIST_BATCHES, {
+    notifyOnNetworkStatusChange: true,
+    onCompleted: onRetrievebatches,
     context: { clientName: 'backend' },
     fetchPolicy: 'no-cache'
   });
@@ -397,7 +418,7 @@ const DataSubmission: FC<Props> = ({ submissionId, tab = URLTabs.DATA_ACTIVITY }
 
     try {
       setLoading(true);
-      const { data: newBatchFiles, error: batchFilesError } = await listBatches({
+      const { data: newBatchFiles, error: batchFilesError, startPolling, stopPolling } = await listBatches({
         variables: {
           submissionID: submissionId,
           first,
@@ -412,9 +433,15 @@ const DataSubmission: FC<Props> = ({ submissionId, tab = URLTabs.DATA_ACTIVITY }
         setError("Unable to retrieve batch data.");
         return;
       }
-      setBatches(newBatchFiles.listBatches.batches);
-      setTotalBatches(newBatchFiles.listBatches.total);
-      setHasUploadingBatches(newBatchFiles.fullStatusList.batches.some((b) => b.status === "Uploading"));
+
+      const hasUploading = newBatchFiles.fullStatusList?.batches?.some((b) => b.status === "Uploading");
+
+      if (hasUploading) {
+        setStartBatchPolling(() => startPolling);
+        setStopBatchPolling(() => stopPolling);
+      }
+
+      // See onRetrievebatches for state updates
     } catch (err) {
       setError("Unable to retrieve batch data.");
     } finally {
@@ -483,7 +510,7 @@ const DataSubmission: FC<Props> = ({ submissionId, tab = URLTabs.DATA_ACTIVITY }
 
     // NOTE: Immediately update submission object to get "Validating" status
     getSubmission();
-    startPolling(60000);
+    startPolling(1000);
   };
 
   const providerValue = useMemo(() => ({
@@ -500,24 +527,18 @@ const DataSubmission: FC<Props> = ({ submissionId, tab = URLTabs.DATA_ACTIVITY }
   }, [submissionError]);
 
   useEffect(() => {
-    if (data?.getSubmission?.fileValidationStatus !== "Validating" && data?.getSubmission?.metadataValidationStatus !== "Validating") {
-      stopPolling();
-    } else {
-      startPolling(60000);
-    }
-  }, [data?.getSubmission?.fileValidationStatus, data?.getSubmission?.metadataValidationStatus]);
-
-  useEffect(() => {
-    if (!hasUploadingBatches && batchRefreshTimeout) {
-      clearInterval(batchRefreshTimeout);
-      setBatchRefreshTimeout(null);
+    if (!hasUploadingBatches && stopBatchPolling) {
+      stopBatchPolling();
       getSubmission();
-    } else if (!batchRefreshTimeout && hasUploadingBatches) {
-      setBatchRefreshTimeout(setInterval(refreshBatchTable, 60000));
-    }
 
-    return () => clearInterval(batchRefreshTimeout);
-  }, [hasUploadingBatches]);
+      setStartBatchPolling(null);
+      setStopBatchPolling(null);
+      return;
+    }
+    if (hasUploadingBatches && startBatchPolling) {
+      startBatchPolling(1000);
+    }
+  }, [hasUploadingBatches, stopBatchPolling, startBatchPolling]);
 
   return (
     <StyledWrapper>
@@ -542,7 +563,7 @@ const DataSubmission: FC<Props> = ({ submissionId, tab = URLTabs.DATA_ACTIVITY }
               </StyledAlert>
             )}
             <DataSubmissionSummary dataSubmission={data?.getSubmission} />
-            <DataSubmissionStatistics
+            <ValidationStatistics
               dataSubmission={data?.getSubmission}
               statistics={data?.submissionStats?.stats}
             />
@@ -553,6 +574,8 @@ const DataSubmission: FC<Props> = ({ submissionId, tab = URLTabs.DATA_ACTIVITY }
               onUpload={handleOnUpload}
             />
             <ValidationControls
+              /* Without key the component will continue to poll if status updates Error => Error and skips 'Validating' status due to race condition */
+              key={`last_validation_time_${lastValidationTime}`}
               dataSubmission={data?.getSubmission}
               onValidate={handleOnValidate}
             />

--- a/src/content/dataSubmissions/DataSubmissionActions.tsx
+++ b/src/content/dataSubmissions/DataSubmissionActions.tsx
@@ -1,7 +1,8 @@
-import { useState } from "react";
+import React, { useState } from "react";
 import { useMutation } from "@apollo/client";
 import { LoadingButton } from "@mui/lab";
 import { Button, OutlinedInput, Stack, Typography, styled } from "@mui/material";
+import { isEqual } from "lodash";
 import { useAuthContext } from "../../components/Contexts/AuthContext";
 import CustomDialog from "../../components/Shared/Dialog";
 import { EXPORT_SUBMISSION, ExportSubmissionResp } from "../../graphql";
@@ -479,4 +480,4 @@ const DataSubmissionActions = ({ submission, submitActionButton, onAction, onErr
   );
 };
 
-export default DataSubmissionActions;
+export default React.memo<Props>(DataSubmissionActions, (prevProps, nextProps) => isEqual(prevProps, nextProps));

--- a/src/content/dataSubmissions/ErrorDialog.tsx
+++ b/src/content/dataSubmissions/ErrorDialog.tsx
@@ -1,4 +1,5 @@
 import { Button, Dialog, DialogProps, IconButton, Stack, Typography, styled } from "@mui/material";
+import React from "react";
 import { ReactComponent as CloseIconSvg } from "../../assets/icons/close_icon.svg";
 import { FormatDate } from "../../utils";
 
@@ -172,4 +173,4 @@ const ErrorDialog = ({
   );
 };
 
-export default ErrorDialog;
+export default React.memo(ErrorDialog);

--- a/src/content/dataSubmissions/FileListDialog.tsx
+++ b/src/content/dataSubmissions/FileListDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import React, { useState } from "react";
 import { Button, Dialog, DialogProps, IconButton, TableContainerProps, Typography, styled } from "@mui/material";
 import { isEqual } from "lodash";
 import { ReactComponent as CloseIconSvg } from "../../assets/icons/close_icon.svg";
@@ -246,4 +246,4 @@ const FileListDialog = ({
   );
 };
 
-export default FileListDialog;
+export default React.memo<Props>(FileListDialog, (prevProps, nextProps) => isEqual(prevProps, nextProps));

--- a/src/content/dataSubmissions/QualityControl.tsx
+++ b/src/content/dataSubmissions/QualityControl.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, useMemo, useRef, useState } from "react";
+import React, { FC, useEffect, useMemo, useRef, useState } from "react";
 import { useLazyQuery, useQuery } from "@apollo/client";
 import { useParams } from "react-router-dom";
 import { isEqual } from "lodash";
@@ -355,4 +355,4 @@ const QualityControl: FC<Props> = ({ submission }: Props) => {
   );
 };
 
-export default QualityControl;
+export default React.memo<Props>(QualityControl, (prevProps, nextProps) => isEqual(prevProps, nextProps));


### PR DESCRIPTION
### Overview

Reduced the getSubmission and listBatches polling from 60s to 1s intervals. Also fixed race-condition bug involving Validate button and polling.

### Change Details (Specifics)

- Added polling for listBatches API
- Set polling interval for getSubmission and listBatches to 1s
- Memoized Data Submission components as the frequent 1s polling would cause excessive re-renders. 
- Fixed bug where clicking the validate button would set the button text to "Validating..." and would infinitely poll getSubmission even though it is done validating.
  
  This was due to a race condition where if the `metadataValidationStatus` is set to "Error" and when an additional validate is started with no changes it would poll getSubmission, but receive the same data back with `metadataValidationStatus` still as "Error". Receiving the same data back made it so the component wouldn't re-render and check the validation status again to stop the polling and update the button text. Added key that updates on every poll attempt to fix issue.

### Related Ticket(s)

[CRDCDH-1138](https://tracker.nci.nih.gov/browse/CRDCDH-1138)
