### PR TITLE
CRDCDH-1187 Parse Model Property `list` Type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7569,8 +7569,8 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/data-model-navigator": {
-      "version": "1.1.30",
-      "resolved": "git+ssh://git@github.com/CBIIT/Data-Model-Navigator.git#dd58d548ec49043636989ff76b21852d41b9396c",
+      "version": "1.1.31",
+      "resolved": "git+ssh://git@github.com/CBIIT/Data-Model-Navigator.git#c04501553d3f450100169173799e9a2056804aeb",
       "license": "ISC",
       "dependencies": {
         "@material-ui/core": "^4.12.4",


### PR DESCRIPTION
### Overview

This PR upgrades DMN to `v1.1.31` which adds support for `list` model property types.

**List WITHOUT acceptable values defined (before/after):**

Table View > Study > Study > `data_types`

<img width="615" alt="Screenshot 2024-06-06 at 11 43 54 AM" src="https://github.com/CBIIT/crdc-datahub-ui/assets/38357871/e9d2c5aa-8165-4c1f-b3cf-19ad25801d6b">
<img width="615" alt="Screenshot 2024-06-06 at 11 43 37 AM" src="https://github.com/CBIIT/crdc-datahub-ui/assets/38357871/9db8e3d8-f1c2-4777-a675-aba246ce66dc">

**List WITH acceptable values defined (before/after)**

Table View > Data File > File > `experimental_strategy_and_data_subtypes`

<img width="615" alt="Screenshot 2024-06-06 at 11 44 09 AM" src="https://github.com/CBIIT/crdc-datahub-ui/assets/38357871/c2e2f48a-1595-43c1-b1d9-e24ce1378860">
<img width="615" alt="Screenshot 2024-06-06 at 11 44 27 AM" src="https://github.com/CBIIT/crdc-datahub-ui/assets/38357871/66f5f30c-2324-4f5d-950a-45ad4d9cd84f">


### Change Details (Specifics)

- See DMN changes in commit https://github.com/CBIIT/Data-Model-Navigator/commit/8612cce7e56a0d6d0368656543db92dda29cafe6

### Related Ticket(s)

CRDCDH-1187
