### PR TITLE
fix: Heavy rerendering caused by SubmissionContext polling

### DIFF
--- a/src/components/Contexts/SubmissionContext.tsx
+++ b/src/components/Contexts/SubmissionContext.tsx
@@ -1,6 +1,8 @@
-import React, { FC, createContext, useCallback, useContext, useEffect, useState } from "react";
+import React, { FC, createContext, useCallback, useContext, useMemo, useState } from "react";
 import { ApolloError, ApolloQueryResult, useQuery } from "@apollo/client";
+import { cloneDeep, isEqual } from "lodash";
 import { GetSubmissionResp, GET_SUBMISSION, GetSubmissionInput } from "../../graphql";
+import { compareNodeStats } from "../../utils";
 
 export type SubmissionCtxState = {
   /**
@@ -15,10 +17,6 @@ export type SubmissionCtxState = {
    * The error returned by the query
    */
   error: ApolloError | null;
-  /**
-   * Whether the query is currently polling
-   */
-  isPolling: boolean;
   /**
    * Initiates polling for the query at the specified interval
    */
@@ -41,20 +39,10 @@ export type SubmissionCtxState = {
 
 export enum SubmissionCtxStatus {
   LOADING = "LOADING",
+  POLLING = "POLLING",
   LOADED = "LOADED",
   ERROR = "ERROR",
 }
-
-const initialState: SubmissionCtxState = {
-  status: SubmissionCtxStatus.LOADING,
-  data: null,
-  error: null,
-  isPolling: false,
-  startPolling: null,
-  stopPolling: null,
-  refetch: null,
-  updateQuery: null,
-};
 
 /**
  * Data Submission Context
@@ -93,6 +81,18 @@ type ProviderProps = {
 };
 
 /**
+ * A memoized version of the Submission Provider
+ *
+ * @note This is to prevent unnecessary re-renders when the context value hasn't changed
+ */
+const MemoedProvider = React.memo<{ value: SubmissionCtxState; children: React.ReactNode }>(
+  ({ value, children }) => (
+    <SubmissionContext.Provider value={value}>{children}</SubmissionContext.Provider>
+  ),
+  isEqual
+);
+
+/**
  * Data Submission Provider component
  *
  * @note This provider will automatically start polling if:
@@ -102,7 +102,6 @@ type ProviderProps = {
  * @returns React Context Provider
  */
 export const SubmissionProvider: FC<ProviderProps> = ({ _id, children }: ProviderProps) => {
-  const [state, setState] = useState<SubmissionCtxState>(initialState);
   const [isPolling, setIsPolling] = useState<boolean>(false);
 
   const {
@@ -114,7 +113,6 @@ export const SubmissionProvider: FC<ProviderProps> = ({ _id, children }: Provide
     refetch,
     updateQuery,
   } = useQuery<GetSubmissionResp, GetSubmissionInput>(GET_SUBMISSION, {
-    notifyOnNetworkStatusChange: true,
     onCompleted: (d) => {
       const isValidating =
         d?.getSubmission?.fileValidationStatus === "Validating" ||
@@ -136,6 +134,34 @@ export const SubmissionProvider: FC<ProviderProps> = ({ _id, children }: Provide
     fetchPolicy: "cache-and-network",
   });
 
+  const status: SubmissionCtxStatus = useMemo<SubmissionCtxStatus>(() => {
+    if (error || (!loading && !data?.getSubmission?._id)) {
+      return SubmissionCtxStatus.ERROR;
+    }
+    if (isPolling) {
+      return SubmissionCtxStatus.POLLING;
+    }
+    if (loading) {
+      return SubmissionCtxStatus.LOADING;
+    }
+
+    return SubmissionCtxStatus.LOADED;
+  }, [loading, error, data, isPolling]);
+
+  const memoedData: GetSubmissionResp = useMemo<GetSubmissionResp>(() => {
+    let sortedStats = [];
+    if (data?.submissionStats?.stats && data.submissionStats.stats instanceof Array) {
+      sortedStats = cloneDeep(data.submissionStats.stats);
+      sortedStats.sort(compareNodeStats);
+    }
+
+    return {
+      getSubmission: data?.getSubmission,
+      submissionStats: { stats: sortedStats },
+      listBatches: data?.listBatches,
+    };
+  }, [data]);
+
   /**
    * Wrapper function to start polling for the submission
    */
@@ -155,34 +181,18 @@ export const SubmissionProvider: FC<ProviderProps> = ({ _id, children }: Provide
     setIsPolling(false);
   }, [stopApolloPolling]);
 
-  useEffect(() => {
-    if (loading) {
-      setState({
-        ...state,
-        status: SubmissionCtxStatus.LOADING,
-      });
-      return;
-    }
-    if (error || !data?.getSubmission?._id) {
-      setState({
-        ...state,
-        status: SubmissionCtxStatus.ERROR,
-        error,
-      });
-      return;
-    }
-
-    setState({
-      status: SubmissionCtxStatus.LOADED,
-      data,
+  const value: SubmissionCtxState = useMemo<SubmissionCtxState>(
+    () => ({
+      status,
+      data: memoedData,
       error,
-      isPolling,
       startPolling,
       stopPolling,
       refetch,
       updateQuery,
-    });
-  }, [loading, error, data, isPolling, startPolling, stopPolling, refetch, updateQuery]);
+    }),
+    [status, memoedData, error, startPolling, stopPolling, refetch, updateQuery]
+  );
 
-  return <SubmissionContext.Provider value={state}>{children}</SubmissionContext.Provider>;
+  return <MemoedProvider value={value}>{children}</MemoedProvider>;
 };

--- a/src/components/Contexts/SubmissionContext.tsx
+++ b/src/components/Contexts/SubmissionContext.tsx
@@ -151,7 +151,7 @@ export const SubmissionProvider: FC<ProviderProps> = ({ _id, children }: Provide
 
   const memoedData: GetSubmissionResp = useMemo<GetSubmissionResp>(() => {
     let sortedStats = [];
-    if (data?.submissionStats?.stats && data.submissionStats.stats instanceof Array) {
+    if (Array.isArray(data?.submissionStats?.stats)) {
       sortedStats = cloneDeep(data.submissionStats.stats);
       sortedStats.sort(compareNodeStats);
     }

--- a/src/components/Contexts/SubmissionContext.tsx
+++ b/src/components/Contexts/SubmissionContext.tsx
@@ -113,6 +113,7 @@ export const SubmissionProvider: FC<ProviderProps> = ({ _id, children }: Provide
     refetch,
     updateQuery,
   } = useQuery<GetSubmissionResp, GetSubmissionInput>(GET_SUBMISSION, {
+    notifyOnNetworkStatusChange: true,
     onCompleted: (d) => {
       const isValidating =
         d?.getSubmission?.fileValidationStatus === "Validating" ||

--- a/src/components/DataSubmissions/CrossValidationButton.test.tsx
+++ b/src/components/DataSubmissions/CrossValidationButton.test.tsx
@@ -64,7 +64,6 @@ const baseSubmissionCtx: SubmissionCtxState = {
   status: SubmissionCtxStatus.LOADING,
   data: null,
   error: null,
-  isPolling: false,
   startPolling: jest.fn(),
   stopPolling: jest.fn(),
   refetch: jest.fn(),

--- a/src/components/DataSubmissions/ValidationControls.test.tsx
+++ b/src/components/DataSubmissions/ValidationControls.test.tsx
@@ -64,7 +64,6 @@ const baseSubmissionCtx: SubmissionCtxState = {
   status: SubmissionCtxStatus.LOADING,
   data: null,
   error: null,
-  isPolling: false,
   startPolling: jest.fn(),
   stopPolling: jest.fn(),
   refetch: jest.fn(),

--- a/src/content/dataSubmissions/DataActivity.test.tsx
+++ b/src/content/dataSubmissions/DataActivity.test.tsx
@@ -77,7 +77,6 @@ describe("General", () => {
         },
       },
       error: null,
-      isPolling: false,
     });
 
     const mocks: MockedResponse<ListBatchesResp>[] = [
@@ -121,7 +120,6 @@ describe("General", () => {
         listBatches: null,
       },
       error: null,
-      isPolling: false,
       refetch: null,
     });
 
@@ -158,7 +156,6 @@ describe("General", () => {
         listBatches: null,
       },
       error: null,
-      isPolling: false,
       refetch: null,
     });
 
@@ -190,7 +187,6 @@ describe("General", () => {
       status: SubmissionCtxStatus.LOADED,
       data: null,
       error: null,
-      isPolling: false,
     });
 
     const { container } = render(<DataActivity />, {
@@ -222,7 +218,6 @@ describe("Table", () => {
         },
       },
       error: null,
-      isPolling: false,
     });
 
     const mocks: MockedResponse<ListBatchesResp>[] = [
@@ -278,7 +273,6 @@ describe("Table", () => {
         },
       },
       error: null,
-      isPolling: false,
       refetch: mockRefetch,
     });
 
@@ -318,7 +312,7 @@ describe("Table", () => {
   it("should not refetch the submission if the submission is already polling", async () => {
     const mockRefetch = jest.fn();
     jest.spyOn(SubmissionCtx, "useSubmissionContext").mockReturnValue({
-      status: SubmissionCtxStatus.LOADED,
+      status: SubmissionCtxStatus.POLLING,
       data: {
         getSubmission: {
           _id: "refetching-submission-test",
@@ -332,7 +326,6 @@ describe("Table", () => {
         },
       },
       error: null,
-      isPolling: true, // NOTE: This is the only difference
       refetch: mockRefetch,
     });
 
@@ -385,7 +378,6 @@ describe("Table", () => {
         },
       },
       error: null,
-      isPolling: false,
     });
 
     const mocks: MockedResponse<ListBatchesResp>[] = [

--- a/src/content/dataSubmissions/DataActivity.tsx
+++ b/src/content/dataSubmissions/DataActivity.tsx
@@ -14,7 +14,10 @@ import { useSnackbar } from "notistack";
 import { LIST_BATCHES, ListBatchesResp } from "../../graphql";
 import GenericTable, { Column } from "../../components/GenericTable";
 import BatchTableContext from "./Contexts/BatchTableContext";
-import { useSubmissionContext } from "../../components/Contexts/SubmissionContext";
+import {
+  SubmissionCtxStatus,
+  useSubmissionContext,
+} from "../../components/Contexts/SubmissionContext";
 import { FormatDate } from "../../utils";
 import FileListDialog from "../../components/FileListDialog";
 import ErrorDetailsDialog from "../../components/ErrorDetailsDialog";
@@ -153,7 +156,7 @@ const DataActivity = forwardRef<DataActivityRef>((_, ref) => {
   const {
     data: dataSubmission,
     refetch: getSubmission,
-    isPolling: isSubmissionPolling,
+    status: submissionStatus,
   } = useSubmissionContext();
   const { _id: submissionId } = dataSubmission?.getSubmission || {};
 
@@ -275,7 +278,7 @@ const DataActivity = forwardRef<DataActivityRef>((_, ref) => {
       startPollingFn(1000);
 
       // If the submission is not polling, refetch to kick-off polling
-      if (!isSubmissionPolling) {
+      if (submissionStatus !== SubmissionCtxStatus.POLLING) {
         getSubmission();
       }
     }


### PR DESCRIPTION
### Overview

This PR resolves one of the issues identified in #423; When the SubmissionContext is polling for status changes, it forces almost all of the nested components to rerender, even when there are no changes in the data. This also addresses an issue with the Table Tooltips reopening constantly on hover when polling. 

Before (rerenders highlighted):

https://github.com/user-attachments/assets/d5a161eb-35f0-436e-a7ce-0eca9df64d6f

After (rerenders highlighted):

https://github.com/user-attachments/assets/e34b9e38-a48c-4786-8e89-6a8ea7fae0f0


### Change Details (Specifics)

- Memoize the submission context state
- Memoize the SubmissionContext Provider
- Remove `isPolling` from the context state and use `status` of `POLLING` instead

### Related Ticket(s)

N/A
