### PR TITLE
CRDCDH-1297 Edit/Add organization should use studyID (Pt. 2)

### DIFF
--- a/src/content/organizations/OrganizationView.tsx
+++ b/src/content/organizations/OrganizationView.tsx
@@ -45,7 +45,9 @@ type Props = {
   _id: string;
 };
 
-type FormInput = Omit<EditOrgInput, "orgID">;
+type FormInput = Omit<EditOrgInput, "orgID" | "studies"> & {
+  studies: string[];
+};
 
 const StyledContainer = styled(Container)({
   marginBottom: "90px",
@@ -248,8 +250,13 @@ const OrganizationView: FC<Props> = ({ _id }: Props) => {
   const onSubmit = async (data: FormInput) => {
     setSaving(true);
 
+    const variables = {
+      ...data,
+      studies: data.studies.map((studyID) => ({ studyID })),
+    };
+
     if (_id === "new" && !organization?._id) {
-      const { data: d, errors } = await createOrganization({ variables: data }).catch((e) => ({
+      const { data: d, errors } = await createOrganization({ variables }).catch((e) => ({
         errors: e?.message,
         data: null,
       }));
@@ -268,7 +275,7 @@ const OrganizationView: FC<Props> = ({ _id }: Props) => {
       reset();
     } else {
       const { data: d, errors } = await editOrganization({
-        variables: { orgID: organization._id, ...data },
+        variables: { orgID: organization._id, ...variables },
       }).catch((e) => ({ errors: e?.message, data: null }));
       setSaving(false);
 

--- a/src/content/organizations/OrganizationView.tsx
+++ b/src/content/organizations/OrganizationView.tsx
@@ -30,6 +30,8 @@ import {
   ListApprovedStudiesResp,
   LIST_CURATORS,
   ListCuratorsResp,
+  EditOrgInput,
+  CreateOrgInput,
 } from "../../graphql";
 import ConfirmDialog from "../../components/Organizations/ConfirmDialog";
 import usePageTitle from "../../hooks/usePageTitle";
@@ -43,9 +45,7 @@ type Props = {
   _id: string;
 };
 
-type FormInput = Omit<EditOrganizationInput, "studies"> & {
-  studies: ApprovedStudy["_id"][];
-};
+type FormInput = Omit<EditOrgInput, "orgID">;
 
 const StyledContainer = styled(Container)({
   marginBottom: "90px",
@@ -220,12 +220,12 @@ const OrganizationView: FC<Props> = ({ _id }: Props) => {
     fetchPolicy: "no-cache",
   });
 
-  const [editOrganization] = useMutation<EditOrgResp>(EDIT_ORG, {
+  const [editOrganization] = useMutation<EditOrgResp, EditOrgInput>(EDIT_ORG, {
     context: { clientName: "backend" },
     fetchPolicy: "no-cache",
   });
 
-  const [createOrganization] = useMutation<CreateOrgResp>(CREATE_ORG, {
+  const [createOrganization] = useMutation<CreateOrgResp, CreateOrgInput>(CREATE_ORG, {
     context: { clientName: "backend" },
     fetchPolicy: "no-cache",
   });
@@ -248,20 +248,8 @@ const OrganizationView: FC<Props> = ({ _id }: Props) => {
   const onSubmit = async (data: FormInput) => {
     setSaving(true);
 
-    const studyMap: {
-      [_id: string]: Pick<ApprovedStudy, "studyName" | "studyAbbreviation">;
-    } = {};
-    approvedStudies?.listApprovedStudies?.forEach(({ _id, studyName, studyAbbreviation }) => {
-      studyMap[_id] = { studyName, studyAbbreviation };
-    });
-
-    const variables = {
-      ...data,
-      studies: data.studies.map((_id) => studyMap[_id])?.filter((s) => !!s?.studyName) || [],
-    };
-
     if (_id === "new" && !organization?._id) {
-      const { data: d, errors } = await createOrganization({ variables }).catch((e) => ({
+      const { data: d, errors } = await createOrganization({ variables: data }).catch((e) => ({
         errors: e?.message,
         data: null,
       }));
@@ -280,7 +268,7 @@ const OrganizationView: FC<Props> = ({ _id }: Props) => {
       reset();
     } else {
       const { data: d, errors } = await editOrganization({
-        variables: { orgID: organization._id, ...variables },
+        variables: { orgID: organization._id, ...data },
       }).catch((e) => ({ errors: e?.message, data: null }));
       setSaving(false);
 

--- a/src/graphql/createOrganization.ts
+++ b/src/graphql/createOrganization.ts
@@ -13,6 +13,7 @@ export const mutation = gql`
       conciergeID
       conciergeName
       studies {
+        _id
         studyName
         studyAbbreviation
       }

--- a/src/graphql/createOrganization.ts
+++ b/src/graphql/createOrganization.ts
@@ -20,6 +20,12 @@ export const mutation = gql`
   }
 `;
 
+export type Input = {
+  name: string;
+  conciergeID: string;
+  studies: ApprovedStudy["_id"][];
+};
+
 export type Response = {
   createOrganization: Organization;
 };

--- a/src/graphql/createOrganization.ts
+++ b/src/graphql/createOrganization.ts
@@ -23,7 +23,7 @@ export const mutation = gql`
 export type Input = {
   name: string;
   conciergeID: string;
-  studies: ApprovedStudy["_id"][];
+  studies: { studyID: string }[];
 };
 
 export type Response = {

--- a/src/graphql/editOrganization.ts
+++ b/src/graphql/editOrganization.ts
@@ -5,7 +5,7 @@ export const mutation = gql`
     $orgID: ID!
     $name: String
     $conciergeID: String
-    $studies: [ID]
+    $studies: [ApprovedStudyInput]
     $status: String
   ) {
     editOrganization(
@@ -34,7 +34,7 @@ export type Input = {
   orgID: string;
   name: string;
   conciergeID: string;
-  studies: ApprovedStudy["_id"][];
+  studies: { studyID: string }[];
   status: Organization["status"];
 };
 

--- a/src/graphql/editOrganization.ts
+++ b/src/graphql/editOrganization.ts
@@ -5,7 +5,7 @@ export const mutation = gql`
     $orgID: ID!
     $name: String
     $conciergeID: String
-    $studies: [ApprovedStudyInput]
+    $studies: [ID]
     $status: String
   ) {
     editOrganization(
@@ -29,6 +29,14 @@ export const mutation = gql`
     }
   }
 `;
+
+export type Input = {
+  orgID: string;
+  name: string;
+  conciergeID: string;
+  studies: ApprovedStudy["_id"][];
+  status: Organization["status"];
+};
 
 export type Response = {
   editOrganization: Organization;

--- a/src/graphql/editOrganization.ts
+++ b/src/graphql/editOrganization.ts
@@ -21,6 +21,7 @@ export const mutation = gql`
       conciergeID
       conciergeName
       studies {
+        _id
         studyName
         studyAbbreviation
       }

--- a/src/graphql/getOrganization.ts
+++ b/src/graphql/getOrganization.ts
@@ -9,6 +9,7 @@ export const query = gql`
       conciergeID
       conciergeName
       studies {
+        _id
         studyName
         studyAbbreviation
       }

--- a/src/graphql/index.ts
+++ b/src/graphql/index.ts
@@ -114,7 +114,7 @@ export { query as GET_ORG } from "./getOrganization";
 export type { Response as GetOrgResp } from "./getOrganization";
 
 export { mutation as EDIT_ORG } from "./editOrganization";
-export type { Response as EditOrgResp } from "./editOrganization";
+export type { Input as EditOrgInput, Response as EditOrgResp } from "./editOrganization";
 
 export { query as LIST_CURATORS } from "./listActiveCurators";
 export type { Response as ListCuratorsResp } from "./listActiveCurators";
@@ -123,7 +123,7 @@ export { query as LIST_APPROVED_STUDIES } from "./listApprovedStudies";
 export type { Response as ListApprovedStudiesResp } from "./listApprovedStudies";
 
 export { mutation as CREATE_ORG } from "./createOrganization";
-export type { Response as CreateOrgResp } from "./createOrganization";
+export type { Input as CreateOrgInput, Response as CreateOrgResp } from "./createOrganization";
 
 // Misc.
 export { mutation as GRANT_TOKEN } from "./grantToken";

--- a/src/graphql/listApprovedStudies.ts
+++ b/src/graphql/listApprovedStudies.ts
@@ -4,7 +4,6 @@ export const query = gql`
   query listApprovedStudies {
     listApprovedStudies {
       _id
-      originalOrg
       studyName
       studyAbbreviation
       dbGaPID

--- a/src/graphql/listApprovedStudiesOfMyOrganization.ts
+++ b/src/graphql/listApprovedStudiesOfMyOrganization.ts
@@ -4,7 +4,6 @@ export const query = gql`
   query listApprovedStudiesOfMyOrganization {
     listApprovedStudiesOfMyOrganization {
       _id
-      originalOrg
       studyName
       studyAbbreviation
       dbGaPID

--- a/src/types/ApprovedStudies.d.ts
+++ b/src/types/ApprovedStudies.d.ts
@@ -1,6 +1,5 @@
 type ApprovedStudy = {
   _id: string;
-  originalOrg: Organization["_id"];
   /**
    * Study name
    *

--- a/src/types/Auth.d.ts
+++ b/src/types/Auth.d.ts
@@ -58,16 +58,9 @@ type Organization = {
   conciergeID: string | null;
   conciergeName: string | null;
   conciergeEmail: string | null;
-  studies: Pick<ApprovedStudy, "studyName" | "studyAbbreviation">[];
+  studies: ApprovedStudy[];
   createdAt: string; // YYYY-MM-DDTHH:mm:ss.sssZ
   updateAt: string; // YYYY-MM-DDTHH:mm:ss.sssZ
-};
-
-type EditOrganizationInput = {
-  name: Organization["name"];
-  conciergeID: User["_id"];
-  studies: Pick<ApprovedStudy, "studyName" | "studyAbbreviation">[];
-  status: Organization["status"];
 };
 
 type Tokens = {

--- a/src/utils/formUtils.test.ts
+++ b/src/utils/formUtils.test.ts
@@ -253,6 +253,33 @@ describe("mapOrganizationStudyToId cases", () => {
     expect(result).toBe("1");
   });
 
+  it("should short-circuit if the study already has an id", () => {
+    const studies = [
+      { _id: "1", studyName: "Study 1", studyAbbreviation: "S1" },
+      { _id: "2", studyName: "Study 2", studyAbbreviation: "S2" },
+    ] as ApprovedStudy[];
+
+    const study = { _id: "id already exists", studyName: "Study 3", studyAbbreviation: "S3" };
+    const result = utils.mapOrganizationStudyToId(study, studies);
+
+    expect(result).toBe("id already exists");
+  });
+
+  it.each([null, undefined, 1])(
+    "should return an empty string if no valid _id is provided and none match",
+    (value) => {
+      const studies = [
+        { _id: "1", studyName: "Study 1", studyAbbreviation: "S1" },
+        { _id: "2", studyName: "Study 2", studyAbbreviation: "S2" },
+      ] as ApprovedStudy[];
+
+      const study = { _id: value, studyName: "Study 3", studyAbbreviation: "S3" };
+      const result = utils.mapOrganizationStudyToId(study, studies);
+
+      expect(result).toBe("");
+    }
+  );
+
   it("should return an empty string if no matching study is found", () => {
     const studies = [
       { _id: "1", studyName: "Study 1", studyAbbreviation: "S1" },

--- a/src/utils/formUtils.ts
+++ b/src/utils/formUtils.ts
@@ -141,6 +141,7 @@ export const formatFullStudyName = (studyName: string, studyAbbreviation: string
  * Attempts to map a study name + abbreviation combination to an approved study ID.
  *
  * - Will return the first match found
+ * - If the orgStudy already has an ID, it will be returned
  * - If no match is found, an empty string is returned
  *
  * @param Study information from Organization object
@@ -152,6 +153,10 @@ export const mapOrganizationStudyToId = (
   studies: Pick<ApprovedStudy, "_id" | "studyName" | "studyAbbreviation">[]
 ): ApprovedStudy["_id"] => {
   const { studyName, studyAbbreviation } = orgStudy || {};
+
+  if (orgStudy && "_id" in orgStudy && typeof orgStudy._id === "string") {
+    return orgStudy?._id;
+  }
 
   return (
     studies?.find(


### PR DESCRIPTION
### Overview

This PR finishes CRDCDH-1297 and updates edit/create Organization API to send the studyID instead of the name/abbreviation.

### Change Details (Specifics)

(Requirement 3 – Organization Edit changes)
- Update the Organization.studies type from a subset `{ name, abbreviation }` to the full `ApprovedStudy`
- Provide the ApprovedStudy `_id` when editing/creating organizations instead of `{ name, abbreviation}`
- Move `EditOrganizationInput` global type definition to the GraphQL mutation file instead
- Update `mapOrganizationStudyToId` to handle the situation in which an organization's studies have IDs already
  - NOTE: This utility is somewhat redundant but I left it in place for backwards compatibility when an organization doesn't have the full ApprovedStudy object (i.e. it was saved before these API changes)

### Related Ticket(s)

CRDCDH-1297
