### PR TITLE
CRDCDH-1774 Ignore casing when comparing name/abbr

### DIFF
--- a/src/utils/formUtils.test.ts
+++ b/src/utils/formUtils.test.ts
@@ -206,6 +206,14 @@ describe("formatFullStudyName cases", () => {
     expect(result).toBe("Study Name");
   });
 
+  it("should ignore casing when comparing the study name and abbreviation", () => {
+    const equalValuesWithDifferentCasing = utils.formatFullStudyName("study name", "STUDY NAME");
+    expect(equalValuesWithDifferentCasing).toBe("study name");
+
+    const equalValuesWithDifferentCasing2 = utils.formatFullStudyName("STUDY NAME", "study name");
+    expect(equalValuesWithDifferentCasing2).toBe("STUDY NAME");
+  });
+
   it("should remove extra spaces from the study name", () => {
     const studyName = "   Study Name   ";
     const result = utils.formatFullStudyName(studyName, "");

--- a/src/utils/formUtils.ts
+++ b/src/utils/formUtils.ts
@@ -129,7 +129,7 @@ export const formatFullStudyName = (studyName: string, studyAbbreviation: string
   if (typeof studyName !== "string") {
     return "";
   }
-  if (studyAbbreviation === studyName) {
+  if (studyAbbreviation?.toLowerCase() === studyName?.toLowerCase()) {
     return studyName.trim();
   }
   if (studyAbbreviation && studyAbbreviation.length > 0) {


### PR DESCRIPTION
### Overview

Simple bug fix to address the formatFullStudyName not ignoring casing when comparing the equality of the Study Name and Study Abbreviation.

### Change Details (Specifics)

- Force study name and abbreviation to lowercase before comparing equality
- Update test coverage to test for this bug

### Related Ticket(s)

CRDCDH-1774
