### PR TITLE
CRDCDH-1181 Adjust Individual Node Chart Carousel

### DIFF
--- a/src/components/Carousel/index.tsx
+++ b/src/components/Carousel/index.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FC, useState } from 'react';
 import { styled } from '@mui/material';
 import Carousel, { CarouselProps } from 'react-multi-carousel';
 import 'react-multi-carousel/lib/styles.css';
@@ -7,6 +7,10 @@ import CustomRightArrow from './CustomRightArrow';
 
 type Props = {
   children: React.ReactNode;
+  /**
+   * If true, will disable any user interaction with the carousel.
+   */
+  locked?: boolean;
 } & Partial<CarouselProps>;
 
 const sizing = {
@@ -16,7 +20,9 @@ const sizing = {
   },
 };
 
-const StyledWrapper = styled('div')({
+const StyledWrapper = styled('div', {
+  shouldForwardProp: (p) => p !== "showLeftFade" && p !== "showRightFade"
+})<{ showLeftFade: boolean; showRightFade: boolean }>(({ showLeftFade, showRightFade }) => ({
   maxWidth: "700px",
   minWidth: "464px", // NOTE: Without a min-width, the carousel collapses to 0px wide
   width: "100%",
@@ -37,7 +43,7 @@ const StyledWrapper = styled('div')({
     left: "calc(100% - 162px)",
     top: "0",
     bottom: "0",
-    width: "162px",
+    width: showRightFade ? "162px" : "0px",
     background: "linear-gradient(to right, rgba(255,255,255,0) 0%, rgba(255,255,255,1) 50%)",
     zIndex: 9,
   },
@@ -47,11 +53,11 @@ const StyledWrapper = styled('div')({
     right: "calc(100% - 162px)",
     top: "0",
     bottom: "0",
-    width: "162px",
+    width: showLeftFade ? "162px" : "0px",
     background: "linear-gradient(to left, rgba(255,255,255,0) 0%, rgba(255,255,255,1) 50%)",
     zIndex: 9,
   },
-});
+}));
 
 const removeAriaHidden = () => {
   const elements = document.querySelectorAll(".react-multi-carousel-item");
@@ -65,22 +71,29 @@ const removeAriaHidden = () => {
  * @param Props
  * @returns {JSX.Element}
  */
-const ContentCarousel: FC<Props> = ({ children, ...props }: Props) => (
-  <StyledWrapper>
-    <Carousel
-      responsive={sizing}
-      swipeable
-      draggable
-      arrows
-      afterChange={removeAriaHidden}
-      itemClass="custom-carousel-item"
-      customLeftArrow={<CustomLeftArrow />}
-      customRightArrow={<CustomRightArrow />}
-      {...props}
-    >
-      {children}
-    </Carousel>
-  </StyledWrapper>
-);
+const ContentCarousel: FC<Props> = ({ children, locked, ...props }: Props) => {
+  const [activeSlide, setActiveSlide] = useState<number>(0);
+
+  const handleBeforeChange = (nextSlide: number) => setActiveSlide(nextSlide);
+
+  return (
+    <StyledWrapper showLeftFade={activeSlide !== 0 && !locked} showRightFade={!locked}>
+      <Carousel
+        responsive={sizing}
+        swipeable={!locked}
+        draggable={!locked}
+        arrows={!locked}
+        beforeChange={handleBeforeChange}
+        afterChange={removeAriaHidden}
+        itemClass="custom-carousel-item"
+        customLeftArrow={<CustomLeftArrow />}
+        customRightArrow={<CustomRightArrow />}
+        {...props}
+      >
+        {children}
+      </Carousel>
+    </StyledWrapper>
+  );
+};
 
 export default ContentCarousel;

--- a/src/components/DataSubmissions/ValidationStatistics.tsx
+++ b/src/components/DataSubmissions/ValidationStatistics.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useMemo, useState } from 'react';
 import { cloneDeep, isEqual } from 'lodash';
-import { Box, Stack, StackProps, Tab, Tabs, Typography, styled } from '@mui/material';
+import { Stack, StackProps, Tab, Tabs, Typography, styled } from '@mui/material';
 import ContentCarousel from '../Carousel';
 import NodeTotalChart from '../NodeTotalChart';
 import MiniPieChart from '../NodeChart';
@@ -98,10 +98,6 @@ const StyledTab = styled(Tab)({
   },
 });
 
-const PaddingBox = styled(Box)({
-  width: "175px",
-});
-
 const defaultFilters: LegendFilter[] = [
   { label: "New", color: "#4D90D3", disabled: false },
   { label: "Passed", color: "#32E69A", disabled: false },
@@ -170,8 +166,9 @@ const DataSubmissionStatistics: FC<Props> = ({ dataSubmission, statistics }: Pro
           {" "}
           {`(${dataset.length})`}
         </StyledSectionTitle>
-        <ContentCarousel partialVisible={false}>
-          {dataset.length > 2 && <PaddingBox />}
+        {/* NOTE: The transform is derived from the difference of Chart width and
+            chart container width which is 50px on each side (100px) */}
+        <ContentCarousel additionalTransfrom={dataset.length > 3 ? 100 : 0} locked={dataset.length <= 3}>
           {dataset?.map((stat) => (
             <MiniPieChart
               key={stat.nodeName}
@@ -180,6 +177,8 @@ const DataSubmissionStatistics: FC<Props> = ({ dataSubmission, statistics }: Pro
               data={buildMiniChartSeries(stat, disabledSeries)}
             />
           ))}
+          {/* NOTE: the 4th node is cut-off without this */}
+          {dataset.length === 4 && <span />}
         </ContentCarousel>
         <StatisticLegend filters={filters} onClick={handleFilterChange} />
       </Stack>


### PR DESCRIPTION
### Overview

This PR adjusts the individual node chart display to show the 3rd node as half-faded for large datasets. For datasets under 4 nodes, it will show up to 3 without any fading.

<details><summary>Screenshots</summary>
<p>
**One Node**
<img width="743" alt="1 Node" src="https://github.com/CBIIT/crdc-datahub-ui/assets/38357871/2d7aa877-935c-41c4-a92d-f0f6a8d14e17">

**Two Nodes**
<img width="743" alt="2 Nodes" src="https://github.com/CBIIT/crdc-datahub-ui/assets/38357871/c0847d2e-dfc0-4483-ab4c-2913425e3ce5">

**Three Nodes**
<img width="743" alt="3 Nodes" src="https://github.com/CBIIT/crdc-datahub-ui/assets/38357871/a3fbb6a2-5757-45f2-8207-3e643312728c">

**Four Nodes**
<img width="743" alt="4 Nodes" src="https://github.com/CBIIT/crdc-datahub-ui/assets/38357871/c7d4864d-5471-4d82-99cd-41f4c6bf7721">

**9 Nodes (same as anything above 5)**
<img width="743" alt="9 Nodes" src="https://github.com/CBIIT/crdc-datahub-ui/assets/38357871/7e1ba768-2374-4a2c-8a92-f53885e32743">
</p>
</details> 

### Change Details (Specifics)

- Add additional `locked` prop to the carousel component which disables fading and user interaction
- Conditionally apply the left-side fading based on current carousel index
- Add a buffer element to the carousel when there's 4 nodes to prevent the 4th node from being cut in half

### Related Ticket(s)

CRDCDH-1181