### PR TITLE
CRDCDH-1780 Add "Test MDF" data model

### DIFF
--- a/src/config/DataCommons.ts
+++ b/src/config/DataCommons.ts
@@ -436,6 +436,111 @@ const DataCommons: DataCommon[] = [
       },
     },
   },
+  {
+    name: "Test MDF",
+    assets: null,
+    configuration: {
+      pageTitle: "Test MDF Data Model",
+      pdfConfig: {
+        fileType: "pdf",
+        prefix: "Test MDF_",
+        downloadPrefix: "Test MDF_",
+        fileTransferManifestName: "Test MDF_",
+        iconSrc: logo,
+        footnote: "https://hub.datacommons.cancer.gov/model-navigator/Test MDF",
+        landscape: true,
+      },
+      facetFilterSearchData: [
+        {
+          groupName: "Category",
+          datafield: "category",
+          section: "Filter By Nodes",
+          tooltip: "category",
+          show: true,
+          checkboxItems: [
+            { name: "Administrative", isChecked: false, group: "category" },
+            { name: "Analysis", isChecked: false, group: "category" },
+            { name: "Biospecimen", isChecked: false, group: "category" },
+            { name: "Case", isChecked: false, group: "category" },
+            { name: "Clinical", isChecked: false, group: "category" },
+            { name: "Clinical_Trial", isChecked: false, group: "category" },
+            { name: "Data_File", isChecked: false, group: "category" },
+            { name: "Study", isChecked: false, group: "category" },
+          ],
+        },
+        {
+          groupName: "Assignment",
+          datafield: "assignment",
+          section: "Filter By Nodes",
+          tooltip: "assignment",
+          show: true,
+          checkboxItems: [
+            { name: "Core", isChecked: false, group: "assignment" },
+            { name: "Extended", isChecked: false, group: "assignment" },
+          ],
+        },
+        {
+          groupName: "Class",
+          datafield: "class",
+          section: "Filter By Nodes",
+          tooltip: "class",
+          show: true,
+          checkboxItems: [
+            { name: "Primary", isChecked: false, group: "class" },
+            { name: "Secondary", isChecked: false, group: "class" },
+          ],
+        },
+        {
+          groupName: "Inclusion",
+          datafield: "inclusion",
+          section: "Filter By Property",
+          tooltip: "inclusion",
+          show: true,
+          checkboxItems: [
+            { name: "Optional", isChecked: false, group: "optional" },
+            { name: "Preferred", isChecked: false, group: "preferred" },
+            { name: "Required", isChecked: false, group: "required" },
+          ],
+        },
+        {
+          groupName: "UI Display",
+          datafield: "uiDisplay",
+          section: "Filter By Property",
+          tooltip: "inclusion",
+          show: true,
+          checkboxItems: [
+            { name: "no", isChecked: false, group: "no" },
+            { name: "yes", isChecked: false, group: "yes" },
+          ],
+        },
+      ],
+      facetFilterSectionVariables: {
+        "Filter By Nodes": {
+          color: "#0D71A3",
+          checkBoxColorsOne: "#E3F4FD",
+          checkBoxColorsTwo: "#f0f8ff",
+          checkBoxBorderColor: "#0D71A3",
+          height: "7px",
+          isExpanded: true,
+        },
+        "Filter By Relationship": {
+          color: "#FF9742",
+          checkBoxColorsOne: "#FF9742",
+          checkBoxColorsTwo: "#FF9742",
+          height: "7px",
+          isExpanded: true,
+        },
+        "Filter By Property": {
+          color: "#0D71A3",
+          checkBoxColorsOne: "#E3F4FD",
+          checkBoxColorsTwo: "#f0f8ff",
+          checkBoxBorderColor: "#0D71A3",
+          height: "7px",
+          isExpanded: true,
+        },
+      },
+    },
+  },
 ];
 
 // TODO: This is a TEMPORARY implementation to hide Data Commons from the UI


### PR DESCRIPTION
### Overview

This PR adds FE support for the "Test MDF" data common (aka data model).

> [!Warning]
> Model navigator can load this model, but some functionality is broken (especially in the table view).

### Change Details (Specifics)

- Add DMN config for the Test MDF model

### Related Ticket(s)

CRDCDH-1780 (FE Task)
CRDCDH-1448 (User Story)

