### PR TITLE
Hotfix: CRDCDH-1609 Data Submission Filters - Fix form from updating with same value 

### DIFF
--- a/src/components/DataSubmissions/DataSubmissionListFilters.tsx
+++ b/src/components/DataSubmissions/DataSubmissionListFilters.tsx
@@ -304,8 +304,12 @@ const DataSubmissionListFilters = ({
       return;
     }
 
-    if (!canViewOtherOrgs && isValidOrg(user?.organization?.orgID)) {
-      setValue("organization", user.organization.orgID);
+    if (
+      !canViewOtherOrgs &&
+      isValidOrg(user?.organization?.orgID) &&
+      user?.organization?.orgID !== orgFilter
+    ) {
+      setValue("organization", user?.organization?.orgID);
     } else if (canViewOtherOrgs && isValidOrg(organizationId)) {
       setValue("organization", organizationId);
     }


### PR DESCRIPTION
### Overview

Fix the debouncing not working when the organization dropdown is read only. This is due to the form updating with the same organization value every time there's a change.

### Change Details (Specifics)

- Added check to make sure the form doesn't update with the same value for organization

### Related Ticket(s)

[CRDCDH-1609](https://tracker.nci.nih.gov/browse/CRDCDH-1609) (Task)
[CRDCDH-1412](https://tracker.nci.nih.gov/browse/CRDCDH-1412) (User Story)
