### PR TITLE
CRDCDH-1254 Deprecate deleting orphaned files in Validation Results tab

### DIFF
--- a/src/components/DataSubmissions/DeleteAllOrphanFilesButton.tsx
+++ b/src/components/DataSubmissions/DeleteAllOrphanFilesButton.tsx
@@ -35,6 +35,14 @@ type Props = {
   onDelete: (success: boolean) => void;
 } & IconButtonProps;
 
+/**
+ * A button component that triggers the deletion of all orphaned files within a submission.
+ *
+ * @param {Props} props
+ * @returns {JSX.Element}
+ *
+ * @deprecated This component is deprecated. The Data View tab will handle deleting orphaned files instead.
+ */
 const DeleteAllOrphanFilesButton = ({ submission, onDelete, disabled, ...rest }: Props) => {
   const { user } = useAuthContext();
   const { enqueueSnackbar } = useSnackbar();

--- a/src/components/DataSubmissions/DeleteOrphanFileChip.tsx
+++ b/src/components/DataSubmissions/DeleteOrphanFileChip.tsx
@@ -58,7 +58,7 @@ type Props = {
  * A chip component that allows deletion of a specific orphan file associated with a submission.
  *
  * @param {Props} props
- * @returns {JSX.Element}
+ * @returns {JSX.Element | null}
  *
  * @deprecated This component is deprecated. The Data View tab will handle deleting orphaned files instead.
  */

--- a/src/components/DataSubmissions/DeleteOrphanFileChip.tsx
+++ b/src/components/DataSubmissions/DeleteOrphanFileChip.tsx
@@ -54,6 +54,14 @@ type Props = {
   onDeleteFile: (success: boolean) => void;
 } & ChipProps;
 
+/**
+ * A chip component that allows deletion of a specific orphan file associated with a submission.
+ *
+ * @param {Props} props
+ * @returns {JSX.Element}
+ *
+ * @deprecated This component is deprecated. The Data View tab will handle deleting orphaned files instead.
+ */
 const DeleteOrphanFileChip = ({
   submission,
   submittedID,

--- a/src/content/dataSubmissions/Contexts/QCResultsContext.tsx
+++ b/src/content/dataSubmissions/Contexts/QCResultsContext.tsx
@@ -1,8 +1,6 @@
 import React from "react";
 
 const QCResultsContext = React.createContext<{
-  submission?: Submission;
-  handleDeleteOrphanFile?: (success: boolean) => void;
   handleOpenErrorDialog?: (data: QCResult) => void;
 }>({});
 

--- a/src/content/dataSubmissions/QualityControl.tsx
+++ b/src/content/dataSubmissions/QualityControl.tsx
@@ -18,8 +18,6 @@ import { FormatDate, compareNodeStats, titleCase } from "../../utils";
 import ErrorDetailsDialog from "../../components/ErrorDetailsDialog";
 import QCResultsContext from "./Contexts/QCResultsContext";
 import { ExportValidationButton } from "../../components/DataSubmissions/ExportValidationButton";
-import DeleteAllOrphanFilesButton from "../../components/DataSubmissions/DeleteAllOrphanFilesButton";
-import DeleteOrphanFileChip from "../../components/DataSubmissions/DeleteOrphanFileChip";
 import StyledSelect from "../../components/StyledFormComponents/StyledSelect";
 
 type FilterForm = {
@@ -142,7 +140,7 @@ const columns: Column<QCResult>[] = [
     renderValue: (data) =>
       (data?.errors?.length > 0 || data?.warnings?.length > 0) && (
         <QCResultsContext.Consumer>
-          {({ submission, handleDeleteOrphanFile, handleOpenErrorDialog }) => (
+          {({ handleOpenErrorDialog }) => (
             <Stack direction="row">
               <StyledIssuesTextWrapper>
                 <span>
@@ -158,11 +156,6 @@ const columns: Column<QCResult>[] = [
                   See details.
                 </StyledErrorDetailsButton>
               </StyledIssuesTextWrapper>
-              <DeleteOrphanFileChip
-                submission={submission}
-                submittedID={data?.submittedID}
-                onDeleteFile={handleDeleteOrphanFile}
-              />
             </Stack>
           )}
         </QCResultsContext.Consumer>
@@ -301,14 +294,6 @@ const QualityControl: FC<Props> = ({ submission, refreshSubmission }: Props) => 
     }
   };
 
-  const handleDeleteOrphanFile = (success: boolean) => {
-    if (!success) {
-      return;
-    }
-    refreshSubmission();
-    tableRef.current?.refresh();
-  };
-
   const handleOpenErrorDialog = (data: QCResult) => {
     setOpenErrorDialog(true);
     setSelectedRow(data);
@@ -316,11 +301,9 @@ const QualityControl: FC<Props> = ({ submission, refreshSubmission }: Props) => 
 
   const providerValue = useMemo(
     () => ({
-      submission,
-      handleDeleteOrphanFile,
       handleOpenErrorDialog,
     }),
-    [submission, handleDeleteOrphanFile, handleOpenErrorDialog]
+    [handleOpenErrorDialog]
   );
 
   useEffect(() => {
@@ -451,11 +434,6 @@ const QualityControl: FC<Props> = ({ submission, refreshSubmission }: Props) => 
                 submission={submission}
                 fields={csvColumns}
                 disabled={totalData <= 0}
-              />
-              <DeleteAllOrphanFilesButton
-                submission={submission}
-                disabled={!submission?.fileErrors?.length}
-                onDelete={handleDeleteOrphanFile}
               />
             </Stack>
           }


### PR DESCRIPTION
### Overview

Deprecated deleting orphaned files buttons and removed them from the Validation Results tab. 

### Change Details (Specifics)

- See submission `8b2e93a6-2b78-4a89-81fe-2174d0cb3b42` for testing. It has orphaned files.

> [!NOTE]
> This will be handled a different way in the Data Viewer tab instead.

### Related Ticket(s)

[CRDCDH-1254](https://tracker.nci.nih.gov/browse/CRDCDH-1254)
