### PR TITLE
CRDCDH-1170 Update Submit dialog text for resubmissions

### DIFF
--- a/src/content/dataSubmissions/DataSubmissionActions.tsx
+++ b/src/content/dataSubmissions/DataSubmissionActions.tsx
@@ -332,8 +332,9 @@ const DataSubmissionActions = ({
         }
       >
         <StyledDialogText variant="body2">
-          This action will lock your submission and it will no longer accept updates to the data.
-          Are you sure you want to proceed?
+          {submission?.status === "Rejected"
+            ? "Are you sure you want to resubmit your data without making any changes? Your previous submission was rejected, and resubmitting without addressing the issues may result in another rejection."
+            : "This action will lock your submission and it will no longer accept updates to the data. Are you sure you want to proceed?"}
         </StyledDialogText>
       </StyledDialog>
 


### PR DESCRIPTION
### Overview

Updated the dialog text for the Submit action, when the submission status is currently in "Rejected" status. The submitter will be resubmitting without any changes.

### Change Details (Specifics)

N/A

### Related Ticket(s)

[CRDCDH-1170](https://tracker.nci.nih.gov/browse/CRDCDH-1170)
