### PR TITLE
CRDCDH-1489 Cross Submission Validation Updates

### DIFF
--- a/src/types/Submissions.d.ts
+++ b/src/types/Submissions.d.ts
@@ -80,7 +80,10 @@ type CrossSubmissionStatus = Exclude<ValidationStatus, "Warning">;
  * @example ```{ "Submitted": ["abc-0001", "xyz-0002"], "In Progress": ["bge-0003"] }```
  */
 type OtherSubmissions = {
-  [key in Extract<SubmissionStatus, "In Progress" | "Submitted" | "Released">]: string[];
+  [key in Extends<
+    SubmissionStatus,
+    "In Progress" | "Submitted" | "Released" | "Rejected" | "Withdrawn"
+  >]: string[];
 };
 
 type SubmissionStatus =

--- a/src/utils/dataSubmissionUtils.test.ts
+++ b/src/utils/dataSubmissionUtils.test.ts
@@ -722,6 +722,8 @@ describe("shouldDisableRelease", () => {
         "In Progress": [],
         Submitted: [],
         Released: [],
+        Rejected: [],
+        Withdrawn: [],
       }),
     });
 
@@ -729,20 +731,26 @@ describe("shouldDisableRelease", () => {
     expect(result.requireAlert).toBe(false);
   });
 
-  it("should allow release with alert when other submissions are In Progress and there are no related submissions", () => {
-    const result: ReleaseInfo = utils.shouldDisableRelease({
-      ...baseSubmission,
-      crossSubmissionStatus: null,
-      otherSubmissions: JSON.stringify({
-        "In Progress": ["ABC-123", "XYZ-456"],
-        Submitted: [],
-        Released: [],
-      }),
-    });
+  it.each<SubmissionStatus>(["In Progress", "Rejected", "Withdrawn"])(
+    "should allow release with alert when other submissions are %s and there are no related submissions",
+    (status) => {
+      const existingSubmissions = ["ABC-123", "XYZ-456"];
+      const result: ReleaseInfo = utils.shouldDisableRelease({
+        ...baseSubmission,
+        crossSubmissionStatus: null,
+        otherSubmissions: JSON.stringify({
+          "In Progress": status === "In Progress" ? existingSubmissions : [],
+          Submitted: [],
+          Released: [],
+          Rejected: status === "Rejected" ? existingSubmissions : [],
+          Withdrawn: status === "Withdrawn" ? existingSubmissions : [],
+        }),
+      });
 
-    expect(result.disable).toBe(false);
-    expect(result.requireAlert).toBe(true);
-  });
+      expect(result.disable).toBe(false);
+      expect(result.requireAlert).toBe(true);
+    }
+  );
 
   it.each<CrossSubmissionStatus>(["Passed"])(
     "should allow release when crossSubmissionStatus is %s even if other submissions exist",
@@ -754,6 +762,8 @@ describe("shouldDisableRelease", () => {
           "In Progress": ["ABC-123", "XYZ-456"],
           Submitted: ["DEF-456", "GHI-789"],
           Released: ["JKL-012", "MNO-345"],
+          Rejected: ["PQR-678", "STU-901"],
+          Withdrawn: ["VWX-234", "YZA-567"],
         }),
       });
 
@@ -778,6 +788,8 @@ describe("shouldDisableRelease", () => {
           "In Progress": ["ABC-123", "XYZ-456"],
           Submitted: ["DEF-456", "GHI-789"],
           Released: ["JKL-012", "MNO-345"],
+          Rejected: ["PQR-678", "STU-901"],
+          Withdrawn: ["VWX-234", "YZA-567"],
         }),
       });
 
@@ -794,6 +806,8 @@ describe("shouldDisableRelease", () => {
         "In Progress": ["ABC-123", "XYZ-456"],
         Submitted: ["JKL-012", "MNO-345"],
         Released: null,
+        Rejected: [],
+        Withdrawn: [],
       }),
     });
 
@@ -809,6 +823,8 @@ describe("shouldDisableRelease", () => {
         "In Progress": ["ABC-123", "XYZ-456"],
         Submitted: null,
         Released: ["JKL-012", "MNO-345"],
+        Rejected: [],
+        Withdrawn: [],
       }),
     });
 

--- a/src/utils/dataSubmissionUtils.ts
+++ b/src/utils/dataSubmissionUtils.ts
@@ -136,10 +136,16 @@ export const shouldDisableRelease = (submission: Submission): ReleaseInfo => {
     return { disable: false, requireAlert: false };
   }
 
-  // Scenario 1: All other submissions are "In Progress", allow release with alert
+  // Scenario 1: All other submissions are "In Progress", "Rejected", or "Withdrawn", allow release with alert
   const hasRelatedSubmitted = parsedSubmissions?.Submitted?.length > 0;
   const hasRelatedReleased = parsedSubmissions?.Released?.length > 0;
-  if (!hasRelatedSubmitted && !hasRelatedReleased && parsedSubmissions["In Progress"]?.length > 0) {
+
+  const hasRelatedInProgress = parsedSubmissions?.["In Progress"]?.length > 0;
+  const hasRelatedRejected = parsedSubmissions?.Rejected?.length > 0;
+  const hasRelatedWithdrawn = parsedSubmissions?.Withdrawn?.length > 0;
+  const allowRelatedWithAlert = hasRelatedInProgress || hasRelatedRejected || hasRelatedWithdrawn;
+
+  if (!hasRelatedSubmitted && !hasRelatedReleased && allowRelatedWithAlert) {
     return { disable: false, requireAlert: true };
   }
 


### PR DESCRIPTION
### Overview

Added consideration for "Rejected" and "Withdrawn" statuses belonging to other submissions within the same study. This will display a custom alert message (same one "In Progress" was already using) when a Data Curator/Admin clicks the Release button and gets a dialog popup. 

### Change Details (Specifics)

- Updated `shouldDisableRelease` utility function logic to include "Rejected" and "Withdrawn" when checking whether or not to require an alert
- Updated tests for the utility function
- Updated types

> [!NOTE]
> Should be merged after BE PR is merged. https://github.com/CBIIT/crdc-datahub-backend/pull/411

### Related Ticket(s)

[CRDCDH-1489](https://tracker.nci.nih.gov/browse/CRDCDH-1489)
