### PR TITLE
CRDCDH-1606 Add nodeCount column to Data Submission List table

### DIFF
--- a/src/components/Contexts/SubmissionContext.test.tsx
+++ b/src/components/Contexts/SubmissionContext.test.tsx
@@ -49,6 +49,7 @@ const baseSubmission: Submission = {
   intention: "New/Update",
   dataType: "Metadata Only",
   otherSubmissions: "",
+  nodeCount: 0,
   createdAt: "",
   updatedAt: "",
   studyID: "",

--- a/src/components/DataSubmissions/CrossValidationButton.test.tsx
+++ b/src/components/DataSubmissions/CrossValidationButton.test.tsx
@@ -53,6 +53,7 @@ const baseSubmission: Omit<
   validationType: ["metadata", "file"],
   studyID: "",
   deletingData: false,
+  nodeCount: 0,
 };
 
 const baseAuthCtx: AuthCtxState = {

--- a/src/components/DataSubmissions/CrossValidationFilters.test.tsx
+++ b/src/components/DataSubmissions/CrossValidationFilters.test.tsx
@@ -49,6 +49,7 @@ const baseSubmission: Submission = {
   intention: "New/Update",
   dataType: "Metadata Only",
   otherSubmissions: "",
+  nodeCount: 0,
   createdAt: "",
   updatedAt: "",
 };

--- a/src/components/DataSubmissions/DataUpload.test.tsx
+++ b/src/components/DataSubmissions/DataUpload.test.tsx
@@ -55,6 +55,7 @@ const baseSubmission: Omit<Submission, "_id"> = {
   validationType: ["metadata", "file"],
   studyID: "",
   deletingData: false,
+  nodeCount: 0,
 };
 
 const baseUser: User = {

--- a/src/components/DataSubmissions/DeleteAllOrphanFilesButton.test.tsx
+++ b/src/components/DataSubmissions/DeleteAllOrphanFilesButton.test.tsx
@@ -53,6 +53,7 @@ const baseSubmission: Submission = {
   validationType: ["metadata", "file"],
   studyID: "",
   deletingData: false,
+  nodeCount: 0,
 };
 
 const baseContext: ContextState = {

--- a/src/components/DataSubmissions/DeleteNodeDataButton.test.tsx
+++ b/src/components/DataSubmissions/DeleteNodeDataButton.test.tsx
@@ -49,6 +49,7 @@ const BaseSubmission: Submission = {
   validationScope: "New",
   validationType: [],
   deletingData: false,
+  nodeCount: 0,
 };
 
 const baseAuthCtx: AuthContextState = {

--- a/src/components/DataSubmissions/DeleteOrphanFileChip.test.tsx
+++ b/src/components/DataSubmissions/DeleteOrphanFileChip.test.tsx
@@ -53,6 +53,7 @@ const baseSubmission: Submission = {
   validationType: ["metadata", "file"],
   studyID: "",
   deletingData: false,
+  nodeCount: 0,
 };
 
 const baseContext: ContextState = {

--- a/src/components/DataSubmissions/ExportCrossValidationButton.test.tsx
+++ b/src/components/DataSubmissions/ExportCrossValidationButton.test.tsx
@@ -48,6 +48,7 @@ const baseSubmission: Submission = {
   crossSubmissionStatus: null,
   studyID: "",
   deletingData: false,
+  nodeCount: 0,
 };
 
 const baseCrossValidationResult: CrossValidationResult = {

--- a/src/components/DataSubmissions/ExportValidationButton.test.tsx
+++ b/src/components/DataSubmissions/ExportValidationButton.test.tsx
@@ -57,6 +57,7 @@ describe("ExportValidationButton cases", () => {
     validationType: ["metadata", "file"],
     studyID: "",
     deletingData: false,
+    nodeCount: 0,
   };
 
   const baseQCResult: Omit<QCResult, "submissionID"> = {

--- a/src/components/DataSubmissions/MetadataUpload.test.tsx
+++ b/src/components/DataSubmissions/MetadataUpload.test.tsx
@@ -40,6 +40,7 @@ const baseSubmission: Omit<
   validationType: ["metadata", "file"],
   studyID: "",
   deletingData: false,
+  nodeCount: 0,
 };
 
 const baseContext: ContextState = {

--- a/src/components/DataSubmissions/ValidationControls.test.tsx
+++ b/src/components/DataSubmissions/ValidationControls.test.tsx
@@ -53,6 +53,7 @@ const baseSubmission: Omit<
   validationType: ["metadata", "file"],
   studyID: "",
   deletingData: false,
+  nodeCount: 0,
 };
 
 const baseAuthCtx: AuthCtxState = {

--- a/src/components/DataSubmissions/ValidationStatistics.test.tsx
+++ b/src/components/DataSubmissions/ValidationStatistics.test.tsx
@@ -33,6 +33,7 @@ const baseSubmission: Omit<Submission, "_id"> = {
   validationType: ["metadata", "file"],
   studyID: "",
   deletingData: false,
+  nodeCount: 0,
 };
 
 describe("Accessibility", () => {

--- a/src/components/DataSubmissions/ValidationStatus.test.tsx
+++ b/src/components/DataSubmissions/ValidationStatus.test.tsx
@@ -40,6 +40,7 @@ const BaseSubmission: Omit<
   updatedAt: "",
   studyID: "",
   deletingData: false,
+  nodeCount: 0,
 };
 
 type TestParentProps = {

--- a/src/content/dataSubmissions/CrossValidation.test.tsx
+++ b/src/content/dataSubmissions/CrossValidation.test.tsx
@@ -57,6 +57,7 @@ const baseSubmission: Submission = {
   crossSubmissionStatus: null,
   studyID: "",
   deletingData: false,
+  nodeCount: 0,
 };
 
 const baseCrossValidationResult: CrossValidationResult = {

--- a/src/content/dataSubmissions/DataActivity.test.tsx
+++ b/src/content/dataSubmissions/DataActivity.test.tsx
@@ -42,6 +42,7 @@ const baseSubmission: Omit<Submission, "_id"> = {
   fileValidationStatus: "New",
   studyID: "",
   deletingData: false,
+  nodeCount: 0,
 };
 
 type ParentProps = {

--- a/src/content/dataSubmissions/DataSubmissionsListView.tsx
+++ b/src/content/dataSubmissions/DataSubmissionsListView.tsx
@@ -79,7 +79,7 @@ const StyledTableCell = styled(TableCell)({
   fontSize: "14px",
   color: "#083A50 !important",
   "&.MuiTableCell-root": {
-    padding: "14px 8px 12px",
+    padding: "14px 4px 12px",
     overflowWrap: "anywhere",
     whiteSpace: "nowrap",
   },
@@ -212,6 +212,12 @@ const columns: Column<T>[] = [
     label: "Primary Contact",
     renderValue: (a) => <TruncatedText text={a.conciergeName} />,
     field: "conciergeName",
+  },
+  {
+    label: "Node Count",
+    renderValue: (a) =>
+      new Intl.NumberFormat("en-US", { maximumFractionDigits: 0 }).format(a.nodeCount || 0),
+    field: "nodeCount",
   },
   {
     label: "Created Date",

--- a/src/content/dataSubmissions/DataSubmissionsListView.tsx
+++ b/src/content/dataSubmissions/DataSubmissionsListView.tsx
@@ -216,7 +216,7 @@ const columns: Column<T>[] = [
   {
     label: "Node Count",
     renderValue: (a) =>
-      new Intl.NumberFormat("en-US", { maximumFractionDigits: 0 }).format(a.nodeCount || 0),
+      Intl.NumberFormat("en-US", { maximumFractionDigits: 0 }).format(a.nodeCount || 0),
     field: "nodeCount",
   },
   {

--- a/src/content/dataSubmissions/QualityControl.test.tsx
+++ b/src/content/dataSubmissions/QualityControl.test.tsx
@@ -55,6 +55,7 @@ const baseSubmission: Submission = {
   crossSubmissionStatus: null,
   studyID: "",
   deletingData: false,
+  nodeCount: 0,
 };
 
 const baseQCResult: QCResult = {

--- a/src/graphql/getSubmission.ts
+++ b/src/graphql/getSubmission.ts
@@ -57,6 +57,7 @@ export const query = gql`
       intention
       dataType
       otherSubmissions
+      nodeCount
       createdAt
       updatedAt
     }

--- a/src/graphql/listSubmissions.ts
+++ b/src/graphql/listSubmissions.ts
@@ -33,6 +33,7 @@ export const query = gql`
         status
         archived
         conciergeName
+        nodeCount
         createdAt
         updatedAt
         intention

--- a/src/types/Submissions.d.ts
+++ b/src/types/Submissions.d.ts
@@ -59,6 +59,10 @@ type Submission = {
    * @see OtherSubmissions
    */
   otherSubmissions: string;
+  /**
+   * The total number of nodes in the Submission
+   */
+  nodeCount: number;
   createdAt: string; // ISO 8601 date time format with UTC or offset e.g., 2023-05-01T09:23:30Z
   updatedAt: string; // ISO 8601 date time format with UTC or offset e.g., 2023-05-01T09:23:30Z
 };

--- a/src/utils/dataSubmissionUtils.test.ts
+++ b/src/utils/dataSubmissionUtils.test.ts
@@ -34,6 +34,7 @@ const baseSubmission: Submission = {
   validationType: ["metadata", "file"],
   studyID: "",
   deletingData: false,
+  nodeCount: 0,
 };
 
 describe("General Submit", () => {


### PR DESCRIPTION
### Overview

Added `nodeCount` column to Data Submission List table and formatted the value.

### Change Details (Specifics)

- Update the Submission type to include nodeCount
- Added `nodeCount` to listSubmissions query return
- Added `nodeCount` to getSubmission query return
- Updated tests to include new property in base submission
- Added new column in Data Submission List table to include `nodeCount`, also reduce spacing between cells to make room for it to avoid horizontal scrolling

> [!NOTE]
> The BE to support including `nodeCount` in the listSubmissions query is not ready yet. I can't test additional ticket requirements until this is ready (Such as sorting and making sure it is still visible for specific submission statuses), but no further FE changes should be required.


### Related Ticket(s)

[CRDCDH-1606](https://tracker.nci.nih.gov/browse/CRDCDH-1606) (Task)
[CRDCDH-1585](https://tracker.nci.nih.gov/browse/CRDCDH-1585) (User Story)
