### PR TITLE
CRDCDH-1318 Fix Data View Table Width

### DIFF
--- a/src/components/GenericTable/index.test.tsx
+++ b/src/components/GenericTable/index.test.tsx
@@ -196,18 +196,13 @@ describe("GenericTable", () => {
   });
 
   describe("Style Application", () => {
-    it("applies horizontal scroll styles when enabled", () => {
-      const { container } = setup({ ...defaultProps, horizontalScroll: true });
-      expect(container.querySelector("table")).toHaveStyle("white-space: nowrap");
-      expect(container.querySelector("table")).toHaveStyle("display: block");
-      expect(container.querySelector("table")).toHaveStyle("overflow-x: auto");
-    });
+    it("applies tableProps to the table element", () => {
+      const { container } = setup({
+        ...defaultProps,
+        tableProps: { sx: { backgroundColor: "red" } },
+      });
 
-    it("does not apply horizontal scroll styles when disabled", () => {
-      const { container } = setup({ ...defaultProps, horizontalScroll: false });
-      expect(container.querySelector("table")).toHaveStyle("white-space: initial");
-      expect(container.querySelector("table")).toHaveStyle("display: table");
-      expect(container.querySelector("table")).toHaveStyle("overflow-x: initial");
+      expect(container.querySelector("table")).toHaveStyle("background-color: red");
     });
 
     it("applies borderBottom style conditionally based on row position", () => {
@@ -254,11 +249,6 @@ describe("GenericTable", () => {
   });
 
   describe("Visual and Interaction Features", () => {
-    it("checks styled component properties when horizontal scroll is enabled", () => {
-      const { container } = setup({ ...defaultProps, horizontalScroll: true });
-      expect(container.querySelector(".MuiTable-root")).toHaveStyle("display: block");
-    });
-
     it("renders top and bottom pagination when position is both", () => {
       const { getByTestId } = setup({ ...defaultProps, position: "both" });
       const topPagination = getByTestId("generic-table-rows-per-page-top");

--- a/src/content/dataSubmissions/SubmittedData.tsx
+++ b/src/content/dataSubmissions/SubmittedData.tsx
@@ -300,10 +300,10 @@ const SubmittedData: FC = () => {
           defaultOrder="desc"
           position="both"
           AdditionalActions={Actions}
-          horizontalScroll
           setItemKey={(item, idx) => `${idx}_${item.nodeID}`}
           onFetchData={handleFetchData}
           containerProps={{ sx: { marginBottom: "8px" } }}
+          tableProps={{ sx: { whiteSpace: "nowrap" } }}
         />
       </DataViewContext.Provider>
     </>


### PR DESCRIPTION
### Overview

This PR changes how a horizontal scrolling table should be implemented. The previous implementation does not work for tables with a small number of columns. No other tables should be effected by this change.

> [!NOTE]
> To support horizontal scrolling for any new tables, simply apply `tableProps={{ sx: { whiteSpace: "nowrap" } }}` to the table

> [!NOTE]
> To test this change, use the ICDC loading file examples and look at the `enrollment` node.

### Change Details (Specifics)

- Remove `horizontalScroll` prop
- Add a wrapper around the GenericTable Table element and allow width expansion beyond the full width
- Update GenericTable tests for this change

### Related Ticket(s)

CRDCDH-1318
