### PR TITLE
Empty commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "build": "react-scripts build",
     "eject": "react-scripts eject",
     "test": "TZ=UTC react-scripts test",
-    "test:ci": "TZ=UTC CI=true react-scripts test --passWithNoTests --coverage",
+    "test:ci": "TZ=UTC CI=true react-scripts test --passWithNoTests --coverage --maxWorkers=2 --maxConcurrent=2",
     "lint": "eslint . --ignore-path .gitignore",
     "lint:ci": "eslint . --ignore-path .gitignore --max-warnings 0",
     "lint:fix": "eslint --fix . --ignore-path .gitignore",

--- a/src/components/FileListDialog/index.test.tsx
+++ b/src/components/FileListDialog/index.test.tsx
@@ -42,17 +42,19 @@ const TestParent: FC<ParentProps> = ({ children }) => (
 
 describe("Accessibility", () => {
   it("should have no violations (no files)", async () => {
-    const { container } = render(
+    const { container, getByTestId } = render(
       <TestParent>
         <Dialog open batch={baseBatch} />
       </TestParent>
     );
 
+    await waitFor(() => expect(getByTestId("file-list-dialog")).toBeVisible());
+
     expect(await axe(container)).toHaveNoViolations();
   });
 
   it("should have no violations (with files)", async () => {
-    const { container } = render(
+    const { container, getByTestId } = render(
       <TestParent>
         <Dialog
           open
@@ -68,6 +70,8 @@ describe("Accessibility", () => {
         />
       </TestParent>
     );
+
+    await waitFor(() => expect(getByTestId("file-list-dialog")).toBeVisible());
 
     expect(await axe(container)).toHaveNoViolations();
   });

--- a/src/content/dataSubmissions/SubmittedData.test.tsx
+++ b/src/content/dataSubmissions/SubmittedData.test.tsx
@@ -390,11 +390,14 @@ describe("SubmittedData > General", () => {
       "All selected nodes are currently being deleted. Please wait..."
     );
 
-    rerender(
-      <TestParent mocks={[]} submissionId="sub-delete-alert" deletingData={false}>
-        <SubmittedData />
-      </TestParent>
-    );
+    // eslint-disable-next-line testing-library/no-unnecessary-act
+    act(() => {
+      rerender(
+        <TestParent mocks={[]} submissionId="sub-delete-alert" deletingData={false}>
+          <SubmittedData />
+        </TestParent>
+      );
+    });
 
     await waitFor(() => {
       expect(getByTestId("submitted-data-deletion-alert")).not.toBeVisible();

--- a/src/content/dataSubmissions/SubmittedData.test.tsx
+++ b/src/content/dataSubmissions/SubmittedData.test.tsx
@@ -3,7 +3,7 @@ import { MockedProvider, MockedResponse } from "@apollo/client/testing";
 import { GraphQLError } from "graphql";
 import { MemoryRouter } from "react-router-dom";
 import { axe } from "jest-axe";
-import { render, waitFor } from "@testing-library/react";
+import { act, render, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import SubmittedData from "./SubmittedData";
 import {
@@ -333,7 +333,10 @@ describe("SubmittedData > General", () => {
       expect(getAllByRole("checkbox")).toHaveLength(21);
     });
 
-    userEvent.click(getAllByRole("checkbox")[0]); // click 'Select All' checkbox
+    // eslint-disable-next-line testing-library/no-unnecessary-act
+    act(() => {
+      userEvent.click(getAllByRole("checkbox")[0]); // click 'Select All' checkbox
+    });
 
     await waitFor(() => {
       expect(global.mockEnqueue).toHaveBeenCalledWith(


### PR DESCRIPTION
Ignore this. Opening a PR so I can run Jest. These two files keep failing on CI only:

https://github.com/CBIIT/crdc-datahub-ui/actions/runs/10409644376/job/28829712043?pr=441

> FAIL src/content/dataSubmissions/SubmittedData.test.tsx (45.734 s)
  ● SubmittedData > General › should show an error message when 'Select All' failed to fetch all nodes (network)

    thrown: "Exceeded timeout of 5000 ms for a test.
    Use jest.setTimeout(newTimeout) to increase the timeout value, if this is a long-running test."

      285 |   });
      286 |
    > 287 |   it("should show an error message when 'Select All' failed to fetch all nodes (network)", async () => {
          |   ^
      288 |     const getNodesMock: MockedResponse<GetSubmissionNodesResp, GetSubmissionNodesInput> = {
      289 |       maxUsageCount: 2, // initial query + orderBy bug
      290 |       request: {

      at src/content/dataSubmissions/SubmittedData.test.tsx:287:3
      at Object.<anonymous> (src/content/dataSubmissions/SubmittedData.test.tsx:92:1)


https://github.com/CBIIT/crdc-datahub-ui/actions/runs/10409644376/job/28829790535?pr=441

> FAIL src/components/FileListDialog/index.test.tsx
  ● Accessibility › should have no violations (with files)

    Expected test not to call console.error().

    If the error is expected, test for it explicitly by mocking it out using jest.spyOn(console, 'error').mockImplementation() and test that the warning occurs.

    Warning: An update to Transition inside a test was not wrapped in act(...).

    When testing, code that causes React state updates should be wrapped into act(...):

    act(() => {
      /* fire events that update state */
    });
    /* assert on the output */

    This ensures that you're testing the behavior the user would see in the browser. Learn more at https://reactjs.org/link/wrap-tests-with-act

      1[68](https://github.com/CBIIT/crdc-datahub-ui/actions/runs/10409644376/job/28829790535?pr=441#step:6:69) | } & Omit<DialogProps, "onClose">;
      1[69](https://github.com/CBIIT/crdc-datahub-ui/actions/runs/10409644376/job/28829790535?pr=441#step:6:70) |
    > 1[70](https://github.com/CBIIT/crdc-datahub-ui/actions/runs/10409644376/job/28829790535?pr=441#step:6:71) | const FileListDialog = ({ batch, onClose, open, ...rest }: Props) => {
          |                           ^
      1[71](https://github.com/CBIIT/crdc-datahub-ui/actions/runs/10409644376/job/28829790535?pr=441#step:6:72) |   const [batchFiles, setBatchFiles] = useState<BatchFileInfo[]>([]);
      1[72](https://github.com/CBIIT/crdc-datahub-ui/actions/runs/10409644376/job/28829790535?pr=441#step:6:73) |   const [prevBatchFilesFetch, setPrevBatchFilesFetch] = useState<FetchListing<BatchFileInfo>>(null);
      1[73](https://github.com/CBIIT/crdc-datahub-ui/actions/runs/10409644376/job/28829790535?pr=441#step:6:74) |