### PR TITLE
Fix Data Submission > Submitted Data Memoization

### DIFF
--- a/src/components/DataSubmissions/MetadataUpload.test.tsx
+++ b/src/components/DataSubmissions/MetadataUpload.test.tsx
@@ -4,7 +4,7 @@ import { MockedProvider, MockedResponse } from "@apollo/client/testing";
 import { axe } from "jest-axe";
 import userEvent from "@testing-library/user-event";
 import { Context, ContextState, Status as AuthStatus } from "../Contexts/AuthContext";
-import { MetadataUpload } from "./MetadataUpload";
+import MetadataUpload from "./MetadataUpload";
 import { CREATE_BATCH, CreateBatchResp, UPDATE_BATCH } from "../../graphql";
 
 // NOTE: We omit any properties that are explicitly used within component logic

--- a/src/components/DataSubmissions/MetadataUpload.tsx
+++ b/src/components/DataSubmissions/MetadataUpload.tsx
@@ -95,7 +95,7 @@ type Props = {
  * @param {Props} props
  * @returns {React.FC<Props>}
  */
-export const MetadataUpload = ({ submission, readOnly, onCreateBatch, onUpload }: Props) => {
+const MetadataUpload = ({ submission, readOnly, onCreateBatch, onUpload }: Props) => {
   const { submissionId } = useParams();
   const { user } = useAuthContext();
 

--- a/src/content/dataSubmissions/DataSubmission.tsx
+++ b/src/content/dataSubmissions/DataSubmission.tsx
@@ -19,7 +19,7 @@ import { useSnackbar, VariantType } from "notistack";
 import bannerPng from "../../assets/dataSubmissions/dashboard_banner.png";
 import summaryBannerSvg from "../../assets/dataSubmissions/summary_banner.png";
 import LinkTab from "../../components/DataSubmissions/LinkTab";
-import { MetadataUpload } from "../../components/DataSubmissions/MetadataUpload";
+import MetadataUpload from "../../components/DataSubmissions/MetadataUpload";
 import {
   GET_SUBMISSION,
   LIST_BATCHES,

--- a/src/content/dataSubmissions/SubmittedData.tsx
+++ b/src/content/dataSubmissions/SubmittedData.tsx
@@ -1,4 +1,4 @@
-import { FC, useMemo, useRef, useState } from "react";
+import React, { FC, useMemo, useRef, useState } from "react";
 import { useLazyQuery } from "@apollo/client";
 import { isEqual } from "lodash";
 import { useSnackbar } from "notistack";
@@ -161,4 +161,6 @@ const SubmittedData: FC<Props> = ({ submissionId, submissionName }) => {
   );
 };
 
-export default SubmittedData;
+export default React.memo<Props>(SubmittedData, (prevProps, nextProps) =>
+  isEqual(prevProps, nextProps)
+);


### PR DESCRIPTION
### Overview

This PR adds memoization to the Submitted Data tab, which was created after memoizing other data submission components.

> [!NOTE]
> You can observe the rerendering by hovering over the Export TSV icon, which collapses and reopens every rerender

https://github.com/CBIIT/crdc-datahub-ui/assets/38357871/97157b0c-15e1-4392-b34b-ea7ce283eaaa

### Change Details (Specifics)

- Memoize the SubmittedData component to prevent rerendering when polling getSubmission
- Fix the import of MetadataUpload, the default export was memoized but the Data Submission page was using the const export

### Related Ticket(s)

N/A
