### PR TITLE
CRDCDH-1605 Standardize Node Type filter sorting

### DIFF
--- a/src/components/DataSubmissions/CrossValidationFilters.test.tsx
+++ b/src/components/DataSubmissions/CrossValidationFilters.test.tsx
@@ -7,11 +7,11 @@ import { GraphQLError } from "graphql";
 import Filters from "./CrossValidationFilters";
 import {
   LIST_BATCHES,
-  LIST_NODE_TYPES,
+  SUBMISSION_STATS,
   ListBatchesInput,
   ListBatchesResp,
-  ListNodeTypesInput,
-  ListNodeTypesResp,
+  SubmissionStatsInput,
+  SubmissionStatsResp,
 } from "../../graphql";
 import {
   SubmissionContext,
@@ -110,14 +110,16 @@ describe("CrossValidationFilters cases", () => {
   });
 
   it("should handle empty nodes and batches without issues", async () => {
-    const nodesMock: MockedResponse<ListNodeTypesResp, ListNodeTypesInput> = {
+    const nodesMock: MockedResponse<SubmissionStatsResp, SubmissionStatsInput> = {
       request: {
-        query: LIST_NODE_TYPES,
+        query: SUBMISSION_STATS,
       },
       variableMatcher: () => true,
       result: {
         data: {
-          listSubmissionNodeTypes: [],
+          submissionStats: {
+            stats: [],
+          },
         },
       },
     };
@@ -149,9 +151,9 @@ describe("CrossValidationFilters cases", () => {
   });
 
   it("should handle GraphQL errors when fetching nodes without issues", async () => {
-    const graphqlErrorNodesMock: MockedResponse<ListNodeTypesResp, ListNodeTypesInput> = {
+    const graphqlErrorNodesMock: MockedResponse<SubmissionStatsResp, SubmissionStatsInput> = {
       request: {
-        query: LIST_NODE_TYPES,
+        query: SUBMISSION_STATS,
       },
       variableMatcher: () => true,
       result: {
@@ -187,9 +189,9 @@ describe("CrossValidationFilters cases", () => {
   });
 
   it("should handle network errors when fetching nodes without issues", async () => {
-    const networkErrorNodesMock: MockedResponse<ListNodeTypesResp, ListNodeTypesInput> = {
+    const networkErrorNodesMock: MockedResponse<SubmissionStatsResp, SubmissionStatsInput> = {
       request: {
-        query: LIST_NODE_TYPES,
+        query: SUBMISSION_STATS,
       },
       variableMatcher: () => true,
       error: new Error("Network Error"),
@@ -223,14 +225,16 @@ describe("CrossValidationFilters cases", () => {
   });
 
   it("should handle GraphQL errors when fetching batches without issues", async () => {
-    const nodesMock: MockedResponse<ListNodeTypesResp, ListNodeTypesInput> = {
+    const nodesMock: MockedResponse<SubmissionStatsResp, SubmissionStatsInput> = {
       request: {
-        query: LIST_NODE_TYPES,
+        query: SUBMISSION_STATS,
       },
       variableMatcher: () => true,
       result: {
         data: {
-          listSubmissionNodeTypes: [],
+          submissionStats: {
+            stats: [],
+          },
         },
       },
     };
@@ -254,14 +258,16 @@ describe("CrossValidationFilters cases", () => {
   });
 
   it("should handle network errors when fetching batches without issues", async () => {
-    const nodesMock: MockedResponse<ListNodeTypesResp, ListNodeTypesInput> = {
+    const nodesMock: MockedResponse<SubmissionStatsResp, SubmissionStatsInput> = {
       request: {
-        query: LIST_NODE_TYPES,
+        query: SUBMISSION_STATS,
       },
       variableMatcher: () => true,
       result: {
         data: {
-          listSubmissionNodeTypes: [],
+          submissionStats: {
+            stats: [],
+          },
         },
       },
     };
@@ -283,14 +289,16 @@ describe("CrossValidationFilters cases", () => {
   });
 
   it("should sort the batch filter by displayID in ascending order", async () => {
-    const nodesMock: MockedResponse<ListNodeTypesResp, ListNodeTypesInput> = {
+    const nodesMock: MockedResponse<SubmissionStatsResp, SubmissionStatsInput> = {
       request: {
-        query: LIST_NODE_TYPES,
+        query: SUBMISSION_STATS,
       },
       variableMatcher: () => true,
       result: {
         data: {
-          listSubmissionNodeTypes: [],
+          submissionStats: {
+            stats: [],
+          },
         },
       },
     };
@@ -351,14 +359,41 @@ describe("CrossValidationFilters cases", () => {
   });
 
   it("should sort the node names alphabetically in descending order", async () => {
-    const nodesMock: MockedResponse<ListNodeTypesResp, ListNodeTypesInput> = {
+    const nodesMock: MockedResponse<SubmissionStatsResp, SubmissionStatsInput> = {
       request: {
-        query: LIST_NODE_TYPES,
+        query: SUBMISSION_STATS,
       },
       variableMatcher: () => true,
       result: {
         data: {
-          listSubmissionNodeTypes: ["node-3", "node-1", "node-2"],
+          submissionStats: {
+            stats: [
+              {
+                nodeName: "node-3",
+                total: 0,
+                new: 0,
+                passed: 0,
+                warning: 0,
+                error: 0,
+              },
+              {
+                nodeName: "node-1",
+                total: 0,
+                new: 0,
+                passed: 0,
+                warning: 0,
+                error: 0,
+              },
+              {
+                nodeName: "node-2",
+                total: 0,
+                new: 0,
+                passed: 0,
+                warning: 0,
+                error: 0,
+              },
+            ],
+          },
         },
       },
     };
@@ -412,14 +447,41 @@ describe("CrossValidationFilters cases", () => {
   });
 
   it("should always visually render the nodeName as lowercase", async () => {
-    const nodesMock: MockedResponse<ListNodeTypesResp, ListNodeTypesInput> = {
+    const nodesMock: MockedResponse<SubmissionStatsResp, SubmissionStatsInput> = {
       request: {
-        query: LIST_NODE_TYPES,
+        query: SUBMISSION_STATS,
       },
       variableMatcher: () => true,
       result: {
         data: {
-          listSubmissionNodeTypes: ["NODE_NAME", "Upper_Case", "lower_case"],
+          submissionStats: {
+            stats: [
+              {
+                nodeName: "NODE_NAME",
+                total: 0,
+                new: 0,
+                passed: 0,
+                warning: 0,
+                error: 0,
+              },
+              {
+                nodeName: "Upper_Case",
+                total: 0,
+                new: 0,
+                passed: 0,
+                warning: 0,
+                error: 0,
+              },
+              {
+                nodeName: "lower_case",
+                total: 0,
+                new: 0,
+                passed: 0,
+                warning: 0,
+                error: 0,
+              },
+            ],
+          },
         },
       },
     };
@@ -462,14 +524,16 @@ describe("CrossValidationFilters cases", () => {
 
   it("should immediately dispatch Batch ID filter changes", async () => {
     const mockOnChange = jest.fn();
-    const nodesMock: MockedResponse<ListNodeTypesResp, ListNodeTypesInput> = {
+    const nodesMock: MockedResponse<SubmissionStatsResp, SubmissionStatsInput> = {
       request: {
-        query: LIST_NODE_TYPES,
+        query: SUBMISSION_STATS,
       },
       variableMatcher: () => true,
       result: {
         data: {
-          listSubmissionNodeTypes: [],
+          submissionStats: {
+            stats: [],
+          },
         },
       },
     };
@@ -528,14 +592,33 @@ describe("CrossValidationFilters cases", () => {
 
   it("should immediately dispatch NodeID ID filter changes", async () => {
     const mockOnChange = jest.fn();
-    const nodesMock: MockedResponse<ListNodeTypesResp, ListNodeTypesInput> = {
+    const nodesMock: MockedResponse<SubmissionStatsResp, SubmissionStatsInput> = {
       request: {
-        query: LIST_NODE_TYPES,
+        query: SUBMISSION_STATS,
       },
       variableMatcher: () => true,
       result: {
         data: {
-          listSubmissionNodeTypes: ["enrollment", "study"],
+          submissionStats: {
+            stats: [
+              {
+                nodeName: "study",
+                total: 0,
+                new: 0,
+                passed: 0,
+                warning: 0,
+                error: 0,
+              },
+              {
+                nodeName: "enrollment",
+                total: 0,
+                new: 0,
+                passed: 0,
+                warning: 0,
+                error: 0,
+              },
+            ],
+          },
         },
       },
     };
@@ -591,14 +674,16 @@ describe("CrossValidationFilters cases", () => {
 
   it("should immediately dispatch Severity filter changes", async () => {
     const mockOnChange = jest.fn();
-    const nodesMock: MockedResponse<ListNodeTypesResp, ListNodeTypesInput> = {
+    const nodesMock: MockedResponse<SubmissionStatsResp, SubmissionStatsInput> = {
       request: {
-        query: LIST_NODE_TYPES,
+        query: SUBMISSION_STATS,
       },
       variableMatcher: () => true,
       result: {
         data: {
-          listSubmissionNodeTypes: [],
+          submissionStats: {
+            stats: [],
+          },
         },
       },
     };

--- a/src/components/DataSubmissions/CrossValidationFilters.tsx
+++ b/src/components/DataSubmissions/CrossValidationFilters.tsx
@@ -3,15 +3,15 @@ import { Controller, useForm } from "react-hook-form";
 import { cloneDeep, isEqual } from "lodash";
 import { Box, FormControl, MenuItem, Stack, styled } from "@mui/material";
 import { useQuery } from "@apollo/client";
-import { FormatDate } from "../../utils";
+import { compareNodeStats, FormatDate } from "../../utils";
 import {
   CrossValidationResultsInput,
   LIST_BATCHES,
-  LIST_NODE_TYPES,
   ListBatchesInput,
   ListBatchesResp,
-  ListNodeTypesInput,
-  ListNodeTypesResp,
+  SUBMISSION_STATS,
+  SubmissionStatsInput,
+  SubmissionStatsResp,
 } from "../../graphql";
 import StyledSelect from "../StyledFormComponents/StyledSelect";
 import StyledLabel from "../StyledFormComponents/StyledLabel";
@@ -72,16 +72,22 @@ const CrossValidationFilters = forwardRef<null, FilterProps>(({ onChange }, ref)
     [batchData]
   );
 
-  const { data: nodeData } = useQuery<ListNodeTypesResp, ListNodeTypesInput>(LIST_NODE_TYPES, {
-    variables: { _id: submissionData?.getSubmission?._id },
-    context: { clientName: "backend" },
-    skip: !submissionData?.getSubmission?._id,
-    fetchPolicy: "cache-and-network",
-  });
+  const { data: submissionStats } = useQuery<SubmissionStatsResp, SubmissionStatsInput>(
+    SUBMISSION_STATS,
+    {
+      variables: { id: submissionData?.getSubmission?._id },
+      context: { clientName: "backend" },
+      skip: !submissionData?.getSubmission?._id,
+      fetchPolicy: "cache-and-network",
+    }
+  );
 
-  const nodeTypes: string[] = useMemo<string[]>(
-    () => cloneDeep(nodeData?.listSubmissionNodeTypes)?.sort((a, b) => a.localeCompare(b)) || [],
-    [nodeData?.listSubmissionNodeTypes]
+  const nodeTypes = useMemo<string[]>(
+    () =>
+      cloneDeep(submissionStats?.submissionStats?.stats)
+        ?.sort(compareNodeStats)
+        ?.map((stat) => stat.nodeName),
+    [submissionStats?.submissionStats?.stats]
   );
 
   useEffect(() => {

--- a/src/components/DataSubmissions/SubmittedDataFilters.test.tsx
+++ b/src/components/DataSubmissions/SubmittedDataFilters.test.tsx
@@ -4,7 +4,7 @@ import UserEvent from "@testing-library/user-event";
 import { axe } from "jest-axe";
 import { MockedProvider, MockedResponse } from "@apollo/client/testing";
 import SubmittedDataFilters from "./SubmittedDataFilters";
-import { SUBMISSION_STATS, SubmissionStatsResp } from "../../graphql";
+import { SUBMISSION_STATS, SubmissionStatsInput, SubmissionStatsResp } from "../../graphql";
 
 type ParentProps = {
   mocks?: MockedResponse[];
@@ -44,7 +44,7 @@ describe("SubmittedDataFilters cases", () => {
 
   it("should handle an empty array of node types without errors", async () => {
     const _id = "example-empty-results";
-    const mocks: MockedResponse<SubmissionStatsResp>[] = [
+    const mocks: MockedResponse<SubmissionStatsResp, SubmissionStatsInput>[] = [
       {
         request: {
           query: SUBMISSION_STATS,
@@ -70,9 +70,9 @@ describe("SubmittedDataFilters cases", () => {
   });
 
   // NOTE: The sorting function `compareNodeStats` is already heavily tested, this is just a sanity check
-  it("should sort the node types by count in descending order", async () => {
+  it("should sort the node types by count in ascending order", async () => {
     const _id = "example-sorting-by-count-id";
-    const mocks: MockedResponse<SubmissionStatsResp>[] = [
+    const mocks: MockedResponse<SubmissionStatsResp, SubmissionStatsInput>[] = [
       {
         request: {
           query: SUBMISSION_STATS,
@@ -109,20 +109,20 @@ describe("SubmittedDataFilters cases", () => {
         hidden: true,
       });
 
-      // The order of the nodes should be N-1 < N-2 < N-3
+      // The order of the nodes should be N-3, N-2, N-1
       expect(muiSelectList).toBeInTheDocument();
-      expect(muiSelectList.innerHTML.search("N-1")).toBeLessThan(
+      expect(muiSelectList.innerHTML.search("N-3")).toBeLessThan(
         muiSelectList.innerHTML.search("N-2")
       );
       expect(muiSelectList.innerHTML.search("N-2")).toBeLessThan(
-        muiSelectList.innerHTML.search("N-3")
+        muiSelectList.innerHTML.search("N-1")
       );
     });
   });
 
   it("should select the first sorted node type in the by default", async () => {
     const _id = "example-select-first-node-id";
-    const mocks: MockedResponse<SubmissionStatsResp>[] = [
+    const mocks: MockedResponse<SubmissionStatsResp, SubmissionStatsInput>[] = [
       {
         request: {
           query: SUBMISSION_STATS,
@@ -135,8 +135,8 @@ describe("SubmittedDataFilters cases", () => {
             submissionStats: {
               stats: [
                 { ...baseStatistic, nodeName: "SECOND", total: 3 },
-                { ...baseStatistic, nodeName: "FIRST", total: 999 },
-                { ...baseStatistic, nodeName: "THIRD", total: 1 },
+                { ...baseStatistic, nodeName: "THIRD", total: 999 },
+                { ...baseStatistic, nodeName: "FIRST", total: 1 },
               ],
             },
           },
@@ -158,7 +158,7 @@ describe("SubmittedDataFilters cases", () => {
   // NOTE: This test used to be the inverse, but we now want to ensure that Data Files are shown
   // Data Files are a special case, as they're common across all Data Models / Data Commons
   it("should show the nodeType 'data file' if present", async () => {
-    const mocks: MockedResponse<SubmissionStatsResp>[] = [
+    const mocks: MockedResponse<SubmissionStatsResp, SubmissionStatsInput>[] = [
       {
         request: {
           query: SUBMISSION_STATS,
@@ -197,7 +197,7 @@ describe("SubmittedDataFilters cases", () => {
   });
 
   it("should always visually render the nodeName as lowercase", async () => {
-    const mocks: MockedResponse<SubmissionStatsResp>[] = [
+    const mocks: MockedResponse<SubmissionStatsResp, SubmissionStatsInput>[] = [
       {
         request: {
           query: SUBMISSION_STATS,
@@ -236,7 +236,7 @@ describe("SubmittedDataFilters cases", () => {
 
   it("should immediately dispatch NodeType and Status filter changes", async () => {
     const mockOnChange = jest.fn();
-    const mocks: MockedResponse<SubmissionStatsResp>[] = [
+    const mocks: MockedResponse<SubmissionStatsResp, SubmissionStatsInput>[] = [
       {
         request: {
           query: SUBMISSION_STATS,
@@ -283,7 +283,7 @@ describe("SubmittedDataFilters cases", () => {
 
   it("should debounce the submittedID field input", async () => {
     const mockOnChange = jest.fn();
-    const mocks: MockedResponse<SubmissionStatsResp>[] = [
+    const mocks: MockedResponse<SubmissionStatsResp, SubmissionStatsInput>[] = [
       {
         request: {
           query: SUBMISSION_STATS,
@@ -327,7 +327,7 @@ describe("SubmittedDataFilters cases", () => {
 
   it("should dispatch an empty submittedID field input immediately", async () => {
     const mockOnChange = jest.fn();
-    const mocks: MockedResponse<SubmissionStatsResp>[] = [
+    const mocks: MockedResponse<SubmissionStatsResp, SubmissionStatsInput>[] = [
       {
         request: {
           query: SUBMISSION_STATS,
@@ -376,7 +376,7 @@ describe("SubmittedDataFilters cases", () => {
 
   it("should not dispatch a submittedID field with less than 3 characters", async () => {
     const mockOnChange = jest.fn();
-    const mocks: MockedResponse<SubmissionStatsResp>[] = [
+    const mocks: MockedResponse<SubmissionStatsResp, SubmissionStatsInput>[] = [
       {
         request: {
           query: SUBMISSION_STATS,

--- a/src/components/DataSubmissions/SubmittedDataFilters.tsx
+++ b/src/components/DataSubmissions/SubmittedDataFilters.tsx
@@ -4,7 +4,12 @@ import { cloneDeep, debounce, isEqual } from "lodash";
 import { Box, FormControl, MenuItem, Stack, styled } from "@mui/material";
 import { useQuery } from "@apollo/client";
 import { compareNodeStats } from "../../utils";
-import { GetSubmissionNodesInput, SUBMISSION_STATS, SubmissionStatsResp } from "../../graphql";
+import {
+  GetSubmissionNodesInput,
+  SUBMISSION_STATS,
+  SubmissionStatsInput,
+  SubmissionStatsResp,
+} from "../../graphql";
 import StyledSelect from "../StyledFormComponents/StyledSelect";
 import StyledInput from "../StyledFormComponents/StyledOutlinedInput";
 
@@ -66,18 +71,20 @@ const SubmittedDataFilters = forwardRef<FilterMethods, FilterProps>(
       debounce((form: FilterForm) => onChange?.(form), 500)
     ).current;
 
-    const { data, refetch } = useQuery<SubmissionStatsResp>(SUBMISSION_STATS, {
-      variables: { id: submissionId },
-      context: { clientName: "backend" },
-      skip: !submissionId,
-      fetchPolicy: "cache-and-network",
-    });
+    const { data, refetch } = useQuery<SubmissionStatsResp, SubmissionStatsInput>(
+      SUBMISSION_STATS,
+      {
+        variables: { id: submissionId },
+        context: { clientName: "backend" },
+        skip: !submissionId,
+        fetchPolicy: "cache-and-network",
+      }
+    );
 
     const nodeTypes = useMemo(
       () =>
         cloneDeep(data?.submissionStats?.stats)
           ?.sort(compareNodeStats)
-          ?.reverse()
           ?.map((stat) => stat.nodeName),
       [data?.submissionStats?.stats]
     );

--- a/src/content/dataSubmissions/CrossValidation.test.tsx
+++ b/src/content/dataSubmissions/CrossValidation.test.tsx
@@ -9,11 +9,11 @@ import {
   CrossValidationResultsInput,
   CrossValidationResultsResp,
   LIST_BATCHES,
-  LIST_NODE_TYPES,
+  SUBMISSION_STATS,
   ListBatchesInput,
   ListBatchesResp,
-  ListNodeTypesInput,
-  ListNodeTypesResp,
+  SubmissionStatsInput,
+  SubmissionStatsResp,
   SUBMISSION_CROSS_VALIDATION_RESULTS,
 } from "../../graphql";
 import {
@@ -82,14 +82,16 @@ const baseBatch = {
   __typename: "Batch",
 };
 
-const nodesMock: MockedResponse<ListNodeTypesResp, ListNodeTypesInput> = {
+const nodesMock: MockedResponse<SubmissionStatsResp, SubmissionStatsInput> = {
   request: {
-    query: LIST_NODE_TYPES,
+    query: SUBMISSION_STATS,
   },
   variableMatcher: () => true,
   result: {
     data: {
-      listSubmissionNodeTypes: [],
+      submissionStats: {
+        stats: [],
+      },
     },
   },
 };
@@ -274,14 +276,25 @@ describe("General", () => {
       },
     };
 
-    const nodesMockWithData: MockedResponse<ListNodeTypesResp, ListNodeTypesInput> = {
+    const nodesMockWithData: MockedResponse<SubmissionStatsResp, SubmissionStatsInput> = {
       request: {
-        query: LIST_NODE_TYPES,
+        query: SUBMISSION_STATS,
       },
       variableMatcher: () => true,
       result: {
         data: {
-          listSubmissionNodeTypes: ["node-xyz"],
+          submissionStats: {
+            stats: [
+              {
+                nodeName: "node-xyz",
+                total: 1,
+                new: 0,
+                passed: 1,
+                warning: 0,
+                error: 0,
+              },
+            ],
+          },
         },
       },
     };

--- a/src/content/dataSubmissions/QualityControl.test.tsx
+++ b/src/content/dataSubmissions/QualityControl.test.tsx
@@ -12,6 +12,7 @@ import {
   SUBMISSION_QC_RESULTS,
   SUBMISSION_STATS,
   SubmissionQCResultsResp,
+  SubmissionStatsInput,
   SubmissionStatsResp,
 } from "../../graphql";
 import {
@@ -78,7 +79,7 @@ const baseBatch = {
   __typename: "Batch",
 };
 
-const nodesMock: MockedResponse<SubmissionStatsResp> = {
+const nodesMock: MockedResponse<SubmissionStatsResp, SubmissionStatsInput> = {
   request: {
     query: SUBMISSION_STATS,
   },
@@ -273,7 +274,7 @@ describe("Filters", () => {
       },
     };
 
-    const nodesMockWithData: MockedResponse<SubmissionStatsResp> = {
+    const nodesMockWithData: MockedResponse<SubmissionStatsResp, SubmissionStatsInput> = {
       request: {
         query: SUBMISSION_STATS,
       },
@@ -383,7 +384,7 @@ describe("Filters", () => {
       },
     };
 
-    const nodesMock: MockedResponse<SubmissionStatsResp> = {
+    const nodesMock: MockedResponse<SubmissionStatsResp, SubmissionStatsInput> = {
       request: {
         query: SUBMISSION_STATS,
       },
@@ -447,7 +448,7 @@ describe("Filters", () => {
       },
     };
 
-    const nodesMock: MockedResponse<SubmissionStatsResp> = {
+    const nodesMock: MockedResponse<SubmissionStatsResp, SubmissionStatsInput> = {
       request: {
         query: SUBMISSION_STATS,
       },
@@ -485,13 +486,13 @@ describe("Filters", () => {
         }
       );
 
-      // The order of the nodes should be node-3, node-2, node-1
+      // The order of the nodes should be node-1, node-2, node-3
       expect(muiSelectList).toBeInTheDocument();
-      expect(muiSelectList.innerHTML.search("node-3")).toBeLessThan(
+      expect(muiSelectList.innerHTML.search("node-1")).toBeLessThan(
         muiSelectList.innerHTML.search("node-2")
       );
       expect(muiSelectList.innerHTML.search("node-2")).toBeLessThan(
-        muiSelectList.innerHTML.search("node-1")
+        muiSelectList.innerHTML.search("node-3")
       );
     });
   });
@@ -513,7 +514,7 @@ describe("Filters", () => {
       },
     };
 
-    const nodesMock: MockedResponse<SubmissionStatsResp> = {
+    const nodesMock: MockedResponse<SubmissionStatsResp, SubmissionStatsInput> = {
       request: {
         query: SUBMISSION_STATS,
       },

--- a/src/content/dataSubmissions/QualityControl.tsx
+++ b/src/content/dataSubmissions/QualityControl.tsx
@@ -11,6 +11,7 @@ import {
   SUBMISSION_QC_RESULTS,
   SUBMISSION_STATS,
   SubmissionQCResultsResp,
+  SubmissionStatsInput,
   SubmissionStatsResp,
 } from "../../graphql";
 import GenericTable, { Column } from "../../components/GenericTable";
@@ -238,19 +239,21 @@ const QualityControl: FC = () => {
     fetchPolicy: "cache-and-network",
   });
 
-  const { data: submissionStats } = useQuery<SubmissionStatsResp>(SUBMISSION_STATS, {
-    variables: { id: submissionId },
-    context: { clientName: "backend" },
-    skip: !submissionId,
-    fetchPolicy: "cache-and-network",
-  });
+  const { data: submissionStats } = useQuery<SubmissionStatsResp, SubmissionStatsInput>(
+    SUBMISSION_STATS,
+    {
+      variables: { id: submissionId },
+      context: { clientName: "backend" },
+      skip: !submissionId,
+      fetchPolicy: "cache-and-network",
+    }
+  );
 
-  const nodeTypes = useMemo(
+  const nodeTypes = useMemo<string[]>(
     () =>
       cloneDeep(submissionStats?.submissionStats?.stats)
         ?.filter((stat) => stat.error > 0 || stat.warning > 0)
         ?.sort(compareNodeStats)
-        ?.reverse()
         ?.map((stat) => stat.nodeName),
     [submissionStats?.submissionStats?.stats]
   );

--- a/src/content/dataSubmissions/SubmittedData.test.tsx
+++ b/src/content/dataSubmissions/SubmittedData.test.tsx
@@ -11,6 +11,7 @@ import {
   GetSubmissionNodesInput,
   GetSubmissionNodesResp,
   SUBMISSION_STATS,
+  SubmissionStatsInput,
   SubmissionStatsResp,
 } from "../../graphql";
 import { SearchParamsProvider } from "../../components/Contexts/SearchParamsContext";
@@ -100,7 +101,7 @@ describe("SubmittedData > General", () => {
     error: 0,
   };
 
-  const mockSubmissionQuery = {
+  const mockSubmissionQuery: MockedResponse<SubmissionStatsResp, SubmissionStatsInput> = {
     request: {
       query: SUBMISSION_STATS,
     },
@@ -410,7 +411,7 @@ describe("SubmittedData > Table", () => {
     error: 0,
   };
 
-  const mockSubmissionQuery: MockedResponse<SubmissionStatsResp> = {
+  const mockSubmissionQuery: MockedResponse<SubmissionStatsResp, SubmissionStatsInput> = {
     request: {
       query: SUBMISSION_STATS,
     },

--- a/src/graphql/index.ts
+++ b/src/graphql/index.ts
@@ -101,7 +101,10 @@ export type {
 } from "./getSubmissionNodes";
 
 export { query as SUBMISSION_STATS } from "./submissionStats";
-export type { Response as SubmissionStatsResp } from "./submissionStats";
+export type {
+  Input as SubmissionStatsInput,
+  Response as SubmissionStatsResp,
+} from "./submissionStats";
 
 export { mutation as DELETE_ORPHANED_FILE } from "./deleteOrphanedFile";
 export type { Response as DeleteOrphanedFileResp } from "./deleteOrphanedFile";

--- a/src/graphql/submissionStats.ts
+++ b/src/graphql/submissionStats.ts
@@ -15,6 +15,13 @@ export const query = gql`
   }
 `;
 
+export type Input = {
+  /**
+   * The ID of the submission to get statistics for
+   */
+  id: string;
+};
+
 export type Response = {
   /**
    * The node statistics for the submission


### PR DESCRIPTION
### Overview

This PR standardizes the sorting of the Node Type filter across different tabs on the Data Submission page.

### Change Details (Specifics)

- Define the input type definition for the SUBMISSION_STATS query and reference it in the implementations
- Cross Validation > Replace the usage of LIST_NODE_TYPES with SUBMISSION_STATS so we can sort the node order
- Data View and Validation Results > Remove the sorting reversal of the node types array
- Miscellaneous updates to test coverage related to these changes

### Related Ticket(s)

CRDCDH-1605 (Task)
CRDCDH-1562 (Story)
