### PR TITLE
Fix silent warnings allowing Jest to succeed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "graphql": "^16.7.1",
         "graphql-tag": "^2.12.6",
         "jest-axe": "^8.0.0",
+        "jest-fail-on-console": "^3.3.0",
         "lodash": "^4.17.21",
         "notistack": "^3.0.1",
         "papaparse": "^5.4.1",
@@ -11242,6 +11243,11 @@
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
+    },
+    "node_modules/jest-fail-on-console": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/jest-fail-on-console/-/jest-fail-on-console-3.3.0.tgz",
+      "integrity": "sha512-J9rnFQvQwkcGJw01zCEKe2Uag+E926lFgIyaQGep2LqhQH7OCRHyD+tm/jnNoKlSRnOBO60DmzMjeQAVI3f5cw=="
     },
     "node_modules/jest-get-type": {
       "version": "27.5.1",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "graphql": "^16.7.1",
     "graphql-tag": "^2.12.6",
     "jest-axe": "^8.0.0",
+    "jest-fail-on-console": "^3.3.0",
     "lodash": "^4.17.21",
     "notistack": "^3.0.1",
     "papaparse": "^5.4.1",

--- a/src/setupTests.tsx
+++ b/src/setupTests.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 // eslint-disable-next-line max-classes-per-file
 import "@testing-library/jest-dom";
 import "jest-axe/extend-expect";
@@ -58,3 +59,14 @@ jest.mock("recharts", () => ({
   ...jest.requireActual("recharts"),
   ResponsiveContainer: MockResponsiveContainer,
 }));
+
+/**
+ * Prevents the console.error and console.warn from silently failing
+ * in tests by throwing an error when called
+ */
+console.error = (message, ...rest) => {
+  throw message instanceof Error ? message : new Error(message, ...rest);
+};
+console.warn = (message, ...rest) => {
+  throw message instanceof Error ? message : new Error(message, ...rest);
+};

--- a/src/setupTests.tsx
+++ b/src/setupTests.tsx
@@ -1,7 +1,7 @@
-/* eslint-disable no-console */
 // eslint-disable-next-line max-classes-per-file
 import "@testing-library/jest-dom";
 import "jest-axe/extend-expect";
+import failOnConsole from "jest-fail-on-console";
 
 /**
  * Mocks the enqueueSnackbar function from notistack for testing
@@ -64,9 +64,7 @@ jest.mock("recharts", () => ({
  * Prevents the console.error and console.warn from silently failing
  * in tests by throwing an error when called
  */
-console.error = (message, ...rest) => {
-  throw message instanceof Error ? message : new Error(message, ...rest);
-};
-console.warn = (message, ...rest) => {
-  throw message instanceof Error ? message : new Error(message, ...rest);
-};
+failOnConsole({
+  shouldFailOnWarn: true,
+  shouldFailOnError: true,
+});


### PR DESCRIPTION
### Overview

This PR prevents console.warn and console.error calls from silently happening in tests and not failing the Jest action for it.

### Change Details (Specifics)

- Add `jest-fail-on-console` dependency

### Related Ticket(s)

N/A
