### PR TITLE
CRDCDH-1496 Add `Federal Monitor` to Operation Dashboard

### DIFF
--- a/src/config/AuthRoles.ts
+++ b/src/config/AuthRoles.ts
@@ -1,5 +1,5 @@
 /**
- * Defines a list of valid user roles.
+ * Defines a list of valid user roles that can be assigned.
  *
  * @type {User["role"][]}
  */
@@ -11,9 +11,6 @@ export const Roles: User["role"][] = [
   "Data Curator",
   "Data Commons POC",
   "Admin",
-  // TODO: Disabled in MVP-1
-  // "Concierge",
-  // "DC_OWNER",
 ];
 
 /**
@@ -49,4 +46,9 @@ export const CrossValidateRoles: User["role"][] = ["Admin", "Data Curator"];
 /**
  * Defines a list of roles that are allowed to interact with the Operation Dashboard.
  */
-export const DashboardRoles: User["role"][] = ["Admin", "Data Curator", "Federal Lead"];
+export const DashboardRoles: User["role"][] = [
+  "Admin",
+  "Data Curator",
+  "Federal Lead",
+  "Federal Monitor",
+];

--- a/src/types/Auth.d.ts
+++ b/src/types/Auth.d.ts
@@ -8,9 +8,8 @@ type User = {
     | "Submitter"
     | "Organization Owner"
     | "Federal Lead"
-    // | "Concierge"
+    | "Federal Monitor"
     | "Data Curator"
-    // | "DC_OWNER"
     | "Data Commons POC"
     | "Admin";
   IDP: "nih" | "login.gov";


### PR DESCRIPTION
### Overview

This PR extends CRDCDH-1444 to allow the "Federal Monitor" role to access the Operation Dashboard. 

> [!NOTE]
> This role cannot actually be assigned ATM but this can be merged regardless.

### Change Details (Specifics)

- Remove comments relating to MVP-1 roles that will not be added
- Update Auth Role type definitions to support `Federal Monitor`
- Update DashboardRoles to add `Federal Monitor`

### Related Ticket(s)

CRDCDH-1496 (FE Task)
CRDCDH-1474 (User Story)
