### PR TITLE
fix: Add null-safe check on `Issues` column error attribute

### DIFF
--- a/src/components/DataSubmissions/ExportValidationButton.test.tsx
+++ b/src/components/DataSubmissions/ExportValidationButton.test.tsx
@@ -469,9 +469,12 @@ describe("ExportValidationButton cases", () => {
     fireEvent.click(getByTestId("export-validation-button"));
 
     await waitFor(() => {
-      expect(global.mockEnqueue).toHaveBeenCalledWith("Unable to export validation results.", {
-        variant: "error",
-      });
+      expect(global.mockEnqueue).toHaveBeenCalledWith(
+        expect.stringContaining("Unable to export validation results. Error:"),
+        {
+          variant: "error",
+        }
+      );
     });
   });
 });

--- a/src/components/DataSubmissions/ExportValidationButton.tsx
+++ b/src/components/DataSubmissions/ExportValidationButton.tsx
@@ -103,7 +103,7 @@ export const ExportValidationButton: React.FC<Props> = ({
 
       downloadBlob(unparse(csvArray), filename, "text/csv");
     } catch (err) {
-      enqueueSnackbar("Unable to export validation results.", {
+      enqueueSnackbar(`Unable to export validation results. Error: ${err}`, {
         variant: "error",
       });
     }

--- a/src/content/dataSubmissions/QualityControl.tsx
+++ b/src/content/dataSubmissions/QualityControl.tsx
@@ -174,7 +174,7 @@ export const csvColumns = {
   Severity: (d: QCResult) => d.severity,
   "Validated Date": (d: QCResult) => FormatDate(d?.validatedDate, "MM-DD-YYYY [at] hh:mm A", ""),
   Issues: (d: QCResult) => {
-    const value = d.errors[0].description ?? d.warnings[0]?.description;
+    const value = d.errors[0]?.description ?? d.warnings[0]?.description;
 
     // NOTE: The ErrorMessage descriptions contain non-standard double quotes
     // that don't render correctly in Excel. This replaces them with standard double quotes.


### PR DESCRIPTION
### Overview

This PR addresses a bug caused by a missing null-safe / optional chaining on the QCResult Errors field. It also adds error details to the "unable to export validation results" alert.

### Change Details (Specifics)

- Add optional chaining to `d.errors[0]?.description` so it will fallback to `d.warnings[0]?.description`
- Add exception details to snackbar alert when unable to generate CSV file

### Related Ticket(s)

TBD
