### PR TITLE
CRDCDH-1545 Create Submission validate dbGaPID for controlled access study

### DIFF
--- a/src/components/DataSubmissions/CreateDataSubmissionDialog.tsx
+++ b/src/components/DataSubmissions/CreateDataSubmissionDialog.tsx
@@ -509,6 +509,7 @@ const CreateDataSubmissionDialog: FC<Props> = ({ onCreate }) => {
                   <StyledOutlinedInput
                     {...register("dbGaPID", {
                       required: isDbGapRequired ? "This field is required" : null,
+                      validate: isDbGapRequired ? validateEmpty : null,
                     })}
                     inputProps={{ maxLength: 50 }}
                     placeholder="Input dbGaP ID"


### PR DESCRIPTION
### Overview

Updated create submission field to validate empty value when dbGaPID is required. Previously you could enter empty spaces to bypass required field.

### Change Details (Specifics)

N/A

> [!NOTE]
> This is separate from BE implementation, but related. Can be merged independently from each other.  

### Related Ticket(s)

[CRDCDH-1545](https://tracker.nci.nih.gov/browse/CRDCDH-1545)
