### PR TITLE
CRDCDH-1611 Submission Request Cancer Types Autocomplete

### DIFF
--- a/src/components/Questionnaire/CustomAutocomplete.tsx
+++ b/src/components/Questionnaire/CustomAutocomplete.tsx
@@ -90,12 +90,10 @@ const StyledAutocomplete = styled(Autocomplete)(({ readOnly }: { readOnly?: bool
       alignItems: "center",
       padding: "10.5px 30px 10.5px 12px !important",
       height: "44px",
-      ...(readOnly
-        ? {
-            backgroundColor: "#E5EEF4",
-            cursor: "not-allowed",
-          }
-        : {}),
+      ...(readOnly && {
+        backgroundColor: "#E5EEF4",
+        cursor: "not-allowed",
+      }),
     },
     "& .MuiInputBase-input": {
       padding: "0 !important",
@@ -286,9 +284,16 @@ const CustomAutocomplete = ({
         />
         <StyledHelperText>{!readOnly && error ? helperText : " "}</StyledHelperText>
       </StyledFormControl>
-      <ProxySelect name={name} aria-labelledby={`${id}-label`} multiple hidden>
+      <ProxySelect
+        name={name}
+        value={val}
+        aria-labelledby={`${id}-label`}
+        onChange={() => {}}
+        multiple
+        hidden
+      >
         {val.map((v) => (
-          <option key={v} value={v} aria-label={v} selected />
+          <option key={v} value={v} aria-label={v} />
         ))}
       </ProxySelect>
     </Grid>

--- a/src/components/Questionnaire/CustomAutocomplete.tsx
+++ b/src/components/Questionnaire/CustomAutocomplete.tsx
@@ -1,0 +1,322 @@
+import {
+  Autocomplete,
+  AutocompleteChangeReason,
+  AutocompleteProps,
+  AutocompleteValue,
+  FormControl,
+  FormHelperText,
+  Grid,
+  TextField,
+  styled,
+} from "@mui/material";
+import { ReactNode, SyntheticEvent, useEffect, useId, useRef, useState } from "react";
+import { ReactComponent as DropdownArrowsIconSvg } from "../../assets/icons/dropdown_arrows.svg";
+import Tooltip from "../Tooltip";
+import { updateInputValidity } from "../../utils";
+
+const StyledFormControl = styled(FormControl)(() => ({
+  height: "100%",
+  justifyContent: "end",
+  "& .MuiFormHelperText-root.Mui-error": {
+    color: "#D54309 !important",
+  },
+  "& .MuiOutlinedInput-notchedOutline": {
+    borderRadius: "8px",
+    borderColor: "#6B7294",
+  },
+  "& .Mui-focused .MuiOutlinedInput-notchedOutline": {
+    border: "1px solid #209D7D !important",
+    boxShadow:
+      "2px 2px 4px 0px rgba(38, 184, 147, 0.10), -1px -1px 6px 0px rgba(38, 184, 147, 0.20)",
+  },
+  "& .Mui-error fieldset": {
+    borderColor: "#D54309 !important",
+  },
+  "& .MuiInputBase-input::placeholder": {
+    color: "#87878C",
+    fontWeight: 400,
+    opacity: 1,
+  },
+  "& .MuiAutocomplete-input": {
+    color: "#083A50",
+  },
+  "& .MuiAutocomplete-root .MuiAutocomplete-endAdornment": {
+    top: "50%",
+    transform: "translateY(-50%)",
+    right: "12px",
+  },
+  "& .MuiAutocomplete-popupIndicator": {
+    marginRight: "1px",
+  },
+  "& .MuiAutocomplete-popupIndicatorOpen": {
+    transform: "none",
+  },
+  "& .MuiPaper-root": {
+    borderRadius: "8px",
+    border: "1px solid #6B7294",
+    marginTop: "2px",
+    "& .MuiAutocomplete-listbox": {
+      padding: 0,
+      overflow: "auto",
+      maxHeight: "300px",
+    },
+    "& .MuiAutocomplete-option[aria-selected='true']": {
+      backgroundColor: "#3E7E6D",
+      color: "#FFFFFF",
+    },
+    "& .MuiAutocomplete-option": {
+      padding: "7.5px 10px",
+      minHeight: "35px",
+      color: "#083A50",
+      background: "#FFFFFF",
+    },
+    "& .MuiAutocomplete-option:hover": {
+      backgroundColor: "#3E7E6D",
+      color: "#FFFFFF",
+    },
+    "& .MuiAutocomplete-option.Mui-focused": {
+      backgroundColor: "#3E7E6D !important",
+      color: "#FFFFFF",
+    },
+  },
+}));
+
+const StyledFormLabel = styled("label")(() => ({
+  fontWeight: 700,
+  fontSize: "16px",
+  lineHeight: "19.6px",
+  minHeight: "20px",
+  color: "#083A50",
+  marginBottom: "4px",
+}));
+
+const StyledAsterisk = styled("span")(() => ({
+  color: "#C93F08",
+  marginLeft: "2px",
+}));
+
+const StyledAutocomplete = styled(Autocomplete)(({ readOnly }: { readOnly?: boolean }) => ({
+  "& .MuiInputBase-root": {
+    "&.MuiAutocomplete-inputRoot.MuiInputBase-root": {
+      display: "flex",
+      alignItems: "center",
+      padding: "12px 30px 12px 12px !important",
+    },
+    "& .MuiOutlinedInput-input:read-only": {
+      backgroundColor: "#E5EEF4",
+      color: "#083A50",
+      cursor: "not-allowed",
+      borderRadius: "8px",
+    },
+    "& .MuiInputBase-input": {
+      fontWeight: 400,
+      fontSize: "16px",
+      fontFamily: "'Nunito', 'Rubik', sans-serif",
+      padding: "0 !important",
+      height: "20px",
+      cursor: readOnly ? "not-allowed !important" : "initial",
+    },
+    "& .MuiAutocomplete-clearIndicator": {
+      visibility: "hidden !important",
+      position: "absolute",
+    },
+  },
+}));
+
+const ProxySelect = styled("select")({
+  display: "none",
+});
+
+const StyledFormHelperText = styled(FormHelperText)({
+  marginLeft: 0,
+  marginTop: "4px",
+  minHeight: "20px",
+});
+
+export type CustomProps = {
+  /**
+   * The HTML form name attribute
+   *
+   * @note Used to parse the form data into a JSON object
+   */
+  name: string;
+  /**
+   * The label text for the input to display above the input field
+   */
+  label: string;
+  /**
+   * The value of the input field
+   */
+  value: string[];
+  /**
+   * The options to display in the input selection dropdown
+   */
+  options: string[];
+  /**
+   * The text to display in the placeholder when multiple values are selected
+   */
+  tagText: (value: string[]) => string;
+  /**
+   * The width of the input in the form grid
+   */
+  gridWidth?: 2 | 4 | 6 | 8 | 10 | 12;
+  helpText?: string;
+  tooltipText?: string | ReactNode;
+  required?: boolean;
+  validate?: (input: string | string[]) => boolean;
+} & Omit<AutocompleteProps<string, boolean, true, true, "div">, "renderInput">;
+
+/**
+ * Provides a custom autocomplete input field with a label and helper text.  The primary focus is:
+ *
+ * - Disable the clear button
+ * - Constrain the rendering of tags to a single line
+ * - Sort the selected options above the unselected options after blur
+ *
+ * @note This component supports only string values currently
+ * @param {CustomProps} props
+ * @returns {JSX.Element}
+ */
+const CustomAutocomplete = ({
+  tagText,
+  name,
+  label,
+  gridWidth,
+  helpText,
+  tooltipText,
+  required,
+  value,
+  onChange,
+  options,
+  validate,
+  placeholder,
+  readOnly,
+  ...rest
+}: CustomProps): JSX.Element => {
+  const id = rest.id || useId();
+
+  const [val, setVal] = useState<string[]>(value);
+  const [error, setError] = useState<boolean>(false);
+  const [hasFocus, setHasFocus] = useState<boolean>(false);
+  const [separatedOptions, setSeparatedOptions] = useState<string[]>(options);
+
+  const helperText = helpText || (required ? "This field is required" : " ");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const processValue = (newValue: string[]) => {
+    if (typeof validate === "function") {
+      const customIsValid = validate(newValue);
+      updateInputValidity(inputRef, !customIsValid ? helpText : "");
+    } else if (required) {
+      updateInputValidity(inputRef, !newValue ? helperText : "");
+    }
+
+    setVal(newValue);
+  };
+
+  const onChangeWrapper = (
+    event: SyntheticEvent,
+    newValue: AutocompleteValue<string[], false, false, false>,
+    reason: AutocompleteChangeReason
+  ): void => {
+    if (typeof onChange === "function") {
+      onChange(event, newValue, reason);
+    }
+
+    processValue(newValue);
+    setError(false);
+  };
+
+  const handleInputBlur = () => {
+    setHasFocus(false);
+    sortOptions(true);
+  };
+
+  const sortOptions = (force = false) => {
+    if (hasFocus && !force) {
+      return;
+    }
+
+    const selectedOptions = val
+      .filter((v) => options.includes(v))
+      .sort((a, b) => a.localeCompare(b));
+    const unselectedOptions = options.filter((o) => !selectedOptions.includes(o));
+
+    setSeparatedOptions([...selectedOptions, ...unselectedOptions]);
+  };
+
+  useEffect(() => {
+    const invalid = () => setError(true);
+
+    inputRef.current?.addEventListener("invalid", invalid);
+    return () => {
+      inputRef.current?.removeEventListener("invalid", invalid);
+    };
+  }, [inputRef]);
+
+  useEffect(() => {
+    processValue(value);
+  }, [value]);
+
+  useEffect(() => {
+    sortOptions();
+  }, [options, val]);
+
+  return (
+    <Grid md={gridWidth || 6} xs={12} item>
+      <StyledFormControl fullWidth error={error}>
+        <StyledFormLabel htmlFor={id} id={`${id}-label`}>
+          {label}
+          {required ? <StyledAsterisk>*</StyledAsterisk> : ""}
+          {tooltipText && <Tooltip placement="right" title={tooltipText} />}
+        </StyledFormLabel>
+        <StyledAutocomplete
+          value={val}
+          onChange={onChangeWrapper}
+          options={separatedOptions}
+          readOnly={readOnly}
+          getOptionLabel={(option: string) => option}
+          renderTags={(value: string[]) => {
+            if (value?.length === 0 || hasFocus) {
+              return null;
+            }
+
+            if (value.length === 1) {
+              return value[0];
+            }
+
+            return tagText(value);
+          }}
+          forcePopupIcon
+          popupIcon={<DropdownArrowsIconSvg />}
+          slotProps={{ popper: { disablePortal: true } }}
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              inputRef={inputRef}
+              placeholder={val?.length > 0 ? undefined : placeholder}
+              id={id}
+              onFocus={() => setHasFocus(true)}
+              onBlur={handleInputBlur}
+              onKeyDown={(event) => {
+                // Prevent backspace from clearing input tags
+                if (event.key === "Backspace") {
+                  event.stopPropagation();
+                }
+              }}
+            />
+          )}
+          {...rest}
+        />
+        <StyledFormHelperText>{!readOnly && error ? helperText : " "}</StyledFormHelperText>
+      </StyledFormControl>
+      <ProxySelect name={name} aria-labelledby={`${id}-label`} multiple hidden>
+        {val.map((v) => (
+          <option key={v} value={v} aria-label={v} selected />
+        ))}
+      </ProxySelect>
+    </Grid>
+  );
+};
+
+export default CustomAutocomplete;

--- a/src/components/Questionnaire/CustomAutocomplete.tsx
+++ b/src/components/Questionnaire/CustomAutocomplete.tsx
@@ -272,7 +272,7 @@ const CustomAutocomplete = ({
               inputRef={inputRef}
               placeholder={val?.length > 0 ? undefined : placeholder}
               id={id}
-              onFocus={() => setHasFocus(true)}
+              onFocus={() => !readOnly && setHasFocus(true)}
               onBlur={handleInputBlur}
               onKeyDown={(event) => {
                 // Prevent backspace from clearing input tags

--- a/src/components/Questionnaire/CustomAutocomplete.tsx
+++ b/src/components/Questionnaire/CustomAutocomplete.tsx
@@ -88,7 +88,8 @@ const StyledAutocomplete = styled(Autocomplete)(({ readOnly }: { readOnly?: bool
     "&.MuiAutocomplete-inputRoot.MuiInputBase-root": {
       display: "flex",
       alignItems: "center",
-      padding: "12px 30px 12px 12px !important",
+      padding: "10.5px 30px 10.5px 12px !important",
+      height: "44px",
       ...(readOnly
         ? {
             backgroundColor: "#E5EEF4",
@@ -97,16 +98,9 @@ const StyledAutocomplete = styled(Autocomplete)(({ readOnly }: { readOnly?: bool
         : {}),
     },
     "& .MuiInputBase-input": {
-      fontWeight: 400,
-      fontSize: "16px",
-      fontFamily: "'Nunito', 'Rubik', sans-serif",
       padding: "0 !important",
       height: "20px",
       cursor: readOnly ? "not-allowed !important" : "initial",
-    },
-    "& .MuiAutocomplete-clearIndicator": {
-      visibility: "hidden !important",
-      position: "absolute",
     },
   },
 }));

--- a/src/components/Questionnaire/CustomAutocomplete.tsx
+++ b/src/components/Questionnaire/CustomAutocomplete.tsx
@@ -4,7 +4,6 @@ import {
   AutocompleteProps,
   AutocompleteValue,
   FormControl,
-  FormHelperText,
   Grid,
   TextField,
   styled,
@@ -13,8 +12,11 @@ import { ReactNode, SyntheticEvent, useEffect, useId, useRef, useState } from "r
 import { ReactComponent as DropdownArrowsIconSvg } from "../../assets/icons/dropdown_arrows.svg";
 import Tooltip from "../Tooltip";
 import { updateInputValidity } from "../../utils";
+import StyledLabel from "../StyledFormComponents/StyledLabel";
+import StyledHelperText from "../StyledFormComponents/StyledHelperText";
+import StyledAsterisk from "../StyledFormComponents/StyledAsterisk";
 
-const StyledFormControl = styled(FormControl)(() => ({
+const StyledFormControl = styled(FormControl)({
   height: "100%",
   justifyContent: "end",
   "& .MuiFormHelperText-root.Mui-error": {
@@ -79,21 +81,7 @@ const StyledFormControl = styled(FormControl)(() => ({
       color: "#FFFFFF",
     },
   },
-}));
-
-const StyledFormLabel = styled("label")(() => ({
-  fontWeight: 700,
-  fontSize: "16px",
-  lineHeight: "19.6px",
-  minHeight: "20px",
-  color: "#083A50",
-  marginBottom: "4px",
-}));
-
-const StyledAsterisk = styled("span")(() => ({
-  color: "#C93F08",
-  marginLeft: "2px",
-}));
+});
 
 const StyledAutocomplete = styled(Autocomplete)(({ readOnly }: { readOnly?: boolean }) => ({
   "& .MuiInputBase-root": {
@@ -125,12 +113,6 @@ const StyledAutocomplete = styled(Autocomplete)(({ readOnly }: { readOnly?: bool
 
 const ProxySelect = styled("select")({
   display: "none",
-});
-
-const StyledFormHelperText = styled(FormHelperText)({
-  marginLeft: 0,
-  marginTop: "4px",
-  minHeight: "20px",
 });
 
 export type CustomProps = {
@@ -265,11 +247,11 @@ const CustomAutocomplete = ({
   return (
     <Grid md={gridWidth || 6} xs={12} item>
       <StyledFormControl fullWidth error={error}>
-        <StyledFormLabel htmlFor={id} id={`${id}-label`}>
+        <StyledLabel htmlFor={id} id={`${id}-label`}>
           {label}
-          {required ? <StyledAsterisk>*</StyledAsterisk> : ""}
+          {required ? <StyledAsterisk /> : ""}
           {tooltipText && <Tooltip placement="right" title={tooltipText} />}
-        </StyledFormLabel>
+        </StyledLabel>
         <StyledAutocomplete
           value={val}
           onChange={onChangeWrapper}
@@ -308,7 +290,7 @@ const CustomAutocomplete = ({
           )}
           {...rest}
         />
-        <StyledFormHelperText>{!readOnly && error ? helperText : " "}</StyledFormHelperText>
+        <StyledHelperText>{!readOnly && error ? helperText : " "}</StyledHelperText>
       </StyledFormControl>
       <ProxySelect name={name} aria-labelledby={`${id}-label`} multiple hidden>
         {val.map((v) => (

--- a/src/components/Questionnaire/CustomAutocomplete.tsx
+++ b/src/components/Questionnaire/CustomAutocomplete.tsx
@@ -89,12 +89,12 @@ const StyledAutocomplete = styled(Autocomplete)(({ readOnly }: { readOnly?: bool
       display: "flex",
       alignItems: "center",
       padding: "12px 30px 12px 12px !important",
-    },
-    "& .MuiOutlinedInput-input:read-only": {
-      backgroundColor: "#E5EEF4",
-      color: "#083A50",
-      cursor: "not-allowed",
-      borderRadius: "8px",
+      ...(readOnly
+        ? {
+            backgroundColor: "#E5EEF4",
+            cursor: "not-allowed",
+          }
+        : {}),
     },
     "& .MuiInputBase-input": {
       fontWeight: 400,

--- a/src/content/questionnaire/sections/C.tsx
+++ b/src/content/questionnaire/sections/C.tsx
@@ -1,7 +1,7 @@
-import { FC, useEffect, useRef, useState } from "react";
+import { FC, SyntheticEvent, useEffect, useRef, useState } from "react";
 import { cloneDeep } from "lodash";
 import { parseForm } from "@jalik/form-parser";
-import { styled } from "@mui/material";
+import { AutocompleteChangeReason, styled } from "@mui/material";
 import { useFormContext } from "../../../components/Contexts/FormContext";
 import FormContainer from "../../../components/Questionnaire/FormContainer";
 import SectionGroup from "../../../components/Questionnaire/SectionGroup";
@@ -15,6 +15,7 @@ import { isValidInRange, filterPositiveIntegerString } from "../../../utils";
 import useFormMode from "../../../hooks/useFormMode";
 import SectionMetadata from "../../../config/SectionMetadata";
 import LabelCheckbox from "../../../components/Questionnaire/LabelCheckbox";
+import CustomAutocomplete from "../../../components/Questionnaire/CustomAutocomplete";
 
 const AccessTypesDescription = styled("span")(() => ({
   fontWeight: 400,
@@ -66,27 +67,25 @@ const FormSectionC: FC<FormSectionProps> = ({ SectionOption, refs }: FormSection
     return { ref: formRef, data: combinedData };
   };
 
-  const filterCancerTypes = (val: string[]) => {
-    // if N/A already previously selected, then unselect N/A
+  const handleCancerTypesChange = (
+    e: SyntheticEvent,
+    newValue: string[],
+    reason: AutocompleteChangeReason
+  ) => {
+    // If N/A was previously selected, then remove N/A
     if (cancerTypes.includes(CUSTOM_CANCER_TYPES.NOT_APPLICABLE)) {
-      return val.filter((option) => option !== CUSTOM_CANCER_TYPES.NOT_APPLICABLE);
+      newValue = newValue.filter((option) => option !== CUSTOM_CANCER_TYPES.NOT_APPLICABLE);
+      // If N/A is newly selected, then unselect all other options
+    } else if (newValue.includes(CUSTOM_CANCER_TYPES.NOT_APPLICABLE)) {
+      newValue = [CUSTOM_CANCER_TYPES.NOT_APPLICABLE];
     }
 
-    // if N/A is being selected, then unselect other options
-    if (val.includes(CUSTOM_CANCER_TYPES.NOT_APPLICABLE)) {
-      return [CUSTOM_CANCER_TYPES.NOT_APPLICABLE];
-    }
-
-    return val;
-  };
-
-  const handleCancerTypesChange = (val: string[]) => {
-    if (val?.includes(CUSTOM_CANCER_TYPES.NOT_APPLICABLE)) {
+    if (newValue?.includes(CUSTOM_CANCER_TYPES.NOT_APPLICABLE)) {
       setOtherCancerTypes("");
       setOtherCancerTypesEnabled(false);
     }
 
-    setCancerTypes(val);
+    setCancerTypes(newValue);
   };
 
   const handleOtherCancerTypesCheckboxChange = (
@@ -158,20 +157,19 @@ const FormSectionC: FC<FormSectionProps> = ({ SectionOption, refs }: FormSection
         title={SectionCMetadata.sections.CANCER_TYPES.title}
         description={SectionCMetadata.sections.CANCER_TYPES.description}
       >
-        <SelectInput
+        <CustomAutocomplete
+          multiple
+          options={cancerTypeOptions}
+          disableClearable
           id="section-c-cancer-types"
           label="Cancer types (select all that apply)"
           name="cancerTypes"
-          options={cancerTypeOptions.map((option) => ({
-            label: option,
-            value: option,
-          }))}
-          placeholder="Select types"
-          value={data.cancerTypes}
+          placeholder="Select cancer types"
+          value={Array.isArray(cancerTypes) ? cancerTypes : []}
           onChange={handleCancerTypesChange}
-          filter={filterCancerTypes}
-          multiple
+          tagText={(value) => `${value.length} Cancer Types selected`}
           readOnly={readOnlyInputs}
+          disableCloseOnSelect
         />
         <TextInput
           id="section-c-other-cancer-types"


### PR DESCRIPTION
### Overview

This PR migrates the existing Submission Request > Section C > Cancer Types dropdown to an autocomplete component, maintaining the multi-select functionality.

> [!NOTE]
> This migration is backwards-compatible with the previous implementation in 3.0.0.

### Change Details (Specifics)

- Build out a MUI Autocomplete wrapper which overwrites the native multi-select "tagging" functionality
  - We already have a autocomplete input for the form, but it's tightly constrained to the expected functionality of a "free-solo" (aka, any value is acceptable) autocomplete. I decided to create another one because I don't want to impact the existing implementation.
- Minor updates to Section C and how we handled the "Not Applicable" option selection

### Related Ticket(s)

CRDCDH-1611 (FE Task)
CRDCDH-1191 (User Story)