### PR TITLE
CRDCDH-1674 Update Submit button logic for Admin Submit

### DIFF
--- a/src/config/SubmitButtonConfig.ts
+++ b/src/config/SubmitButtonConfig.ts
@@ -67,7 +67,7 @@ export const SUBMIT_BUTTON_CONDITIONS: SubmitButtonCondition[] = [
     preConditionCheck: (s) => s.dataType === "Metadata Only",
     check: (s) => !!s.metadataValidationStatus,
     tooltip: TOOLTIP_TEXT.SUBMISSION_ACTIONS.SUBMIT.DISABLED.NEW_DATA_OR_VALIDATION_ERRORS,
-    required: false,
+    required: true,
   },
   {
     _identifier:
@@ -75,7 +75,7 @@ export const SUBMIT_BUTTON_CONDITIONS: SubmitButtonCondition[] = [
     preConditionCheck: (s) => s.dataType === "Metadata and Data Files",
     check: (s) => !!s.fileValidationStatus,
     tooltip: TOOLTIP_TEXT.SUBMISSION_ACTIONS.SUBMIT.DISABLED.MISSING_DATA_FILE,
-    required: false,
+    required: true,
   },
   {
     _identifier:
@@ -83,7 +83,7 @@ export const SUBMIT_BUTTON_CONDITIONS: SubmitButtonCondition[] = [
     preConditionCheck: (s) => s.dataType === "Metadata and Data Files",
     check: (s) => !!s.metadataValidationStatus,
     tooltip: TOOLTIP_TEXT.SUBMISSION_ACTIONS.SUBMIT.DISABLED.NEW_DATA_OR_VALIDATION_ERRORS,
-    required: false,
+    required: true,
   },
   {
     _identifier: "There should be no validation errors for metadata or data files",
@@ -102,15 +102,6 @@ export const ADMIN_OVERRIDE_CONDITIONS: AdminOverrideCondition[] = [
   {
     _identifier: "Admin Override - Submission has validation errors",
     check: (s) => s.metadataValidationStatus === "Error" || s.fileValidationStatus === "Error",
-    tooltip: undefined,
-  },
-  {
-    _identifier:
-      "Admin Override - Submission is missing either metadata or data files for 'Metadata and Data Files' submissions",
-    check: (s) =>
-      (!!s.metadataValidationStatus && !s.fileValidationStatus) ||
-      (!s.metadataValidationStatus && !!s.fileValidationStatus),
-    preConditionCheck: (s) => s.dataType === "Metadata and Data Files",
     tooltip: undefined,
   },
 ];

--- a/src/config/SubmitButtonConfig.ts
+++ b/src/config/SubmitButtonConfig.ts
@@ -60,7 +60,7 @@ export const SUBMIT_BUTTON_CONDITIONS: SubmitButtonCondition[] = [
     preConditionCheck: (s) => s.intention === "Delete",
     check: (s) => !!s.metadataValidationStatus,
     tooltip: TOOLTIP_TEXT.SUBMISSION_ACTIONS.SUBMIT.DISABLED.NEW_DATA_OR_VALIDATION_ERRORS,
-    required: false,
+    required: true,
   },
   {
     _identifier: "Metadata validation should be initialized for 'Metadata Only' submissions",

--- a/src/utils/dataSubmissionUtils.test.ts
+++ b/src/utils/dataSubmissionUtils.test.ts
@@ -349,15 +349,15 @@ describe("Admin Submit", () => {
     expect(result.isAdminOverride).toBe(false);
   });
 
-  it("should allow admin override when metadata is passed but file validation is null", () => {
+  it("should not allow admin override when metadata is passed but file validation is null", () => {
     const submission: Submission = {
       ...baseSubmission,
       metadataValidationStatus: "Passed",
       fileValidationStatus: null,
     };
     const result = utils.shouldEnableSubmit(submission, "Admin");
-    expect(result.enabled).toBe(true);
-    expect(result.isAdminOverride).toBe(true);
+    expect(result.enabled).toBe(false);
+    expect(result.isAdminOverride).toBe(false);
   });
 
   it("should not enable submit when both validations are null", () => {
@@ -373,6 +373,7 @@ describe("Admin Submit", () => {
   it("should allow admin override when file validation is null and intention is 'Delete'", () => {
     const submission: Submission = {
       ...baseSubmission,
+      dataType: "Metadata Only",
       metadataValidationStatus: "Error",
       fileValidationStatus: null,
       intention: "Delete",
@@ -437,6 +438,7 @@ describe("Admin Submit", () => {
   it("should allow submit with isAdminOverride when metadata validation is 'Error', file validation is null, and intention is 'Delete'", () => {
     const submission: Submission = {
       ...baseSubmission,
+      dataType: "Metadata Only",
       metadataValidationStatus: "Error",
       fileValidationStatus: null,
       intention: "Delete",
@@ -514,14 +516,12 @@ describe("shouldAllowAdminOverride", () => {
   it("should check condition if preConditionCheck is met", () => {
     const submission: Submission = {
       ...baseSubmission,
-      dataType: "Metadata and Data Files",
-      metadataValidationStatus: "Passed",
+      dataType: "Metadata Only",
+      metadataValidationStatus: "Error",
       fileValidationStatus: null,
     };
     const result = utils.shouldAllowAdminOverride(submission);
-    expect(result._identifier).toBe(
-      "Admin Override - Submission is missing either metadata or data files for 'Metadata and Data Files' submissions"
-    );
+    expect(result._identifier).toBe("Admin Override - Submission has validation errors");
     expect(result.enabled).toBe(true);
     expect(result.isAdminOverride).toBe(true);
   });


### PR DESCRIPTION
### Overview

Removed Admin Override option for when missing either "Metadata" or "Data Files" within a "Metadata and Data Files" Data Submission.

### Change Details (Specifics)

- Removed Admin Override rule
- Updated some basic rules to be required to avoid it being overridable 
- Updated tests to reflect change

### Related Ticket(s)

[CRDCDH-1674](https://tracker.nci.nih.gov/browse/CRDCDH-1674) (Bug Ticket)
