### PR TITLE
CRDCDH-1675 Fix Other Clinical Data Types delimiter

### DIFF
--- a/src/content/questionnaire/sections/Review.tsx
+++ b/src/content/questionnaire/sections/Review.tsx
@@ -668,7 +668,7 @@ const FormSectionReview: FC<FormSectionProps> = ({ SectionOption, refs }: FormSe
               idPrefix="review-clinical-data-types-other-clinical-data-types"
               gridWidth={12}
               label="Other Clinical Data types"
-              value={data.clinicalData?.otherDataTypes?.split(",")}
+              value={data.clinicalData?.otherDataTypes}
               valuePlacement="bottom"
               delimiter="|"
               isList


### PR DESCRIPTION
### Overview

Minor PR to fix a 3.0.0 regression for the Other Clinical Data Types delimiter. This was introduced when merging 2.1.0 into 3.0.0

### Change Details (Specifics)

- Remove the explicit `split` call on the Other Clinical Data Types field in the Review Section. Calling `split` on the field pre-maturely turned it into an array, causing the `|` delimiter to be unused

### Related Ticket(s)

CRDCDH-1675
