### PR TITLE
CRDCDH-1095 Data Submission Upload update for "Metadata Only" Data Type

### DIFF
--- a/src/components/DataSubmissions/DataUpload.test.tsx
+++ b/src/components/DataSubmissions/DataUpload.test.tsx
@@ -80,13 +80,13 @@ describe("Basic Functionality", () => {
   });
 
   it("should not crash when the submission is null", () => {
-    const { getByTestId } = render(
+    const { getByText } = render(
       <TestParent>
         <DataUpload submission={null} />
       </TestParent>
     );
 
-    expect(getByTestId("uploader-cli-footer")).toBeVisible();
+    expect(getByText("Upload Data Files")).toBeVisible();
   });
 
   it("should handle API network errors gracefully", async () => {
@@ -178,18 +178,45 @@ describe("Implementation Requirements", () => {
     });
   });
 
-  it("should have the Configuration download link", async () => {
+  it("should have the Configuration download link when 'Metadata and Data Files' dataType", async () => {
     const mocks: MockedResponse[] = [];
 
     const { getByText, getByTestId } = render(
       <TestParent mocks={mocks}>
-        <DataUpload submission={{ ...baseSubmission, _id: "config-download-link-id" }} />
+        <DataUpload
+          submission={{
+            ...baseSubmission,
+            _id: "config-download-link-id",
+            dataType: "Metadata and Data Files",
+          }}
+        />
       </TestParent>
     );
     const button = getByTestId("uploader-cli-config-button");
 
     expect(getByText(/download configuration file/i)).toBeVisible();
     expect(button).toBeVisible();
+  });
+
+  it("should render alt CLI footer when 'Metadata Only' dataType", async () => {
+    const mocks: MockedResponse[] = [];
+
+    const { getByText, getByTestId } = render(
+      <TestParent mocks={mocks}>
+        <DataUpload
+          submission={{
+            ...baseSubmission,
+            _id: "config-download-link-id",
+            dataType: "Metadata Only",
+          }}
+        />
+      </TestParent>
+    );
+
+    expect(getByTestId("uploader-cli-footer-alt")).toBeVisible();
+    expect(
+      getByText(/This submission is for metadata only; there is no need to upload data files./i)
+    ).toBeVisible();
   });
 
   it("should download the Uploader CLI configuration file on click", async () => {

--- a/src/components/DataSubmissions/DataUpload.tsx
+++ b/src/components/DataSubmissions/DataUpload.tsx
@@ -117,11 +117,7 @@ export const DataUpload: FC<Props> = ({ submission }: Props) => {
 
   return (
     <FlowWrapper index={2} title="Upload Data Files" actions={Actions}>
-      {submission?.dataType === "Metadata Only" ? (
-        <StyledBox data-testid="uploader-cli-footer-alt">
-          This submission is for metadata only; there is no need to upload data files.
-        </StyledBox>
-      ) : (
+      {submission?.dataType === "Metadata and Data Files" ? (
         <>
           <StyledBox data-testid="uploader-cli-footer">
             The CLI Tool is used to upload data files to DataHub and requires a configuration file
@@ -145,6 +141,10 @@ export const DataUpload: FC<Props> = ({ submission }: Props) => {
             onDownload={handleConfigDownload}
           />
         </>
+      ) : (
+        <StyledBox data-testid="uploader-cli-footer-alt">
+          This submission is for metadata only; there is no need to upload data files.
+        </StyledBox>
       )}
     </FlowWrapper>
   );

--- a/src/components/DataSubmissions/DataUpload.tsx
+++ b/src/components/DataSubmissions/DataUpload.tsx
@@ -98,8 +98,12 @@ export const DataUpload: FC<Props> = ({ submission }: Props) => {
     }
   };
 
-  const Actions: ReactElement = useMemo(
-    () => (
+  const Actions: ReactElement = useMemo(() => {
+    if (submission?.dataType === "Metadata Only") {
+      return null;
+    }
+
+    return (
       <StyledDownloadButton
         onClick={() => setConfigDialogOpen(true)}
         variant="contained"
@@ -108,35 +112,40 @@ export const DataUpload: FC<Props> = ({ submission }: Props) => {
       >
         Download Configuration File
       </StyledDownloadButton>
-    ),
-    []
-  );
+    );
+  }, [submission?.dataType]);
 
   return (
     <FlowWrapper index={2} title="Upload Data Files" actions={Actions}>
-      <>
-        <StyledBox data-testid="uploader-cli-footer">
-          The CLI Tool is used to upload data files to DataHub and requires a configuration file to
-          work. The CLI Tools is a one-time download however the configuration file needs to be
-          customized for each submission. You can either edit the example configuration files found
-          in the{" "}
-          <StyledToolButton
-            onClick={() => setCLIDialogOpen(true)}
-            data-testid="uploader-cli-download-button"
-          >
-            <span>CLI Tool download</span>
-            <StyledOpenInNewIcon />
-          </StyledToolButton>
-          , or you can click the button on the right to download a configuration file customized for
-          this submission.
+      {submission?.dataType === "Metadata Only" ? (
+        <StyledBox data-testid="uploader-cli-footer-alt">
+          This submission is for metadata only; there is no need to upload data files.
         </StyledBox>
-        <UploaderToolDialog open={cliDialogOpen} onClose={() => setCLIDialogOpen(false)} />
-        <UploaderConfigDialog
-          open={configDialogOpen}
-          onClose={() => setConfigDialogOpen(false)}
-          onDownload={handleConfigDownload}
-        />
-      </>
+      ) : (
+        <>
+          <StyledBox data-testid="uploader-cli-footer">
+            The CLI Tool is used to upload data files to DataHub and requires a configuration file
+            to work. The CLI Tools is a one-time download however the configuration file needs to be
+            customized for each submission. You can either edit the example configuration files
+            found in the{" "}
+            <StyledToolButton
+              onClick={() => setCLIDialogOpen(true)}
+              data-testid="uploader-cli-download-button"
+            >
+              <span>CLI Tool download</span>
+              <StyledOpenInNewIcon />
+            </StyledToolButton>
+            , or you can click the button on the right to download a configuration file customized
+            for this submission.
+          </StyledBox>
+          <UploaderToolDialog open={cliDialogOpen} onClose={() => setCLIDialogOpen(false)} />
+          <UploaderConfigDialog
+            open={configDialogOpen}
+            onClose={() => setConfigDialogOpen(false)}
+            onDownload={handleConfigDownload}
+          />
+        </>
+      )}
     </FlowWrapper>
   );
 };

--- a/src/components/DataSubmissions/ValidationControls.test.tsx
+++ b/src/components/DataSubmissions/ValidationControls.test.tsx
@@ -769,6 +769,31 @@ describe("Implementation Requirements", () => {
     expect(getByLabelText(radio, "Both")).toBeDisabled();
   });
 
+  it("should disable 'Validate Data Files' and 'Both' for the submission dataType of 'Metadata Only'", () => {
+    const { getByTestId } = render(
+      <TestParent context={{ ...baseContext, user: { ...baseUser, role: "Submitter" } }}>
+        <ValidationControls
+          dataSubmission={{
+            ...baseSubmission,
+            _id: "example-sub-id-disabled",
+            status: "In Progress",
+            metadataValidationStatus: "New",
+            fileValidationStatus: "New",
+            intention: "New/Update",
+            dataType: "Metadata Only",
+          }}
+          onValidate={jest.fn()}
+        />
+      </TestParent>
+    );
+
+    const radio = getByTestId("validate-controls-validation-type") as HTMLInputElement;
+
+    expect(getByLabelText(radio, "Validate Metadata")).toBeEnabled();
+    expect(getByLabelText(radio, "Validate Data Files")).toBeDisabled();
+    expect(getByLabelText(radio, "Both")).toBeDisabled();
+  });
+
   // NOTE: This impacts Data Curators and Admins only, since only they can validate post-submit.
   it.each<User["role"]>(["Admin", "Data Curator"])(
     "should select 'All Uploaded Data' when the submission is 'Submitted' and the role is '%s'",

--- a/src/components/DataSubmissions/ValidationControls.tsx
+++ b/src/components/DataSubmissions/ValidationControls.tsx
@@ -134,7 +134,7 @@ const ValidationControls: FC<Props> = ({ dataSubmission, onValidate }: Props) =>
     if (permissionMap.includes(user.role) === false) {
       return false;
     }
-    if (dataSubmission.intention === "Delete") {
+    if (dataSubmission.intention === "Delete" || dataSubmission.dataType === "Metadata Only") {
       return false;
     }
 

--- a/src/utils/dataSubmissionUtils.test.ts
+++ b/src/utils/dataSubmissionUtils.test.ts
@@ -84,6 +84,18 @@ describe("General Submit", () => {
     expect(result.isAdminOverride).toBe(false);
   });
 
+  it('should allow submit when metadata validation is "Passed" and is "Metadata Only" dataType', () => {
+    const submission: Submission = {
+      ...baseSubmission,
+      dataType: "Metadata Only",
+      metadataValidationStatus: "Passed",
+      fileValidationStatus: null,
+    };
+    const result: SubmitInfo = utils.shouldDisableSubmit(submission, "Submitter");
+    expect(result.disable).toBe(false);
+    expect(result.isAdminOverride).toBe(false);
+  });
+
   it("should not disable submit when user role is not Admin and there are no validation errors", () => {
     const submission: Submission = {
       ...baseSubmission,
@@ -275,6 +287,17 @@ describe("General Submit", () => {
     expect(result.isAdminOverride).toBe(false);
   });
 
+  it('should allow submit when metadata validations is in "Passed" state', () => {
+    const submission: Submission = {
+      ...baseSubmission,
+      metadataValidationStatus: "Warning",
+      fileValidationStatus: "Warning",
+    };
+    const result: SubmitInfo = utils.shouldDisableSubmit(submission, "Submitter");
+    expect(result.disable).toBe(false);
+    expect(result.isAdminOverride).toBe(false);
+  });
+
   it('should allow submit when both validations are in "Warning" state', () => {
     const submission: Submission = {
       ...baseSubmission,
@@ -319,6 +342,18 @@ describe("Admin Submit", () => {
     const result: SubmitInfo = utils.shouldDisableSubmit(submission, "Admin");
     expect(result.disable).toBe(false);
     expect(result.isAdminOverride).toBe(true);
+  });
+
+  it("should allow submit without isAdminOverride but null data files with 'Metadata Only' dataType", () => {
+    const submission: Submission = {
+      ...baseSubmission,
+      dataType: "Metadata Only",
+      metadataValidationStatus: "Passed",
+      fileValidationStatus: null,
+    };
+    const result: SubmitInfo = utils.shouldDisableSubmit(submission, "Admin");
+    expect(result.disable).toBe(false);
+    expect(result.isAdminOverride).toBe(false);
   });
 
   it("should allow submit with isAdminOverride but null metadata", () => {
@@ -445,6 +480,18 @@ describe("Admin Submit", () => {
       metadataValidationStatus: "Passed",
       fileValidationStatus: null,
       intention: "Delete",
+    };
+    const result: SubmitInfo = utils.shouldDisableSubmit(submission, "Admin");
+    expect(result.disable).toBe(false);
+    expect(result.isAdminOverride).toBe(false);
+  });
+
+  it("should allow submit without isAdminOverride when metadata validation is 'Passed', file validation is null, and dataType is 'Metadata Only'", () => {
+    const submission: Submission = {
+      ...baseSubmission,
+      dataType: "Metadata Only",
+      metadataValidationStatus: "Passed",
+      fileValidationStatus: null,
     };
     const result: SubmitInfo = utils.shouldDisableSubmit(submission, "Admin");
     expect(result.disable).toBe(false);

--- a/src/utils/dataSubmissionUtils.ts
+++ b/src/utils/dataSubmissionUtils.ts
@@ -16,7 +16,8 @@ export const shouldDisableSubmit = (submission: Submission, userRole: User["role
   if (!userRole) {
     return { disable: true, isAdminOverride: false };
   }
-  const { metadataValidationStatus, fileValidationStatus, fileErrors, intention } = submission;
+  const { metadataValidationStatus, fileValidationStatus, fileErrors, intention, dataType } =
+    submission;
 
   const isAdmin = userRole === "Admin";
   const isMissingBoth = !metadataValidationStatus && !fileValidationStatus;
@@ -27,6 +28,7 @@ export const shouldDisableSubmit = (submission: Submission, userRole: User["role
   const hasNew = metadataValidationStatus === "New" || fileValidationStatus === "New";
   const hasError = metadataValidationStatus === "Error" || fileValidationStatus === "Error";
   const hasSubmissionLevelErrors = fileErrors?.length > 0;
+  const allowsMetadataOnly = isDeleteIntention || dataType === "Metadata Only";
 
   const isAdminOverride =
     isAdmin &&
@@ -34,14 +36,14 @@ export const shouldDisableSubmit = (submission: Submission, userRole: User["role
     !isMissingBoth &&
     !hasNew &&
     !hasSubmissionLevelErrors &&
-    (hasError || (isMissingOne && !isDeleteIntention));
+    (hasError || (isMissingOne && !allowsMetadataOnly));
   const disable =
     isValidating ||
     isMissingBoth ||
     hasNew ||
     hasSubmissionLevelErrors ||
     (isDeleteIntention && !metadataValidationStatus) ||
-    (userRole !== "Admin" && (hasError || (isMissingOne && !isDeleteIntention)));
+    (userRole !== "Admin" && (hasError || (isMissingOne && !allowsMetadataOnly)));
 
   return { disable, isAdminOverride };
 };


### PR DESCRIPTION
### Overview

Updated Step 2 in the Data Submission data upload process to display text when Submission is "Metadata Only".

### Change Details (Specifics)

- Replaced Step 2 text and hid buttons when Submission is "Metadata Only"
- Disabled "Validate Data Files" and "Both" when Submission is "Metadata Only". Although, this would never be enabled anyways since BE is blocking Data Files from ever being uploaded for this `dataType`.
- The "Submit" button is enabled when all metadata passed validation in a "Metadata Only" dataType Submission.

> [!NOTE]
> BE API's are not ready. Submit won't work, but the button will be enabled. Also, you can still upload Data Files to a 'Metadata Only' Submission via the CLI.

### Related Ticket(s)

[CRDCDH-1095](https://tracker.nci.nih.gov/browse/CRDCDH-1095)
