### PR TITLE
CRDCDH-1607 Data Submission List table improvements

### DIFF
--- a/src/components/GenericTable/index.tsx
+++ b/src/components/GenericTable/index.tsx
@@ -48,10 +48,10 @@ const StyledTableContainer = styled(TableContainer)({
     background: "#E3EEF9",
   },
   "& .MuiTableCell-root:first-of-type": {
-    paddingLeft: "40.44px",
+    paddingLeft: "24px",
   },
   "& .MuiTableCell-root:last-of-type": {
-    paddingRight: "40.44px",
+    paddingRight: "24px",
   },
 });
 
@@ -72,7 +72,7 @@ const StyledTableRow = styled(TableRow)({
 
 const StyledHeaderCell = styled(TableCell)({
   fontWeight: 700,
-  fontSize: "16px",
+  fontSize: "14px",
   lineHeight: "16px",
   color: "#fff !important",
   padding: "22px 53px 22px 16px",
@@ -89,7 +89,7 @@ const StyledHeaderCell = styled(TableCell)({
 });
 
 const StyledTableCell = styled(TableCell)({
-  fontSize: "16px",
+  fontSize: "14px",
   color: "#083A50 !important",
   fontFamily: "'Nunito', 'Rubik', sans-serif",
   fontStyle: "normal",

--- a/src/components/TruncatedText/index.test.tsx
+++ b/src/components/TruncatedText/index.test.tsx
@@ -1,0 +1,168 @@
+import React from "react";
+import { render, waitFor } from "@testing-library/react";
+import { axe } from "jest-axe";
+import userEvent from "@testing-library/user-event";
+import TruncatedText from ".";
+
+describe("Accessibility", () => {
+  it("should have no violations", async () => {
+    const { container } = render(<TruncatedText text="Accessible text" />);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});
+
+describe("Basic Functionality", () => {
+  it("renders without crashing", () => {
+    const { getByTestId } = render(<TruncatedText text="Sample" />);
+    expect(getByTestId("truncated-text-label")).toBeInTheDocument();
+    expect(getByTestId("truncated-text-label")).toHaveTextContent("Sample");
+  });
+
+  it("does not truncate text shorter than maxCharacters", () => {
+    const { getByTestId } = render(<TruncatedText text="Short" maxCharacters={10} />);
+    expect(getByTestId("truncated-text-label")).toHaveTextContent("Short");
+  });
+
+  it("truncates text longer than maxCharacters", () => {
+    const { getByTestId } = render(
+      <TruncatedText text="This text is definitely too long" maxCharacters={10} />
+    );
+    expect(getByTestId("truncated-text-label")).toHaveTextContent("This text...");
+  });
+
+  it("shows an ellipsis when ellipsis prop is true", () => {
+    const { getByTestId } = render(
+      <TruncatedText text="Long text to be truncated" maxCharacters={5} ellipsis />
+    );
+    expect(getByTestId("truncated-text-label")).toHaveTextContent("Long...");
+  });
+
+  it("does not show an ellipsis when ellipsis prop is false", () => {
+    const { getByTestId } = render(
+      <TruncatedText text="Long text to be truncated" maxCharacters={5} ellipsis={false} />
+    );
+    expect(getByTestId("truncated-text-label")).toHaveTextContent("Long");
+  });
+
+  it("displays underline when underline prop is true and text is truncated", () => {
+    const { getByTestId } = render(
+      <TruncatedText text="Long text to be underlined" maxCharacters={5} underline />
+    );
+    const textWrapper = getByTestId("truncated-text-wrapper");
+    expect(textWrapper).toHaveStyle("text-decoration: underline");
+  });
+
+  it("does not display underline when underline prop is false", () => {
+    const { getByTestId } = render(
+      <TruncatedText text="Long text not underlined" maxCharacters={5} underline={false} />
+    );
+    const textWrapper = getByTestId("truncated-text-wrapper");
+    expect(textWrapper).not.toHaveStyle("text-decoration: underline");
+  });
+
+  it("uses custom tooltipText when provided", async () => {
+    const { getByTestId, findByRole } = render(
+      <TruncatedText text="Some really long text" maxCharacters={5} tooltipText="Custom Tooltip" />
+    );
+    const textLabel = getByTestId("truncated-text-label");
+    userEvent.hover(textLabel);
+
+    const tooltip = await findByRole("tooltip");
+    expect(tooltip).toHaveTextContent("Custom Tooltip");
+  });
+
+  it("displays tooltip with full text when text is truncated", async () => {
+    const fullText = "This is a very long text that needs truncation";
+    const { getByTestId, findByRole } = render(
+      <TruncatedText text={fullText} maxCharacters={10} />
+    );
+    const textLabel = getByTestId("truncated-text-label");
+    userEvent.hover(textLabel);
+
+    const tooltip = await findByRole("tooltip");
+    expect(tooltip).toHaveTextContent(fullText);
+  });
+
+  it("does not display tooltip when text is not truncated", async () => {
+    const { getByTestId, queryByRole } = render(
+      <TruncatedText text="Short text" maxCharacters={10} />
+    );
+    const textLabel = getByTestId("truncated-text-label");
+    userEvent.hover(textLabel);
+
+    await waitFor(() => {
+      expect(queryByRole("tooltip")).not.toBeInTheDocument();
+    });
+  });
+
+  it("handles empty text gracefully", () => {
+    const { getByTestId } = render(<TruncatedText text="" />);
+    expect(getByTestId("truncated-text-label")).toHaveTextContent("");
+  });
+
+  it("handles null text gracefully", () => {
+    const { getByTestId } = render(<TruncatedText text={null} />);
+    expect(getByTestId("truncated-text-label")).toHaveTextContent("");
+  });
+
+  it("does not truncate text equal to maxCharacters", () => {
+    const { getByTestId } = render(<TruncatedText text="ExactLength" maxCharacters={11} />);
+    expect(getByTestId("truncated-text-label")).toHaveTextContent("ExactLength");
+  });
+
+  it("truncates text exceeding maxCharacters by one", () => {
+    const { getByTestId } = render(<TruncatedText text="ExceedsLength" maxCharacters={10} />);
+    expect(getByTestId("truncated-text-label")).toHaveTextContent("ExceedsLen...");
+  });
+
+  it("trims whitespace before adding ellipsis", () => {
+    const { getByTestId } = render(<TruncatedText text="  Whitespace text  " maxCharacters={10} />);
+    expect(getByTestId("truncated-text-label")).toHaveTextContent("Whitespace...");
+  });
+
+  it("disables tooltip when text is not truncated", async () => {
+    const { getByTestId, queryByRole } = render(
+      <TruncatedText text="Short text" maxCharacters={20} />
+    );
+    const textLabel = getByTestId("truncated-text-label");
+    userEvent.hover(textLabel);
+
+    await waitFor(() => {
+      expect(queryByRole("tooltip")).not.toBeInTheDocument();
+    });
+  });
+});
+
+describe("Edge Cases", () => {
+  it("handles text with only whitespace", () => {
+    const { getByTestId } = render(<TruncatedText text="     " />);
+    expect(getByTestId("truncated-text-label")).toHaveTextContent("");
+  });
+
+  it("handles special characters in text", () => {
+    const { getByTestId } = render(<TruncatedText text="!@#$%^&*()" maxCharacters={5} />);
+    expect(getByTestId("truncated-text-label")).toHaveTextContent("!@#$%...");
+  });
+
+  it("handles negative maxCharacters value", () => {
+    const { getByTestId } = render(
+      <TruncatedText text="Negative maxCharacters" maxCharacters={-5} />
+    );
+    expect(getByTestId("truncated-text-label")).toHaveTextContent("...");
+  });
+
+  it("handles zero maxCharacters value", () => {
+    const { getByTestId } = render(<TruncatedText text="Zero maxCharacters" maxCharacters={0} />);
+    expect(getByTestId("truncated-text-label")).toHaveTextContent("...");
+  });
+
+  it("handles undefined maxCharacters value", () => {
+    const { getByTestId } = render(<TruncatedText text="Default maxCharacters" />);
+    expect(getByTestId("truncated-text-label")).toHaveTextContent("Default ma...");
+  });
+
+  it("handles maxCharacters larger than text length", () => {
+    const { getByTestId } = render(<TruncatedText text="Short text" maxCharacters={100} />);
+    expect(getByTestId("truncated-text-label")).toHaveTextContent("Short text");
+  });
+});

--- a/src/components/TruncatedText/index.tsx
+++ b/src/components/TruncatedText/index.tsx
@@ -1,0 +1,88 @@
+import { FC, memo } from "react";
+import { styled } from "@mui/material";
+import StyledTooltip from "../StyledFormComponents/StyledTooltip";
+
+const StyledText = styled("span")(() => ({
+  display: "block",
+  textDecoration: "none",
+  whiteSpace: "nowrap",
+  overflow: "hidden",
+  textOverflow: "ellipsis",
+}));
+
+const StyledTextWrapper = styled("span", {
+  shouldForwardProp: (p) => p !== "truncated" && p !== "underline",
+})<{ truncated: boolean; underline: boolean }>(({ truncated, underline }) => ({
+  display: "block",
+  textDecoration: truncated && underline ? "underline" : "none",
+  textDecorationStyle: "dashed",
+  textUnderlineOffset: "4px",
+  cursor: truncated ? "pointer" : "inherit",
+}));
+
+type Props = {
+  /**
+   * The displayed text that will be hoverable
+   * when a truncation tooltip is available
+   */
+  text: string;
+  /**
+   * Provide custom text to show in the tooltip,
+   * otherwise 'text' will be used
+   */
+  tooltipText?: string;
+  /**
+   * The max number of characters allowed before
+   * truncation will occur
+   */
+  maxCharacters?: number;
+  /**
+   * A boolean indicating whether or not to display
+   * an underline when truncation occurs
+   */
+  underline?: boolean;
+  /**
+   * A boolean indicating whether or not to display
+   * an ellipsis when truncation occurs
+   */
+  ellipsis?: boolean;
+};
+
+/**
+ * A component that truncates text to a specified number of characters.
+ * If truncated, it displays an ellipsis and shows the full text in a tooltip on hover.
+ *
+ * @param {Props} props
+ * @returns {JSX.Element}
+ */
+const TruncatedText: FC<Props> = ({
+  text,
+  tooltipText,
+  maxCharacters = 10,
+  underline = true,
+  ellipsis = true,
+}: Props) => {
+  const isTruncated = text?.length > maxCharacters;
+  const displayText = isTruncated
+    ? `${text?.trim()?.slice(0, maxCharacters)?.trim()}${ellipsis ? "..." : ""}`
+    : text;
+
+  return (
+    <StyledTooltip
+      placement="top"
+      title={tooltipText || text || ""}
+      disableHoverListener={!isTruncated}
+      data-testid="truncated-text-tooltip"
+    >
+      <StyledTextWrapper
+        truncated={isTruncated}
+        underline={underline}
+        data-testid="truncated-text-wrapper"
+      >
+        <StyledText data-testid="truncated-text-label">{displayText}</StyledText>
+      </StyledTextWrapper>
+    </StyledTooltip>
+  );
+};
+
+export default memo(TruncatedText);

--- a/src/content/dataSubmissions/DataSubmissionsListView.tsx
+++ b/src/content/dataSubmissions/DataSubmissionsListView.tsx
@@ -28,6 +28,8 @@ import GenericTable, { Column } from "../../components/GenericTable";
 import { LIST_SUBMISSIONS, ListSubmissionsResp } from "../../graphql";
 import StyledSelectFormComponent from "../../components/StyledFormComponents/StyledSelect";
 import { useSearchParamsContext } from "../../components/Contexts/SearchParamsContext";
+import TruncatedText from "../../components/TruncatedText";
+import StyledTooltip from "../../components/StyledFormComponents/StyledTooltip";
 
 type T = ListSubmissionsResp["listSubmissions"]["submissions"][0];
 
@@ -54,15 +56,19 @@ const StyledTableHead = styled(TableHead)({
 
 const StyledHeaderCell = styled(TableCell)({
   fontWeight: 700,
-  fontSize: "16px",
+  fontSize: "14px",
   lineHeight: "16px",
   color: "#fff !important",
   "&.MuiTableCell-root": {
-    padding: "15px 8px 17px",
+    padding: "15px 4px 17px",
+    color: "#fff !important",
+    // whiteSpace: "nowrap",
+  },
+  "& .MuiSvgIcon-root, & .MuiButtonBase-root": {
     color: "#fff !important",
   },
-  "& .MuiSvgIcon-root,  & .MuiButtonBase-root": {
-    color: "#fff !important",
+  "& .MuiSvgIcon-root": {
+    marginRight: 0,
   },
   "&:last-of-type": {
     paddingRight: "4px",
@@ -70,11 +76,12 @@ const StyledHeaderCell = styled(TableCell)({
 });
 
 const StyledTableCell = styled(TableCell)({
-  fontSize: "16px",
+  fontSize: "14px",
   color: "#083A50 !important",
   "&.MuiTableCell-root": {
-    padding: "8px 8px",
+    padding: "14px 8px 12px",
     overflowWrap: "anywhere",
+    whiteSpace: "nowrap",
   },
   "&:last-of-type": {
     paddingRight: "4px",
@@ -119,6 +126,10 @@ const StyledDisabledText = styled(Box)(({ theme }) => ({
   color: theme.palette.text.disabled,
 }));
 
+const StyledDateTooltip = styled(StyledTooltip)(() => ({
+  cursor: "pointer",
+}));
+
 const initialTouchedFields: TouchedState = {
   organization: false,
   status: false,
@@ -129,67 +140,109 @@ const columns: Column<T>[] = [
     label: "Submission Name",
     renderValue: (a) =>
       a.status === "Deleted" || a.archived === true ? (
-        <StyledDisabledText>{a.name}</StyledDisabledText>
+        <StyledDisabledText>
+          <TruncatedText text={a.name} />
+        </StyledDisabledText>
       ) : (
-        <Link to={`/data-submission/${a._id}/upload-activity`}>{a.name}</Link>
+        <Link to={`/data-submission/${a._id}/upload-activity`}>
+          <TruncatedText text={a.name} underline={false} />
+        </Link>
       ),
     field: "name",
+    sx: {
+      width: "139px",
+    },
   },
   {
     label: "Submitter",
-    renderValue: (a) => a.submitterName,
+    renderValue: (a) => <TruncatedText text={a.submitterName} />,
     field: "submitterName",
+    sx: {
+      width: "102px",
+    },
   },
   {
     label: "Data Commons",
     renderValue: (a) => a.dataCommons,
     field: "dataCommons",
+    sx: {
+      width: "94px",
+    },
   },
   {
     label: "Type",
     renderValue: (a) => a.intention,
     field: "intention",
+    sx: {
+      width: "96px",
+    },
   },
   {
     label: "DM Version",
     renderValue: (a) => a.modelVersion,
     field: "modelVersion",
+    sx: {
+      width: "79px",
+    },
   },
   {
     label: "Organization",
-    renderValue: (a) => a.organization.name,
+    renderValue: (a) => <TruncatedText text={a.organization.name} />,
     fieldKey: "organization.name",
   },
   {
     label: "Study",
-    renderValue: (a) => a.studyAbbreviation,
+    renderValue: (a) => <TruncatedText text={a.studyAbbreviation} />,
     field: "studyAbbreviation",
   },
   {
     label: "dbGaP ID",
-    renderValue: (a) => a.dbGaPID,
+    renderValue: (a) => <TruncatedText text={a.dbGaPID} />,
     field: "dbGaPID",
   },
   {
     label: "Status",
     renderValue: (a) => a.status,
     field: "status",
+    sx: {
+      width: "87px",
+    },
   },
   {
     label: "Primary Contact",
-    renderValue: (a) => a.conciergeName,
+    renderValue: (a) => <TruncatedText text={a.conciergeName} />,
     field: "conciergeName",
   },
   {
     label: "Created Date",
-    renderValue: (a) => (a.createdAt ? FormatDate(a.createdAt, "M/D/YYYY h:mm A") : ""),
+    renderValue: (a) =>
+      a.createdAt ? (
+        <StyledDateTooltip title={FormatDate(a.createdAt, "M/D/YYYY h:mm A")} placement="top">
+          <span>{FormatDate(a.createdAt, "M/D/YYYY")}</span>
+        </StyledDateTooltip>
+      ) : (
+        ""
+      ),
     field: "createdAt",
+    sx: {
+      width: "92px",
+    },
   },
   {
     label: "Last Updated",
-    renderValue: (a) => (a.updatedAt ? FormatDate(a.updatedAt, "M/D/YYYY h:mm A") : ""),
+    renderValue: (a) =>
+      a.updatedAt ? (
+        <StyledDateTooltip title={FormatDate(a.updatedAt, "M/D/YYYY h:mm A")} placement="top">
+          <span>{FormatDate(a.updatedAt, "M/D/YYYY")}</span>
+        </StyledDateTooltip>
+      ) : (
+        ""
+      ),
     field: "updatedAt",
     default: true,
+    sx: {
+      width: "108px",
+    },
   },
 ];
 

--- a/src/content/organizations/ListView.tsx
+++ b/src/content/organizations/ListView.tsx
@@ -117,7 +117,7 @@ const StyledSelect = styled(Select)(baseTextFieldStyles);
 
 const StyledHeaderCell = styled(TableCell)({
   fontWeight: 700,
-  fontSize: "16px",
+  fontSize: "14px",
   color: "#fff !important",
   "&.MuiTableCell-root": {
     padding: "8px 16px",
@@ -132,7 +132,7 @@ const StyledHeaderCell = styled(TableCell)({
 });
 
 const StyledTableCell = styled(TableCell)({
-  fontSize: "16px",
+  fontSize: "14px",
   color: "#083A50 !important",
   "&.MuiTableCell-root": {
     padding: "8px 16px",

--- a/src/content/questionnaire/ListView.tsx
+++ b/src/content/questionnaire/ListView.tsx
@@ -72,7 +72,7 @@ const StyledTableHead = styled(TableHead)({
 
 const StyledHeaderCell = styled(TableCell)({
   fontWeight: 700,
-  fontSize: "16px",
+  fontSize: "14px",
   color: "#fff !important",
   "&.MuiTableCell-root": {
     padding: "8px 16px",
@@ -87,7 +87,7 @@ const StyledHeaderCell = styled(TableCell)({
 });
 
 const StyledTableCell = styled(TableCell)({
-  fontSize: "16px",
+  fontSize: "14px",
   color: "#083A50 !important",
   "&.MuiTableCell-root": {
     padding: "8px 16px",

--- a/src/content/users/ListView.tsx
+++ b/src/content/users/ListView.tsx
@@ -100,7 +100,7 @@ const StyledSelect = styled(Select)({
 
 const StyledHeaderCell = styled(TableCell)({
   fontWeight: 700,
-  fontSize: "16px",
+  fontSize: "14px",
   color: "#fff !important",
   "&.MuiTableCell-root": {
     padding: "8px 16px",
@@ -115,7 +115,7 @@ const StyledHeaderCell = styled(TableCell)({
 });
 
 const StyledTableCell = styled(TableCell)({
-  fontSize: "16px",
+  fontSize: "14px",
   color: "#083A50 !important",
   "&.MuiTableCell-root": {
     padding: "8px 16px",


### PR DESCRIPTION
### Overview

Updated Data Submission List table to prevent text wrapping in the table rows.

### Change Details (Specifics)

- Reduced font size of all tables by 2px (16px => 14px)
- Reduced the start and end padding of all tables (40.44px => 24px)
- Set fixed-widths to specific columns in the Data Submission List table
- Forced text truncation for variable-width columns in the Data Submission List table. When truncated the text is hoverable and a tooltip will appear with full text
- Allowed wrapping in header names as this saves extra space
- If "Submission Name" columns is truncated, I left the original solid underline instead of changing it to a dashed underline to avoid confusion. Deleted/Archived submission do have the dashed underline as they are not clickable
- Moved "dbGaP ID" column to variable-length columns as it allows up to 50 characters in Submission Request form
- Updated dates to only show date portion, but will show full date and time on hover tooltip
- Tested with all letters and some emojis. Some unique characters with extra width could cause a scrollable table, but this is not likely to be used. (ex. "⸻" is a single character. LMK if you agree with ignoring these).

### Related Ticket(s)

[CRDCDH-1607](https://tracker.nci.nih.gov/browse/CRDCDH-1607) (Task)
[CRDCDH-1333](https://tracker.nci.nih.gov/browse/CRDCDH-1333) (User Story)
