### PR TITLE
fix: Random failures with Jest CI

### DIFF
--- a/src/components/DataSubmissions/DataUpload.test.tsx
+++ b/src/components/DataSubmissions/DataUpload.test.tsx
@@ -247,8 +247,11 @@ describe("Implementation Requirements", () => {
 
     expect(called).toBe(false);
 
-    // Open the dialog
-    userEvent.click(getByTestId("uploader-cli-config-button"));
+    // eslint-disable-next-line testing-library/no-unnecessary-act -- RHF is throwing an error without act
+    await act(async () => {
+      // Open the dialog
+      userEvent.click(getByTestId("uploader-cli-config-button"));
+    });
 
     // Skip filling the fields and click the download button
     // eslint-disable-next-line testing-library/no-unnecessary-act -- RHF is throwing an error without act


### PR DESCRIPTION
### Overview

This PR should fix a randomized test failure caused by React Hook Form. See the action run [9411823501](https://github.com/CBIIT/crdc-datahub-ui/actions/runs/9411823501) or [9418434115](https://github.com/CBIIT/crdc-datahub-ui/actions/runs/9418434115).

I can't replicate this issue locally, but I did re-run the Jest job against this PR 5 times without issues:
- [258](https://github.com/CBIIT/crdc-datahub-ui/actions/runs/9418412154)
- [257](https://github.com/CBIIT/crdc-datahub-ui/actions/runs/9418410980)
- [256](https://github.com/CBIIT/crdc-datahub-ui/actions/runs/9418408396)
- [255](https://github.com/CBIIT/crdc-datahub-ui/actions/runs/9418286250)
- [254](https://github.com/CBIIT/crdc-datahub-ui/actions/runs/9418201981)

### Change Details (Specifics)

- Wrap a test case in `act` and disable linting against it

### Related Ticket(s)

N/A
