### PR TITLE
CRDCDH-1614 Misc. CLI Config File dialog updates

### DIFF
--- a/src/components/DataSubmissions/DataUpload.test.tsx
+++ b/src/components/DataSubmissions/DataUpload.test.tsx
@@ -150,7 +150,9 @@ describe("Basic Functionality", () => {
     // Open the dialog
     userEvent.click(getByTestId("uploader-cli-config-button"));
 
-    // Skip filling the fields and click the download button
+    userEvent.type(getByTestId("uploader-config-dialog-input-data-folder"), "test-folder");
+    userEvent.type(getByTestId("uploader-config-dialog-input-manifest"), "test-manifest");
+
     userEvent.click(getByText("Download"));
 
     await waitFor(() => {
@@ -185,7 +187,9 @@ describe("Basic Functionality", () => {
     // Open the dialog
     userEvent.click(getByTestId("uploader-cli-config-button"));
 
-    // Skip filling the fields and click the download button
+    userEvent.type(getByTestId("uploader-config-dialog-input-data-folder"), "test-folder");
+    userEvent.type(getByTestId("uploader-config-dialog-input-manifest"), "test-manifest");
+
     userEvent.click(getByText("Download"));
 
     await waitFor(() => {
@@ -195,6 +199,61 @@ describe("Basic Functionality", () => {
           variant: "error",
         }
       );
+    });
+  });
+
+  it("should hide the CLI Configuration dialog when onClose is called", async () => {
+    const { getByTestId, findAllByRole, queryByRole } = render(
+      <TestParent mocks={[]}>
+        <DataUpload
+          submission={{
+            ...baseSubmission,
+            _id: "hide-config-dialog-on-close",
+            dataType: "Metadata and Data Files",
+          }}
+        />
+      </TestParent>
+    );
+
+    // Open the dialog
+    userEvent.click(getByTestId("uploader-cli-config-button"));
+
+    const dialog = await findAllByRole("presentation");
+
+    expect(dialog[1]).toBeVisible();
+
+    // Close the dialog
+    userEvent.click(dialog[1]);
+
+    await waitFor(() => {
+      expect(queryByRole("dialog")).not.toBeInTheDocument();
+    });
+  });
+
+  it("should hide the Uploader CLI dialog when onClose is called", async () => {
+    const { getByTestId, findAllByRole, queryByRole } = render(
+      <TestParent mocks={[]}>
+        <DataUpload
+          submission={{
+            ...baseSubmission,
+            _id: "hide-cli-dialog-on-close",
+          }}
+        />
+      </TestParent>
+    );
+
+    // Open the dialog
+    userEvent.click(getByTestId("uploader-cli-download-button"));
+
+    const dialog = await findAllByRole("presentation");
+
+    expect(dialog[1]).toBeVisible();
+
+    // Close the dialog
+    userEvent.click(dialog[1]);
+
+    await waitFor(() => {
+      expect(queryByRole("dialog")).not.toBeInTheDocument();
     });
   });
 });
@@ -334,7 +393,9 @@ describe("Implementation Requirements", () => {
       userEvent.click(getByTestId("uploader-cli-config-button"));
     });
 
-    // Skip filling the fields and click the download button
+    userEvent.type(getByTestId("uploader-config-dialog-input-data-folder"), "test-folder");
+    userEvent.type(getByTestId("uploader-config-dialog-input-manifest"), "test-manifest");
+
     // eslint-disable-next-line testing-library/no-unnecessary-act -- RHF is throwing an error without act
     await act(async () => {
       userEvent.click(getByText("Download"));
@@ -380,7 +441,9 @@ describe("Implementation Requirements", () => {
       // Open the dialog
       userEvent.click(getByTestId("uploader-cli-config-button"));
 
-      // Skip filling the fields and click the download button
+      userEvent.type(getByTestId("uploader-config-dialog-input-data-folder"), "test-folder");
+      userEvent.type(getByTestId("uploader-config-dialog-input-manifest"), "test-manifest");
+
       userEvent.click(getByText("Download"));
 
       await waitFor(() => {

--- a/src/components/DataSubmissions/DataUpload.tsx
+++ b/src/components/DataSubmissions/DataUpload.tsx
@@ -102,7 +102,7 @@ export const DataUpload: FC<Props> = ({ submission }: Props) => {
   };
 
   const Actions: ReactElement = useMemo(() => {
-    if (submission?.dataType === "Metadata Only") {
+    if (submission?.dataType !== "Metadata and Data Files") {
       return null;
     }
 

--- a/src/components/UploaderConfigDialog/index.test.tsx
+++ b/src/components/UploaderConfigDialog/index.test.tsx
@@ -98,7 +98,7 @@ describe("Basic Functionality", () => {
     });
   });
 
-  it("should call the onDownload function when the 'Download' button is clicked", async () => {
+  it("should call the onDownload function when the 'Download' button is clicked with a valid form", async () => {
     const { getByTestId } = render(
       <TestParent>
         <UploaderConfigDialog open onDownload={mockDownload} onClose={mockOnClose} />
@@ -106,6 +106,9 @@ describe("Basic Functionality", () => {
     );
 
     expect(mockDownload).not.toHaveBeenCalled();
+
+    userEvent.type(getByTestId("uploader-config-dialog-input-data-folder"), "test-folder");
+    userEvent.type(getByTestId("uploader-config-dialog-input-manifest"), "test-manifest");
 
     userEvent.click(getByTestId("uploader-config-dialog-download-button"));
 
@@ -152,6 +155,75 @@ describe("Basic Functionality", () => {
     await waitFor(() => {
       expect(dataFolderInput).toHaveValue("");
       expect(manifestInput).toHaveValue("");
+    });
+  });
+});
+
+describe("Implementation Requirements", () => {
+  const mockDownload = jest.fn();
+  const mockOnClose = jest.fn();
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("should not submit the form if any of the inputs are invalid", async () => {
+    const { getByTestId, queryAllByText } = render(
+      <TestParent>
+        <UploaderConfigDialog open onDownload={mockDownload} onClose={mockOnClose} />
+      </TestParent>
+    );
+
+    userEvent.click(getByTestId("uploader-config-dialog-download-button"));
+
+    await waitFor(() => {
+      expect(queryAllByText(/This field is required/)).toHaveLength(2);
+    });
+
+    expect(mockDownload).not.toHaveBeenCalled();
+  });
+
+  it("should have a tooltip on the Data Files Folder input", async () => {
+    const { getByTestId, findByRole } = render(
+      <TestParent>
+        <UploaderConfigDialog open onDownload={mockDownload} onClose={mockOnClose} />
+      </TestParent>
+    );
+
+    userEvent.hover(getByTestId("data-folder-input-tooltip"));
+
+    const tooltip = await findByRole("tooltip");
+    expect(tooltip).toBeInTheDocument();
+    expect(tooltip).toHaveTextContent(
+      "Enter the full path for the Data Files folder on your local machine or S3 bucket"
+    );
+
+    userEvent.unhover(getByTestId("data-folder-input-tooltip"));
+
+    await waitFor(() => {
+      expect(tooltip).not.toBeVisible();
+    });
+  });
+
+  it("should have a tooltip on the Manifest File input", async () => {
+    const { getByTestId, findByRole } = render(
+      <TestParent>
+        <UploaderConfigDialog open onDownload={mockDownload} onClose={mockOnClose} />
+      </TestParent>
+    );
+
+    userEvent.hover(getByTestId("manifest-input-tooltip"));
+
+    const tooltip = await findByRole("tooltip");
+    expect(tooltip).toBeInTheDocument();
+    expect(tooltip).toHaveTextContent(
+      "Enter the full path for the File Manifest on your local machine or S3 bucket"
+    );
+
+    userEvent.unhover(getByTestId("manifest-input-tooltip"));
+
+    await waitFor(() => {
+      expect(tooltip).not.toBeVisible();
     });
   });
 });

--- a/src/components/UploaderConfigDialog/index.tsx
+++ b/src/components/UploaderConfigDialog/index.tsx
@@ -168,38 +168,48 @@ const UploaderConfigDialog: FC<Props> = ({ onClose, onDownload, open, ...rest })
               Full Path to Data Files Folder
               <StyledAsterisk />
               <Tooltip
-                title="Enter the full path for the Data Files folder on your local machine or S3 bucket"
+                title="Enter the full path for the Data Files folder on your local machine or S3 bucket."
                 open={undefined}
                 disableHoverListener={false}
                 data-testid="data-folder-input-tooltip"
               />
             </StyledLabel>
             <StyledOutlinedInput
-              {...register("dataFolder", { required: "This field is required" })}
+              {...register("dataFolder", {
+                required: "This field is required",
+                setValueAs: (v: string) => v?.trim(),
+              })}
               placeholder="/Users/me/my-data-files-folder"
               data-testid="uploader-config-dialog-input-data-folder"
               inputProps={{ "aria-labelledby": "data-folder-input-label" }}
             />
-            <StyledHelperText>{errors?.dataFolder?.message}</StyledHelperText>
+            <StyledHelperText data-testid="uploader-config-dialog-error-data-folder">
+              {errors?.dataFolder?.message}
+            </StyledHelperText>
           </Box>
           <Box>
             <StyledLabel id="manifest-input-label">
               Full Path to Manifest File
               <StyledAsterisk />
               <Tooltip
-                title="Enter the full path for the File Manifest on your local machine or S3 bucket"
+                title="Enter the full path for the File Manifest on your local machine or S3 bucket."
                 open={undefined}
                 disableHoverListener={false}
                 data-testid="manifest-input-tooltip"
               />
             </StyledLabel>
             <StyledOutlinedInput
-              {...register("manifest", { required: "This field is required" })}
+              {...register("manifest", {
+                required: "This field is required",
+                setValueAs: (v: string) => v?.trim(),
+              })}
               placeholder="/Users/me/my-metadata-folder/my-file-manifest.tsv"
               data-testid="uploader-config-dialog-input-manifest"
               inputProps={{ "aria-labelledby": "manifest-input-label" }}
             />
-            <StyledHelperText>{errors?.manifest?.message}</StyledHelperText>
+            <StyledHelperText data-testid="uploader-config-dialog-error-manifest">
+              {errors?.manifest?.message}
+            </StyledHelperText>
           </Box>
         </StyledForm>
       </StyledDialogContent>

--- a/src/components/UploaderConfigDialog/index.tsx
+++ b/src/components/UploaderConfigDialog/index.tsx
@@ -11,9 +11,13 @@ import {
 } from "@mui/material";
 import { LoadingButton } from "@mui/lab";
 import { useForm } from "react-hook-form";
+import { isEqual } from "lodash";
 import { ReactComponent as CloseIconSvg } from "../../assets/icons/close_icon.svg";
 import StyledOutlinedInput from "../StyledFormComponents/StyledOutlinedInput";
 import StyledLabel from "../StyledFormComponents/StyledLabel";
+import StyledAsterisk from "../StyledFormComponents/StyledAsterisk";
+import Tooltip from "../Tooltip";
+import StyledHelperText from "../StyledFormComponents/StyledHelperText";
 
 const StyledDialog = styled(Dialog)({
   "& .MuiDialog-paper": {
@@ -65,7 +69,7 @@ const StyledCloseDialogButton = styled(IconButton)({
 const StyledForm = styled("form")({
   display: "flex",
   flexDirection: "column",
-  gap: "28px",
+  gap: "8px",
   margin: "0 auto",
   marginTop: "28px",
   maxWidth: "484px",
@@ -117,13 +121,14 @@ type Props = {
  * @returns {React.FC<Props>}
  */
 const UploaderConfigDialog: FC<Props> = ({ onClose, onDownload, open, ...rest }) => {
-  const { reset, register, getValues } = useForm<InputForm>();
+  const { reset, register, handleSubmit, formState } = useForm<InputForm>();
+  const { errors } = formState;
 
   const [downloading, setDownloading] = useState<boolean>(false);
 
-  const handleDownload = async () => {
+  const onSubmit = async (data: InputForm) => {
     setDownloading(true);
-    await onDownload(getValues());
+    await onDownload(data);
     setDownloading(false);
   };
 
@@ -151,33 +156,50 @@ const UploaderConfigDialog: FC<Props> = ({ onClose, onDownload, open, ...rest })
         data-testid="uploader-config-dialog-header"
         variant="h1"
       >
-        Download
-        <br />
-        Configuration File
+        Download Configuration File
       </StyledHeader>
       <StyledDialogContent>
         <StyledBodyText data-testid="uploader-config-dialog-body" variant="body1">
-          Please provide the full pathway to the data files on your local system and to the file
-          manifest.
+          Please provide the full path to the data files and to the file manifest.
         </StyledBodyText>
-        <StyledForm onSubmit={handleDownload}>
+        <StyledForm onSubmit={handleSubmit(onSubmit)} id="uploader-config-dialog-form">
           <Box>
-            <StyledLabel id="data-folder-input-label">Local Path of Data Files Folder</StyledLabel>
+            <StyledLabel id="data-folder-input-label">
+              Full Path to Data Files Folder
+              <StyledAsterisk />
+              <Tooltip
+                title="Enter the full path for the Data Files folder on your local machine or S3 bucket"
+                open={undefined}
+                disableHoverListener={false}
+                data-testid="data-folder-input-tooltip"
+              />
+            </StyledLabel>
             <StyledOutlinedInput
-              {...register("dataFolder", { required: true })}
+              {...register("dataFolder", { required: "This field is required" })}
               placeholder="/Users/me/my-data-files-folder"
               data-testid="uploader-config-dialog-input-data-folder"
               inputProps={{ "aria-labelledby": "data-folder-input-label" }}
             />
+            <StyledHelperText>{errors?.dataFolder?.message}</StyledHelperText>
           </Box>
           <Box>
-            <StyledLabel id="manifest-input-label">Local Path of Manifest File</StyledLabel>
+            <StyledLabel id="manifest-input-label">
+              Full Path to Manifest File
+              <StyledAsterisk />
+              <Tooltip
+                title="Enter the full path for the File Manifest on your local machine or S3 bucket"
+                open={undefined}
+                disableHoverListener={false}
+                data-testid="manifest-input-tooltip"
+              />
+            </StyledLabel>
             <StyledOutlinedInput
-              {...register("manifest", { required: true })}
+              {...register("manifest", { required: "This field is required" })}
               placeholder="/Users/me/my-metadata-folder/my-file-manifest.tsv"
               data-testid="uploader-config-dialog-input-manifest"
               inputProps={{ "aria-labelledby": "manifest-input-label" }}
             />
+            <StyledHelperText>{errors?.manifest?.message}</StyledHelperText>
           </Box>
         </StyledForm>
       </StyledDialogContent>
@@ -192,7 +214,8 @@ const UploaderConfigDialog: FC<Props> = ({ onClose, onDownload, open, ...rest })
         <StyledButton
           data-testid="uploader-config-dialog-download-button"
           variant="outlined"
-          onClick={handleDownload}
+          type="submit"
+          form="uploader-config-dialog-form"
           loading={downloading}
         >
           Download
@@ -202,4 +225,4 @@ const UploaderConfigDialog: FC<Props> = ({ onClose, onDownload, open, ...rest })
   );
 };
 
-export default UploaderConfigDialog;
+export default React.memo<Props>(UploaderConfigDialog, isEqual);


### PR DESCRIPTION
### Overview

This PR modifies the CLI Configuration download dialog to make fields required and update the verbiage to indicate S3 buckets are now supported.

### Change Details (Specifics)

- Update the CLI Config form to make the data file folder path and file manifest path fields required
- Update the CLI Config dialog to memoize it
- Standardize the dataType logic in the DataUpload component
- Update test coverage for the misc. changes

### Related Ticket(s)

CRDCDH-1614 (Task)
CRDCDH-1565 (User Story)
