### PR TITLE
CRDCDH-1247 Require Cross Validation with related Released submissions

### DIFF
--- a/src/components/DataSubmissions/CrossValidationButton.test.tsx
+++ b/src/components/DataSubmissions/CrossValidationButton.test.tsx
@@ -214,6 +214,7 @@ describe("Basic Functionality", () => {
             otherSubmissions: JSON.stringify({
               "In Progress": [],
               Submitted: ["submitted-id"],
+              Released: [],
             }),
           }}
         />
@@ -262,6 +263,7 @@ describe("Basic Functionality", () => {
             otherSubmissions: JSON.stringify({
               "In Progress": [],
               Submitted: ["submitted-id"],
+              Released: [],
             }),
           }}
         />
@@ -306,6 +308,7 @@ describe("Basic Functionality", () => {
             otherSubmissions: JSON.stringify({
               "In Progress": [],
               Submitted: ["submitted-id"],
+              Released: [],
             }),
           }}
         />
@@ -340,6 +343,7 @@ describe("Implementation Requirements", () => {
             otherSubmissions: JSON.stringify({
               "In Progress": [],
               Submitted: ["submitted-id"],
+              Released: [],
             }),
           }}
         />
@@ -361,6 +365,7 @@ describe("Implementation Requirements", () => {
             otherSubmissions: JSON.stringify({
               "In Progress": ["some-other-id"],
               Submitted: ["submitted-id"],
+              Released: [],
             }),
           }}
         />
@@ -380,6 +385,7 @@ describe("Implementation Requirements", () => {
       otherSubmissions: JSON.stringify({
         "In Progress": [],
         Submitted: ["submitted-id"],
+        Released: [],
       }),
     };
 
@@ -419,6 +425,30 @@ describe("Implementation Requirements", () => {
             otherSubmissions: JSON.stringify({
               "In Progress": [],
               Submitted: ["submitted-id", "another-submitted-id"],
+              Released: [],
+            }),
+          }}
+        />
+      </TestParent>
+    );
+
+    expect(getByTestId("cross-validate-button")).toBeInTheDocument();
+    expect(getByTestId("cross-validate-button")).toBeEnabled();
+  });
+
+  it("should be enabled only if there are other related Released submissions", () => {
+    const { getByTestId } = render(
+      <TestParent authCtxState={{ ...baseAuthCtx, user: { ...baseUser, role: "Admin" } }}>
+        <CrossValidationButton
+          submission={{
+            ...baseSubmission,
+            _id: "validating-test-id",
+            status: "Submitted",
+            crossSubmissionStatus: "New",
+            otherSubmissions: JSON.stringify({
+              "In Progress": [],
+              Submitted: [],
+              Released: ["submitted-id", "another-submitted-id"],
             }),
           }}
         />
@@ -441,6 +471,7 @@ describe("Implementation Requirements", () => {
             otherSubmissions: JSON.stringify({
               "In Progress": ["in-prog-id", "another-in-prog-id"],
               Submitted: [], // NOTE: This disables the button
+              Released: [],
             }),
           }}
         />
@@ -464,6 +495,7 @@ describe("Implementation Requirements", () => {
               otherSubmissions: JSON.stringify({
                 "In Progress": ["submitted-id", "another-submitted-id"],
                 Submitted: ["submitted-id", "another-submitted-id"],
+                Released: ["submitted-id", "another-submitted-id"],
               }),
             }}
           />
@@ -489,6 +521,7 @@ describe("Implementation Requirements", () => {
               otherSubmissions: JSON.stringify({
                 "In Progress": [],
                 Submitted: ["submitted-id", "another-submitted-id"],
+                Released: [],
               }),
             }}
           />
@@ -518,6 +551,7 @@ describe("Implementation Requirements", () => {
               "In Progress": [],
               // NOTE: Even with these values, the button should not render
               Submitted: ["submitted-id", "another-submitted-id"],
+              Released: ["x", "y", "z"],
             }),
           }}
         />
@@ -539,6 +573,7 @@ describe("Implementation Requirements", () => {
             otherSubmissions: JSON.stringify({
               "In Progress": [],
               Submitted: ["this-enables-the-button"],
+              Released: [],
             }),
           }}
         />
@@ -570,6 +605,7 @@ describe("Implementation Requirements", () => {
             otherSubmissions: JSON.stringify({
               "In Progress": [],
               Submitted: ["this-enables-the-button"],
+              Released: ["also-would-enable-the-button"],
             }),
           }}
         />

--- a/src/components/DataSubmissions/CrossValidationButton.tsx
+++ b/src/components/DataSubmissions/CrossValidationButton.tsx
@@ -56,6 +56,8 @@ export const CrossValidationButton: FC<Props> = ({ submission, ...props }) => {
 
   const { _id, status, crossSubmissionStatus, otherSubmissions } = submission || {};
   const parsedSubmissions = safeParse<OtherSubmissions>(otherSubmissions);
+  const hasOtherSubmissions =
+    parsedSubmissions?.Submitted?.length > 0 || parsedSubmissions?.Released?.length > 0;
 
   const [loading, setLoading] = useState<boolean>(false);
   const [isValidating, setIsValidating] = useState<boolean>(crossSubmissionStatus === "Validating");
@@ -122,7 +124,7 @@ export const CrossValidationButton: FC<Props> = ({ submission, ...props }) => {
   if (
     !user?.role ||
     !CrossValidateRoles.includes(user.role) ||
-    !parsedSubmissions?.Submitted?.length ||
+    !hasOtherSubmissions ||
     status !== "Submitted"
   ) {
     return null;

--- a/src/types/Submissions.d.ts
+++ b/src/types/Submissions.d.ts
@@ -80,7 +80,7 @@ type CrossSubmissionStatus = Exclude<ValidationStatus, "Warning">;
  * @example ```{ "Submitted": ["abc-0001", "xyz-0002"], "In Progress": ["bge-0003"] }```
  */
 type OtherSubmissions = {
-  [key in Extract<SubmissionStatus, "In Progress" | "Submitted">]: string[];
+  [key in Extract<SubmissionStatus, "In Progress" | "Submitted" | "Released">]: string[];
 };
 
 type SubmissionStatus =

--- a/src/utils/dataSubmissionUtils.test.ts
+++ b/src/utils/dataSubmissionUtils.test.ts
@@ -721,6 +721,7 @@ describe("shouldDisableRelease", () => {
       otherSubmissions: JSON.stringify({
         "In Progress": [],
         Submitted: [],
+        Released: [],
       }),
     });
 
@@ -728,13 +729,14 @@ describe("shouldDisableRelease", () => {
     expect(result.requireAlert).toBe(false);
   });
 
-  it("should allow release with alert when other submissions are In Progress and there are no Submitted submissions", () => {
+  it("should allow release with alert when other submissions are In Progress and there are no related submissions", () => {
     const result: ReleaseInfo = utils.shouldDisableRelease({
       ...baseSubmission,
       crossSubmissionStatus: null,
       otherSubmissions: JSON.stringify({
         "In Progress": ["ABC-123", "XYZ-456"],
         Submitted: [],
+        Released: [],
       }),
     });
 
@@ -743,7 +745,7 @@ describe("shouldDisableRelease", () => {
   });
 
   it.each<CrossSubmissionStatus>(["Passed"])(
-    "should allow release when crossSubmissionStatus is %s and other submissions exist",
+    "should allow release when crossSubmissionStatus is %s even if other submissions exist",
     (status) => {
       const result: ReleaseInfo = utils.shouldDisableRelease({
         ...baseSubmission,
@@ -751,6 +753,7 @@ describe("shouldDisableRelease", () => {
         otherSubmissions: JSON.stringify({
           "In Progress": ["ABC-123", "XYZ-456"],
           Submitted: ["DEF-456", "GHI-789"],
+          Released: ["JKL-012", "MNO-345"],
         }),
       });
 
@@ -774,6 +777,7 @@ describe("shouldDisableRelease", () => {
         otherSubmissions: JSON.stringify({
           "In Progress": ["ABC-123", "XYZ-456"],
           Submitted: ["DEF-456", "GHI-789"],
+          Released: ["JKL-012", "MNO-345"],
         }),
       });
 
@@ -781,6 +785,36 @@ describe("shouldDisableRelease", () => {
       expect(result.requireAlert).toBe(false);
     }
   );
+
+  it("should not allow release when cross validation has not run and there are Submitted submissions", () => {
+    const result: ReleaseInfo = utils.shouldDisableRelease({
+      ...baseSubmission,
+      crossSubmissionStatus: null,
+      otherSubmissions: JSON.stringify({
+        "In Progress": ["ABC-123", "XYZ-456"],
+        Submitted: ["JKL-012", "MNO-345"],
+        Released: null,
+      }),
+    });
+
+    expect(result.disable).toBe(true);
+    expect(result.requireAlert).toBe(false);
+  });
+
+  it("should not allow release when cross validation has not run and there are Released submissions", () => {
+    const result: ReleaseInfo = utils.shouldDisableRelease({
+      ...baseSubmission,
+      crossSubmissionStatus: null,
+      otherSubmissions: JSON.stringify({
+        "In Progress": ["ABC-123", "XYZ-456"],
+        Submitted: null,
+        Released: ["JKL-012", "MNO-345"],
+      }),
+    });
+
+    expect(result.disable).toBe(true);
+    expect(result.requireAlert).toBe(false);
+  });
 
   it("should not throw an exception when Submission is null", () => {
     expect(() => utils.shouldDisableRelease(null as Submission)).not.toThrow();

--- a/src/utils/dataSubmissionUtils.ts
+++ b/src/utils/dataSubmissionUtils.ts
@@ -134,12 +134,14 @@ export const shouldDisableRelease = (submission: Submission): ReleaseInfo => {
   }
 
   // Scenario 1: All other submissions are "In Progress", allow release with alert
-  if (parsedSubmissions?.Submitted?.length === 0 && parsedSubmissions["In Progress"]?.length > 0) {
+  const hasRelatedSubmitted = parsedSubmissions?.Submitted?.length > 0;
+  const hasRelatedReleased = parsedSubmissions?.Released?.length > 0;
+  if (!hasRelatedSubmitted && !hasRelatedReleased && parsedSubmissions["In Progress"]?.length > 0) {
     return { disable: false, requireAlert: true };
   }
 
-  // Scenario 2: More than one other "Submitted" submission exists, disable release entirely
-  if (parsedSubmissions?.Submitted?.length > 0) {
+  // Scenario 2: More than one other Submitted/Released submission exists, disable release entirely
+  if (hasRelatedSubmitted || hasRelatedReleased) {
     return { disable: true, requireAlert: false };
   }
 


### PR DESCRIPTION
### Overview

This PR improves upon CRDCDH-922, requiring Cross Validation **also** when there are submissions for the same study that are released. Previously, it was only for "Submitted" submissions

### Change Details (Specifics)

- Update CrossValidateButton and related utils to also check for "Released" submissions
- Update related type definitions

### Related Ticket(s)

CRDCDH-1247
