### PR TITLE
CRDCDH-1632 Data Curator Data Commons assignment

### DIFF
--- a/src/config/AuthRoles.ts
+++ b/src/config/AuthRoles.ts
@@ -26,10 +26,9 @@ export const OrgRequiredRoles: UserRole[] = ["Submitter", "Organization Owner", 
  *
  * @note This requires that an organization with the specified name exists in the database.
  */
-type RoleSubset = Extends<UserRole, "Admin" | "Data Curator" | "Federal Lead" | "Federal Monitor">;
+type RoleSubset = Extends<UserRole, "Admin" | "Federal Lead" | "Federal Monitor">;
 export const OrgAssignmentMap: Record<RoleSubset, string> = {
   Admin: "FNL",
-  "Data Curator": "FNL",
   "Federal Lead": "NCI",
   "Federal Monitor": "NCI",
 };

--- a/src/content/users/ProfileView.tsx
+++ b/src/content/users/ProfileView.tsx
@@ -443,7 +443,7 @@ const ProfileView: FC<Props> = ({ _id, viewType }: Props) => {
                   user.userStatus
                 )}
               </StyledField>
-              <StyledField>
+              <StyledField visible={fieldset.organization !== "HIDDEN"}>
                 <StyledLabel id="userOrganizationLabel">Organization</StyledLabel>
                 {visibleFieldState.includes(fieldset.organization) ? (
                   <Controller

--- a/src/hooks/useProfileFields.ts
+++ b/src/hooks/useProfileFields.ts
@@ -72,10 +72,15 @@ const useProfileFields = (
   }
 
   // Only applies to Data Commons POC
-  if (profileOf?.role === "Data Commons POC") {
+  if (profileOf?.role === "Data Commons POC" || profileOf?.role === "Data Curator") {
     fields.dataCommons = user?.role === "Admin" && viewType === "users" ? "UNLOCKED" : "READ_ONLY";
   } else {
     fields.dataCommons = "HIDDEN";
+  }
+
+  // Only applies to Data Curator
+  if (profileOf?.role === "Data Curator") {
+    fields.organization = "HIDDEN";
   }
 
   return fields;


### PR DESCRIPTION
### Overview

This PR updates the Data Curator implementation to add Data Commons assignment, identical to Data Commons POC functionality.

> [!NOTE]
> This feature is still waiting for BE updates including:
> - Allow assignment of Data Commons to a Curator
> - Update the on save error message when a DC is not assigned
>
> But the PR can be merged without these changes.

### Change Details (Specifics)

- Require Data Commons for Data Curators
- Hide Organization field for Data Curators 
- Update ProfileView to support a hidden Organization field (previously wasn't necessary)
- Update misc. test coverage for these changes 

### Related Ticket(s)

CRDCDH-1632 (FE Task)
CRDCDH-1567 (User Story)
