### PR TITLE
CRDCDH-1170 Added Submit and Cancel buttons when Data Submission is in Rejected status

### DIFF
--- a/src/content/dataSubmissions/DataSubmissionActions.tsx
+++ b/src/content/dataSubmissions/DataSubmissionActions.tsx
@@ -104,7 +104,7 @@ type ActionKey =
 const actionConfig: Record<ActionKey, ActionConfig> = {
   Submit: {
     roles: ["Submitter", "Organization Owner", "Data Curator", "Admin"],
-    statuses: ["In Progress", "Withdrawn"],
+    statuses: ["In Progress", "Withdrawn", "Rejected"],
   },
   Release: {
     roles: ["Data Curator", "Admin"],
@@ -128,7 +128,7 @@ const actionConfig: Record<ActionKey, ActionConfig> = {
   },
   Cancel: {
     roles: ["Submitter", "Organization Owner", "Data Curator", "Admin"],
-    statuses: ["New", "In Progress"],
+    statuses: ["New", "In Progress", "Rejected"],
   },
   Archive: {
     roles: ["Data Curator", "Admin"],


### PR DESCRIPTION
### Overview

Updated Data Submission Dashboard to display "Submit" and "Cancel" buttons when the submission is in a "Rejected" status.

### Change Details (Specifics)

- Added transition in Data Submission workflow "Rejected" => "Submitted"
- Added transition in Data Submission workflow "Rejected" => "Canceled"

> [!NOTE]
> BE doesn't yet support transition from "Rejected" => "Canceled".

### Related Ticket(s)

[CRDCDH-1170](https://tracker.nci.nih.gov/browse/CRDCDH-1170)
