### PR TITLE
CRDCDH-1739 Data Activity show who uploaded

### DIFF
--- a/src/content/dataSubmissions/DataActivity.tsx
+++ b/src/content/dataSubmissions/DataActivity.tsx
@@ -21,6 +21,11 @@ import {
 import { FormatDate } from "../../utils";
 import FileListDialog from "../../components/FileListDialog";
 import ErrorDetailsDialog from "../../components/ErrorDetailsDialog";
+import StyledTooltip from "../../components/StyledFormComponents/StyledTooltip";
+
+const StyledDateTooltip = styled(StyledTooltip)({
+  cursor: "pointer",
+});
 
 const StyledRejectedStatus = styled("div")({
   color: "#B54717",
@@ -107,13 +112,23 @@ const columns: Column<Batch>[] = [
   },
   {
     label: "Uploaded Date",
-    renderValue: (data) =>
-      data?.createdAt ? `${FormatDate(data.createdAt, "MM-DD-YYYY [at] hh:mm A")}` : "",
+    renderValue: (data) => (
+      <StyledDateTooltip title={FormatDate(data.createdAt, "M/D/YYYY h:mm A")} placement="top">
+        <span data-testid={`activity-uploaded-date-${data?._id}`}>
+          {FormatDate(data.createdAt, "M/D/YYYY")}
+        </span>
+      </StyledDateTooltip>
+    ),
     field: "createdAt",
     default: true,
     sx: {
-      minWidth: "240px",
+      minWidth: "92px",
     },
+  },
+  {
+    label: "Uploaded By",
+    renderValue: (data) => data?.submitterName || "",
+    field: "submitterName",
   },
   {
     label: "Upload Errors",

--- a/src/graphql/listBatches.ts
+++ b/src/graphql/listBatches.ts
@@ -26,6 +26,8 @@ const FullBatchFragment = gql`
       createdAt
       updatedAt
     }
+    submitterID
+    submitterName
     status
     errors
   }

--- a/src/graphql/listBatches.ts
+++ b/src/graphql/listBatches.ts
@@ -26,7 +26,6 @@ const FullBatchFragment = gql`
       createdAt
       updatedAt
     }
-    submitterID
     submitterName
     status
     errors
@@ -80,7 +79,7 @@ export type Response<IsPartial = false> = {
     total: number;
     batches: (IsPartial extends true
       ? Pick<Batch, "_id" | "displayID" | "createdAt" | "updatedAt">
-      : Batch)[];
+      : Omit<Batch, "submitterID">)[];
   };
   batchStatusList: {
     batches: Pick<Batch, "_id" | "status">[];

--- a/src/types/Submissions.d.ts
+++ b/src/types/Submissions.d.ts
@@ -167,22 +167,29 @@ type Batch = {
   files: BatchFileInfo[];
   status: BatchStatus;
   errors: string[];
+  /**
+   * The ID of the user who created the batch
+   *
+   * @since 3.1.0
+   */
+  submitterID?: string;
+  /**
+   * The name of the user who created the batch
+   *
+   * @since 3.1.0
+   */
+  submitterName?: string;
   createdAt: string; // ISO 8601 date time format with UTC or offset e.g., 2023-05-01T09:23:30Z
   updatedAt: string; // ISO 8601 date time format with UTC or offset e.g., 2023-05-01T09:23:30Z
 };
 
-type NewBatch = {
-  _id: string;
-  submissionID: string; // parent
-  bucketName?: string; // S3 bucket of the submission, for file batch / CLI use
-  filePrefix?: string; // prefix/path within S3 bucket, for file batch / CLI use
-  type: UploadType;
-  fileCount: number; // calculated by BE
+type NewBatch = Pick<
+  Batch,
+  "_id" | "submissionID" | "type" | "fileCount" | "status" | "errors" | "createdAt" | "updatedAt"
+> & {
+  bucketName?: string;
+  filePrefix?: string;
   files: FileURL[];
-  status: BatchStatus; // [New, Uploaded, Upload Failed, Loaded, Rejected] Loaded and Rejected are for metadata batch only
-  errors: string[];
-  createdAt: string; // ISO 8601 date time format with UTC or offset e.g., 2023-05-01T09:23:30Z
-  updatedAt: string; // ISO 8601 date time format with UTC or offset e.g., 2023-05-01T09:23:30Z
 };
 
 type ListBatches = {

--- a/src/types/Submissions.d.ts
+++ b/src/types/Submissions.d.ts
@@ -161,22 +161,18 @@ type UploadType = "metadata" | "data file";
 type Batch = {
   _id: string;
   displayID: number;
-  submissionID: string; // parent
+  submissionID: string;
   type: UploadType;
-  fileCount: number; // calculated by BE
+  fileCount: number;
   files: BatchFileInfo[];
   status: BatchStatus;
   errors: string[];
   /**
    * The ID of the user who created the batch
-   *
-   * @since 3.1.0
    */
   submitterID?: string;
   /**
    * The name of the user who created the batch
-   *
-   * @since 3.1.0
    */
   submitterName?: string;
   createdAt: string; // ISO 8601 date time format with UTC or offset e.g., 2023-05-01T09:23:30Z


### PR DESCRIPTION
### Overview

This PR adds a new "Uploaded By" column to the Data Activity tab which displays who uploaded the batch (The data submission submitter, organization owner, or collaborator).

> [!Warning]
> There are requested changes in the BE to correctly store the name of the batch creator. Currently, it just stores the name of the original submission request creator. Unless the schema field names change, there should be no FE impact.

### Change Details (Specifics)

- Add the "Uploaded By" column to the Data Submission > Data Activity Tab
- Copy the concise date formatting from the Data Submission List and apply it to the Uploaded Date column
- Add `submitterName` and `submitterID` to the Batch type, both of these fields do not exist in prior releases, so I marked them as "optional"
- Refine the `NewBatch` type to inherit from the `Batch` type

### Related Ticket(s)

CRDCDH-1739 (FE Task)
CRDCDH-1696 (User Story)