### PR TITLE
CRDCDH-1318 Fix Data View Table Width

### DIFF
--- a/src/components/GenericTable/index.test.tsx
+++ b/src/components/GenericTable/index.test.tsx
@@ -136,18 +136,13 @@ describe("GenericTable", () => {
   });
 
   describe("Style Application", () => {
-    it("applies horizontal scroll styles when enabled", () => {
-      const { container } = setup({ ...defaultProps, horizontalScroll: true });
-      expect(container.querySelector("table")).toHaveStyle("white-space: nowrap");
-      expect(container.querySelector("table")).toHaveStyle("display: block");
-      expect(container.querySelector("table")).toHaveStyle("overflow-x: auto");
-    });
+    it("applies tableProps to the table element", () => {
+      const { container } = setup({
+        ...defaultProps,
+        tableProps: { sx: { backgroundColor: "red" } },
+      });
 
-    it("does not apply horizontal scroll styles when disabled", () => {
-      const { container } = setup({ ...defaultProps, horizontalScroll: false });
-      expect(container.querySelector("table")).toHaveStyle("white-space: initial");
-      expect(container.querySelector("table")).toHaveStyle("display: table");
-      expect(container.querySelector("table")).toHaveStyle("overflow-x: initial");
+      expect(container.querySelector("table")).toHaveStyle("background-color: red");
     });
 
     it("applies borderBottom style conditionally based on row position", () => {
@@ -194,11 +189,6 @@ describe("GenericTable", () => {
   });
 
   describe("Visual and Interaction Features", () => {
-    it("checks styled component properties when horizontal scroll is enabled", () => {
-      const { container } = setup({ ...defaultProps, horizontalScroll: true });
-      expect(container.querySelector(".MuiTable-root")).toHaveStyle("display: block");
-    });
-
     it("renders top and bottom pagination when position is both", () => {
       const { getByTestId } = setup({ ...defaultProps, position: "both" });
       const topPagination = getByTestId("generic-table-rows-per-page-top");

--- a/src/components/GenericTable/index.tsx
+++ b/src/components/GenericTable/index.tsx
@@ -8,6 +8,7 @@ import {
   TableContainerProps,
   TableHead,
   TablePaginationProps,
+  TableProps,
   TableRow,
   TableSortLabel,
   Typography,
@@ -54,13 +55,10 @@ const StyledTableContainer = styled(TableContainer)({
   },
 });
 
-const StyledTable = styled(Table, {
-  shouldForwardProp: (p) => p !== "horizontalScroll",
-})<{ horizontalScroll: boolean }>(({ horizontalScroll }) => ({
-  whiteSpace: horizontalScroll ? "nowrap" : "initial",
-  display: horizontalScroll ? "block" : "table",
-  overflowX: horizontalScroll ? "auto" : "initial",
-}));
+const StyledTableWrapper = styled("div")({
+  overflowX: "auto",
+  width: "100%",
+});
 
 const StyledTableHead = styled(TableHead)({
   background: "#4D7C8F",
@@ -119,13 +117,13 @@ export type Props<T> = {
   total: number;
   loading?: boolean;
   disableUrlParams?: boolean;
-  horizontalScroll?: boolean;
   position?: PaginationPosition;
   noContentText?: string;
   defaultOrder?: Order;
   defaultRowsPerPage?: number;
   rowsPerPageOptions?: number[];
   paginationPlacement?: CSSProperties["justifyContent"];
+  tableProps?: TableProps;
   containerProps?: TableContainerProps;
   numRowsNoContent?: number;
   AdditionalActions?: React.ReactNode;
@@ -146,13 +144,13 @@ const GenericTable = <T,>(
     total: initTotal = 0,
     loading,
     disableUrlParams = true,
-    horizontalScroll = false,
     position = "bottom",
     noContentText,
     defaultOrder = "desc",
     defaultRowsPerPage = 10,
     rowsPerPageOptions = [5, 10, 20, 50],
     paginationPlacement,
+    tableProps,
     containerProps,
     numRowsNoContent = 10,
     AdditionalActions,
@@ -421,88 +419,90 @@ const GenericTable = <T,>(
       {(position === "top" || position === "both") && (
         <Pagination verticalPlacement="top" disabled={!data || loading || !paramsInitialized} />
       )}
-      <StyledTable horizontalScroll={horizontalScroll && total > 0}>
-        {columns?.length > 0 && (
-          <TableHeadComponent>
-            <TableRow>
-              {columns.map((col: Column<T>) => (
-                <TableHeaderCellComponent
-                  key={col.label.toString()}
-                  sx={col.sx}
-                  data-testid={`generic-table-header-${col.label.toString()}`}
-                >
-                  {!col.sortDisabled ? (
-                    <TableSortLabel
-                      active={orderByColumn === col}
-                      direction={orderByColumn === col ? sortDirection : "asc"}
-                      onClick={() => handleRequestSort(col)}
-                    >
-                      {col.label}
-                    </TableSortLabel>
-                  ) : (
-                    col.label
-                  )}
-                </TableHeaderCellComponent>
-              ))}
-            </TableRow>
-          </TableHeadComponent>
-        )}
-        <TableBody>
-          {(!paramsInitialized || showDelayedLoading) && (total === 0 || !data?.length)
-            ? Array.from(Array(numRowsNoContent).keys())?.map((_, idx) => (
-                <StyledTableRow key={`loading_row_${idx}`}>
+      <StyledTableWrapper>
+        <Table {...tableProps}>
+          {columns?.length > 0 && (
+            <TableHeadComponent>
+              <TableRow>
+                {columns.map((col: Column<T>) => (
+                  <TableHeaderCellComponent
+                    key={col.label.toString()}
+                    sx={col.sx}
+                    data-testid={`generic-table-header-${col.label.toString()}`}
+                  >
+                    {!col.sortDisabled ? (
+                      <TableSortLabel
+                        active={orderByColumn === col}
+                        direction={orderByColumn === col ? sortDirection : "asc"}
+                        onClick={() => handleRequestSort(col)}
+                      >
+                        {col.label}
+                      </TableSortLabel>
+                    ) : (
+                      col.label
+                    )}
+                  </TableHeaderCellComponent>
+                ))}
+              </TableRow>
+            </TableHeadComponent>
+          )}
+          <TableBody>
+            {(!paramsInitialized || showDelayedLoading) && (total === 0 || !data?.length)
+              ? Array.from(Array(numRowsNoContent).keys())?.map((_, idx) => (
+                  <StyledTableRow key={`loading_row_${idx}`}>
+                    <TableCell colSpan={columns.length} />
+                  </StyledTableRow>
+                ))
+              : data?.map((d: T, idx: number) => {
+                  const itemKey = setItemKey ? setItemKey(d, idx) : d["_id"];
+                  return (
+                    <TableRow tabIndex={-1} hover key={itemKey}>
+                      {columns.map((col: Column<T>) => (
+                        <TableBodyCellComponent
+                          key={`${itemKey}_${col.label}`}
+                          sx={{
+                            borderBottom:
+                              idx !== (data?.length ?? 0) - 1 ? "1px solid #6B7294" : "none",
+                          }}
+                          data-testid="table-body-cell-with-data"
+                        >
+                          {col.renderValue(d)}
+                        </TableBodyCellComponent>
+                      ))}
+                    </TableRow>
+                  );
+                })}
+
+            {!showDelayedLoading &&
+              paramsInitialized &&
+              emptyRows > 0 &&
+              Array.from(Array(emptyRows).keys())?.map((row) => (
+                <StyledTableRow key={`empty_row_${row}`}>
                   <TableCell colSpan={columns.length} />
                 </StyledTableRow>
-              ))
-            : data?.map((d: T, idx: number) => {
-                const itemKey = setItemKey ? setItemKey(d, idx) : d["_id"];
-                return (
-                  <TableRow tabIndex={-1} hover key={itemKey}>
-                    {columns.map((col: Column<T>) => (
-                      <TableBodyCellComponent
-                        key={`${itemKey}_${col.label}`}
-                        sx={{
-                          borderBottom:
-                            idx !== (data?.length ?? 0) - 1 ? "1px solid #6B7294" : "none",
-                        }}
-                        data-testid="table-body-cell-with-data"
-                      >
-                        {col.renderValue(d)}
-                      </TableBodyCellComponent>
-                    ))}
-                  </TableRow>
-                );
-              })}
+              ))}
 
-          {!showDelayedLoading &&
-            paramsInitialized &&
-            emptyRows > 0 &&
-            Array.from(Array(emptyRows).keys())?.map((row) => (
-              <StyledTableRow key={`empty_row_${row}`}>
-                <TableCell colSpan={columns.length} />
-              </StyledTableRow>
-            ))}
-
-          {/* No content message */}
-          {!showDelayedLoading &&
-            paramsInitialized &&
-            (!total || total === 0 || (total && !data?.length)) && (
-              <TableRow style={{ height: 46 * numRowsNoContent }}>
-                <TableCell colSpan={columns.length}>
-                  <Typography
-                    variant="body1"
-                    align="center"
-                    fontSize={18}
-                    fontWeight={500}
-                    color="#757575"
-                  >
-                    {noContentText || "No existing data was found"}
-                  </Typography>
-                </TableCell>
-              </TableRow>
-            )}
-        </TableBody>
-      </StyledTable>
+            {/* No content message */}
+            {!showDelayedLoading &&
+              paramsInitialized &&
+              (!total || total === 0 || (total && !data?.length)) && (
+                <TableRow style={{ height: 46 * numRowsNoContent }}>
+                  <TableCell colSpan={columns.length}>
+                    <Typography
+                      variant="body1"
+                      align="center"
+                      fontSize={18}
+                      fontWeight={500}
+                      color="#757575"
+                    >
+                      {noContentText || "No existing data was found"}
+                    </Typography>
+                  </TableCell>
+                </TableRow>
+              )}
+          </TableBody>
+        </Table>
+      </StyledTableWrapper>
       {(position === "bottom" || position === "both") && (
         <Pagination verticalPlacement="bottom" disabled={!data || loading || !paramsInitialized} />
       )}

--- a/src/content/dataSubmissions/SubmittedData.tsx
+++ b/src/content/dataSubmissions/SubmittedData.tsx
@@ -159,10 +159,10 @@ const SubmittedData: FC<Props> = ({ submissionId, submissionName }) => {
         defaultOrder="desc"
         position="both"
         AdditionalActions={Actions}
-        horizontalScroll
         setItemKey={(item, idx) => `${idx}_${item.nodeID}_${item.nodeID}`}
         onFetchData={handleFetchData}
         containerProps={{ sx: { marginBottom: "8px" } }}
+        tableProps={{ sx: { whiteSpace: "nowrap" } }}
       />
     </>
   );


### PR DESCRIPTION
### Overview

This PR changes how a horizontal scrolling table should be implemented. The previous implementation does not work for tables with a small number of columns. No other tables should be effected by this change.

> [!NOTE]
> To support horizontal scrolling for any new tables, simply apply `tableProps={{ sx: { whiteSpace: "nowrap" } }}` to the table

> [!NOTE]
> To test this change, use the ICDC loading file examples and look at the `enrollment` node.

### Change Details (Specifics)

- Remove `horizontalScroll` prop
- Add a wrapper around the GenericTable Table element and allow width expansion beyond the full width
- Update GenericTable tests for this change

### Related Ticket(s)

CRDCDH-1318
