### PR TITLE
CRDCDH-1740 Redesign History Dialog component

### DIFF
--- a/src/components/HistoryDialog/index.test.tsx
+++ b/src/components/HistoryDialog/index.test.tsx
@@ -153,6 +153,45 @@ describe("Implementation Requirements", () => {
     ).toHaveAttribute("title", "2024-09-05T14:45:00Z");
   });
 
+  it("should render the name for each history item if provided", () => {
+    const history: HistoryBase<MockStatuses>[] = [
+      {
+        status: "uploaded",
+        dateTime: "2024-09-25T14:45:00Z",
+        userID: "test",
+        userName: "Test User",
+      },
+      {
+        status: "downloaded",
+        dateTime: "2024-09-11T14:45:00Z",
+        userID: "test",
+        userName: "Another User",
+      },
+    ];
+
+    const { getByTestId } = render(<HistoryDialog {...BaseProps} history={history} />);
+
+    expect(
+      within(getByTestId("history-item-0")).getByTestId("history-item-0-name")
+    ).toHaveTextContent("Test User");
+
+    expect(
+      within(getByTestId("history-item-1")).getByTestId("history-item-1-name")
+    ).toHaveTextContent("Another User");
+  });
+
+  it("should not render the name for each history item if not provided", () => {
+    const history: HistoryBase<MockStatuses>[] = [
+      { status: "uploaded", dateTime: "2024-09-25T14:45:00Z", userID: "test" },
+      { status: "downloaded", dateTime: "2024-09-11T14:45:00Z", userID: "test" },
+    ];
+
+    const { queryByTestId } = render(<HistoryDialog {...BaseProps} history={history} />);
+
+    expect(queryByTestId("history-item-0-name")).not.toBeInTheDocument();
+    expect(queryByTestId("history-item-1-name")).not.toBeInTheDocument();
+  });
+
   it("should fallback to #FFF if getTextColor is not a function", () => {
     const history: HistoryBase<MockStatuses>[] = [
       { status: "uploaded", dateTime: "2024-09-05T14:45:00Z", userID: "test", reviewComment: "" },

--- a/src/components/HistoryDialog/index.test.tsx
+++ b/src/components/HistoryDialog/index.test.tsx
@@ -76,6 +76,18 @@ describe("Basic Functionality", () => {
 
     expect(getTextColor).toHaveBeenCalledWith("uploaded");
   });
+
+  it("should not render the headers if showHeaders is false", () => {
+    const { queryByTestId, getByTestId, rerender } = render(
+      <HistoryDialog {...BaseProps} showHeaders={false} />
+    );
+
+    expect(queryByTestId("history-dialog-header-row")).not.toBeInTheDocument();
+
+    rerender(<HistoryDialog {...BaseProps} showHeaders />);
+
+    expect(getByTestId("history-dialog-header-row")).toBeInTheDocument();
+  });
 });
 
 describe("Implementation Requirements", () => {

--- a/src/components/HistoryDialog/index.tsx
+++ b/src/components/HistoryDialog/index.tsx
@@ -49,6 +49,7 @@ const StyledTitle = styled("p")({
 const StyledDialogContent = styled(DialogContent, { shouldForwardProp: (p) => p !== "headerRow" })<{
   headerRow: boolean;
 }>(({ headerRow }) => ({
+  "--border-bottom-width": "0.5px",
   marginTop: headerRow ? "53px" : "74px",
   marginBottom: "35px",
   paddingLeft: "37px",
@@ -81,7 +82,7 @@ const StyledCloseButton = styled(Button)({
 });
 
 const StyledHeaderRow = styled(Grid)({
-  borderBottom: "0.5px solid #375F9A",
+  borderBottom: "var(--border-bottom-width) solid #375F9A",
   paddingBottom: "8px",
   marginBottom: "4px",
 });
@@ -99,7 +100,7 @@ const StyledHeaderItem = styled(Typography)<React.CSSProperties>((styles) => ({
 
 const StyledEventRow = styled(Grid)({
   padding: "17px 0",
-  borderBottom: "0.5px solid #375F9A",
+  borderBottom: "var(--border-bottom-width) solid #375F9A",
   alignItems: "center",
 });
 
@@ -145,7 +146,7 @@ const TopConnector = styled("div")({
   left: "5px",
   bottom: "0",
   width: "6px",
-  height: "27px",
+  height: "calc(27px + var(--border-bottom-width) / 2)",
   background: "white",
 });
 
@@ -155,7 +156,7 @@ const BottomConnector = styled("div")({
   left: "5px",
   top: "0",
   width: "6px",
-  height: "27px",
+  height: "calc(27px + var(--border-bottom-width) / 2)",
   background: "white",
 });
 

--- a/src/components/HistoryDialog/index.tsx
+++ b/src/components/HistoryDialog/index.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, memo, useCallback, useMemo } from "react";
+import React, { CSSProperties, memo, useCallback, useMemo } from "react";
 import {
   Button,
   Dialog,
@@ -11,6 +11,7 @@ import {
   styled,
 } from "@mui/material";
 import { FormatDate, SortHistory } from "../../utils";
+import TruncatedText from "../TruncatedText";
 
 const StyledDialog = styled(Dialog)({
   "& .MuiDialog-paper": {
@@ -70,8 +71,6 @@ const StyledCloseButton = styled(Button)({
   color: "#fff",
   borderColor: "#fff",
   margin: "0 auto",
-  padding: "10px",
-  lineHeight: "24px",
   "&:hover": {
     borderColor: "#fff",
   },
@@ -83,7 +82,7 @@ const StyledGridHeader = styled(Grid)({
   marginBottom: "4px",
 });
 
-const StyledHistoryHeader = styled(Typography)({
+const StyledHistoryHeader = styled(Typography)<React.CSSProperties>((styles) => ({
   fontFamily: "Public Sans",
   fontWeight: "300",
   fontSize: "8px",
@@ -91,26 +90,36 @@ const StyledHistoryHeader = styled(Typography)({
   textTransform: "uppercase",
   color: "#9FB3D1",
   userSelect: "none",
-});
+  ...styles,
+}));
 
 const StyledGridEventItem = styled(Grid)({
-  padding: "20px 0",
+  padding: "17px 0",
   borderBottom: "0.5px solid #375F9A",
   alignItems: "center",
 });
 
-const StyledHistoryItem = styled(Typography)<{
-  color: CSSProperties["color"];
-  textAlign?: CSSProperties["textAlign"];
-}>(({ textAlign = "center", color }) => ({
+const BaseItemTypographyStyles: React.CSSProperties = {
   fontFamily: "Public Sans",
   fontWeight: "400",
   fontSize: "13px",
   letterSpacing: "0.0025em",
   userSelect: "none",
-  textAlign,
-  color,
-}));
+};
+
+const StyledHistoryItem = styled(Typography)<React.CSSProperties>(
+  ({ textAlign = "center", color = "inherit" }) => ({
+    ...BaseItemTypographyStyles,
+    textAlign,
+    color,
+  })
+);
+
+const DotContainer = styled("div")({
+  position: "relative",
+  width: "100%",
+  height: "100%",
+});
 
 const VerticalDot = styled("div")({
   position: "absolute",
@@ -130,7 +139,7 @@ const TopConnector = styled("div")({
   left: "5px",
   bottom: "0",
   width: "6px",
-  height: "30px", // TODO: Rows can be different heights and this should be dynamic
+  height: "27px",
   background: "white",
 });
 
@@ -140,7 +149,7 @@ const BottomConnector = styled("div")({
   left: "5px",
   top: "0",
   width: "6px",
-  height: "30px", // TODO: Rows can be different heights and this should be dynamic
+  height: "27px",
   background: "white",
 });
 
@@ -255,7 +264,9 @@ const HistoryDialog = <T extends string>({
         <StyledGridHeader container columnSpacing={3}>
           <Grid item xs={2} />
           <Grid item xs={3}>
-            <StyledHistoryHeader>Status</StyledHistoryHeader>
+            <StyledHistoryHeader textAlign="left" paddingLeft="12px">
+              Status
+            </StyledHistoryHeader>
           </Grid>
           <Grid item xs={3}>
             <StyledHistoryHeader>Date</StyledHistoryHeader>
@@ -265,8 +276,7 @@ const HistoryDialog = <T extends string>({
               <StyledHistoryHeader>User</StyledHistoryHeader>
             </Grid>
           )}
-          {/* TODO: fine tune spacing when no name column is shown */}
-          <Grid item xs={eventHasNames ? 1 : 4} />
+          <Grid item xs={1} />
         </StyledGridHeader>
         {events?.map(({ status, date, color, name, nameColor, icon }, index) => (
           <StyledGridEventItem
@@ -276,12 +286,12 @@ const HistoryDialog = <T extends string>({
             columnSpacing={3}
           >
             <Grid item xs={2}>
-              <div style={{ position: "relative", width: "100%", height: "100%" }}>
+              <DotContainer>
                 {index !== 0 && <TopConnector />}
                 <VerticalDot />
                 <HorizontalLine />
                 {index !== events.length - 1 && <BottomConnector />}
-              </div>
+              </DotContainer>
             </Grid>
             <Grid item xs={3}>
               <StyledHistoryItem
@@ -303,11 +313,20 @@ const HistoryDialog = <T extends string>({
             </Grid>
             {eventHasNames && (
               <Grid item xs={3} data-testid={`history-item-${index}-name`}>
-                <StyledHistoryItem color={nameColor}>{name}</StyledHistoryItem>
+                <StyledHistoryItem>
+                  <TruncatedText
+                    text={name}
+                    maxCharacters={14}
+                    wrapperStyles={{
+                      ...BaseItemTypographyStyles,
+                      margin: "0 auto",
+                      color: nameColor,
+                    }}
+                  />
+                </StyledHistoryItem>
               </Grid>
             )}
-            {/* TODO: fine tune spacing when no name column is shown */}
-            <Grid item xs={eventHasNames ? 1 : 4} sx={{ position: "relative" }}>
+            <Grid item xs={1} sx={{ position: "relative" }}>
               {icon && (
                 <StyledIcon>
                   <img
@@ -326,6 +345,7 @@ const HistoryDialog = <T extends string>({
           onClick={onClose}
           variant="outlined"
           size="large"
+          color="info"
           data-testid="history-dialog-close"
         >
           Close
@@ -335,5 +355,4 @@ const HistoryDialog = <T extends string>({
   );
 };
 
-// TODO: type this
-export default memo(HistoryDialog);
+export default memo(HistoryDialog) as typeof HistoryDialog;

--- a/src/components/HistoryDialog/index.tsx
+++ b/src/components/HistoryDialog/index.tsx
@@ -7,9 +7,9 @@ import {
   DialogProps,
   DialogTitle,
   Typography,
-  Grid,
   styled,
 } from "@mui/material";
+import Grid from "@mui/material/Unstable_Grid2";
 import { FormatDate, SortHistory } from "../../utils";
 import TruncatedText from "../TruncatedText";
 
@@ -17,7 +17,7 @@ const StyledDialog = styled(Dialog)({
   "& .MuiDialog-paper": {
     borderRadius: "8px",
     boxShadow: "0px 4px 45px 0px rgba(0, 0, 0, 0.40)",
-    padding: "28px 24px",
+    padding: "22px 24px 54px 24px",
     width: "567px !important",
     border: "2px solid #388DEE",
     background: "#2E4D7B",
@@ -46,11 +46,15 @@ const StyledTitle = styled("p")({
   margin: "0",
 });
 
-const StyledDialogContent = styled(DialogContent)({
-  marginTop: "20px",
-  marginBottom: "22px",
+const StyledDialogContent = styled(DialogContent, { shouldForwardProp: (p) => p !== "headerRow" })<{
+  headerRow: boolean;
+}>(({ headerRow }) => ({
+  marginTop: headerRow ? "53px" : "74px",
+  marginBottom: "35px",
+  paddingLeft: "37px",
+  paddingRight: "37px",
   overflowY: "visible",
-});
+}));
 
 const StyledIcon = styled("div")({
   position: "absolute",
@@ -93,10 +97,6 @@ const StyledHeaderItem = styled(Typography)<React.CSSProperties>((styles) => ({
   ...styles,
 }));
 
-const HeaderGap = styled("div")({
-  height: "40px",
-});
-
 const StyledEventRow = styled(Grid)({
   padding: "17px 0",
   borderBottom: "0.5px solid #375F9A",
@@ -109,6 +109,7 @@ const BaseItemTypographyStyles: React.CSSProperties = {
   fontSize: "13px",
   letterSpacing: "0.0025em",
   userSelect: "none",
+  whiteSpace: "nowrap",
 };
 
 const StyledEventItem = styled(Typography)<React.CSSProperties>(
@@ -123,6 +124,7 @@ const DotContainer = styled("div")({
   position: "relative",
   width: "100%",
   height: "100%",
+  zIndex: 999,
 });
 
 const VerticalDot = styled("div")({
@@ -292,28 +294,26 @@ const HistoryDialog = <T extends string>({
         <StyledPreTitle>{preTitle}</StyledPreTitle>
         <StyledTitle>{title}</StyledTitle>
       </StyledDialogTitle>
-      <StyledDialogContent>
-        {showHeaders ? (
+      <StyledDialogContent headerRow={showHeaders}>
+        {showHeaders && (
           <StyledHeaderRow container columnSpacing={3} data-testid="history-dialog-header-row">
             {/* Spacing for the DotContainer */}
-            <Grid item xs={2} />
-            <Grid item xs={3}>
+            <Grid xs={2} />
+            <Grid xs={3}>
               <StyledHeaderItem textAlign="left" paddingLeft="12px">
                 Status
               </StyledHeaderItem>
             </Grid>
-            <Grid item xs={3}>
+            <Grid xs={3}>
               <StyledHeaderItem>Date</StyledHeaderItem>
             </Grid>
             {eventHasNames && (
-              <Grid item xs={3}>
+              <Grid xs={3}>
                 <StyledHeaderItem>User</StyledHeaderItem>
               </Grid>
             )}
-            <Grid item xs={1} />
+            <Grid xs={1} />
           </StyledHeaderRow>
-        ) : (
-          <HeaderGap />
         )}
         {events?.map(({ status, date, color, name, nameColor, icon }, index) => (
           <StyledEventRow
@@ -322,8 +322,8 @@ const HistoryDialog = <T extends string>({
             data-testid={`history-item-${index}`}
             columnSpacing={3}
           >
-            {!eventHasNames && <Grid item xs={1.5} />}
-            <Grid item xs={2}>
+            {!eventHasNames && <Grid xs={1.5} />}
+            <Grid xs={2}>
               <DotContainer>
                 {index !== 0 && <TopConnector />}
                 <VerticalDot />
@@ -331,7 +331,7 @@ const HistoryDialog = <T extends string>({
                 {index !== events.length - 1 && <BottomConnector />}
               </DotContainer>
             </Grid>
-            <Grid item xs={3}>
+            <Grid xs={3}>
               <StyledEventItem
                 color={color}
                 textAlign="left"
@@ -340,7 +340,7 @@ const HistoryDialog = <T extends string>({
                 {status?.toUpperCase()}
               </StyledEventItem>
             </Grid>
-            <Grid item xs={3}>
+            <Grid xs={3}>
               <StyledEventItem
                 color={color}
                 title={date}
@@ -350,7 +350,7 @@ const HistoryDialog = <T extends string>({
               </StyledEventItem>
             </Grid>
             {eventHasNames && (
-              <Grid item xs={3} data-testid={`history-item-${index}-name`}>
+              <Grid xs={3} data-testid={`history-item-${index}-name`}>
                 <StyledEventItem>
                   <TruncatedText
                     text={name}
@@ -365,7 +365,6 @@ const HistoryDialog = <T extends string>({
               </Grid>
             )}
             <Grid
-              item
               xs={1}
               sx={{
                 position: "relative",

--- a/src/components/StatusBar/StatusBar.test.tsx
+++ b/src/components/StatusBar/StatusBar.test.tsx
@@ -1,6 +1,6 @@
 import { FC, useMemo } from "react";
 import { BrowserRouter } from "react-router-dom";
-import { fireEvent, render, waitFor } from "@testing-library/react";
+import { fireEvent, render, waitFor, within } from "@testing-library/react";
 import { axe } from "jest-axe";
 import { ContextState, Context as FormCtx, Status as FormStatus } from "../Contexts/FormContext";
 import StatusBar from "./StatusBar";
@@ -351,13 +351,26 @@ describe("StatusBar > History Modal Tests", () => {
 
     fireEvent.click(getByText("Full History"));
 
-    const elements = getByTestId("status-bar-history-dialog").querySelectorAll("li");
-    expect(elements[0]).toHaveTextContent(/Rejected/i);
-    expect(elements[0]).toHaveTextContent("11/24/2023");
-    expect(elements[1]).toHaveTextContent(/In Progress/i);
-    expect(elements[1]).toHaveTextContent("11/22/2023");
-    expect(elements[2]).toHaveTextContent(/New/i);
-    expect(elements[2]).toHaveTextContent("11/20/2023");
+    expect(
+      within(getByTestId("history-item-0")).getByTestId("history-item-0-status")
+    ).toHaveTextContent(/Rejected/i);
+    expect(
+      within(getByTestId("history-item-0")).getByTestId("history-item-0-date")
+    ).toHaveTextContent("11/24/2023");
+
+    expect(
+      within(getByTestId("history-item-1")).getByTestId("history-item-1-status")
+    ).toHaveTextContent(/In Progress/i);
+    expect(
+      within(getByTestId("history-item-1")).getByTestId("history-item-1-date")
+    ).toHaveTextContent("11/22/2023");
+
+    expect(
+      within(getByTestId("history-item-2")).getByTestId("history-item-2-status")
+    ).toHaveTextContent(/New/i);
+    expect(
+      within(getByTestId("history-item-2")).getByTestId("history-item-2-date")
+    ).toHaveTextContent("11/20/2023");
   });
 
   it("renders only the most recent event with an icon", () => {

--- a/src/components/StatusBar/components/HistorySection.tsx
+++ b/src/components/StatusBar/components/HistorySection.tsx
@@ -93,6 +93,7 @@ const HistorySection: FC = () => {
             getTextColor={getStatusColor}
             open={open}
             onClose={() => setOpen(false)}
+            showHeaders={false}
             data-testid="status-bar-history-dialog"
           />
         </>

--- a/src/components/TruncatedText/index.test.tsx
+++ b/src/components/TruncatedText/index.test.tsx
@@ -131,6 +131,17 @@ describe("Basic Functionality", () => {
       expect(queryByRole("tooltip")).not.toBeInTheDocument();
     });
   });
+
+  it("should forward the wrapperStyles prop to the text wrapper element", () => {
+    const { getByTestId } = render(
+      <TruncatedText text="Styled text" wrapperStyles={{ color: "red", marginTop: "90px" }} />
+    );
+
+    const textWrapper = getByTestId("truncated-text-wrapper");
+
+    expect(textWrapper).toHaveStyle("color: red");
+    expect(textWrapper).toHaveStyle("margin-top: 90px");
+  });
 });
 
 describe("Edge Cases", () => {

--- a/src/components/TruncatedText/index.tsx
+++ b/src/components/TruncatedText/index.tsx
@@ -11,15 +11,18 @@ const StyledText = styled("span")(() => ({
 }));
 
 const StyledTextWrapper = styled("span", {
-  shouldForwardProp: (p) => p !== "truncated" && p !== "underline",
-})<{ truncated: boolean; underline: boolean }>(({ truncated, underline }) => ({
-  display: "block",
-  textDecoration: truncated && underline ? "underline" : "none",
-  textDecorationStyle: "dashed",
-  textUnderlineOffset: "4px",
-  cursor: truncated ? "pointer" : "inherit",
-  width: "fit-content",
-}));
+  shouldForwardProp: (p) => p !== "truncated" && p !== "underline" && p !== "styles",
+})<{ truncated: boolean; underline: boolean; styles: React.CSSProperties }>(
+  ({ truncated, underline, styles }) => ({
+    display: "block",
+    textDecoration: truncated && underline ? "underline" : "none",
+    textDecorationStyle: "dashed",
+    textUnderlineOffset: "4px",
+    cursor: truncated ? "pointer" : "inherit",
+    width: "fit-content",
+    ...styles,
+  })
+);
 
 type Props = {
   /**
@@ -47,6 +50,10 @@ type Props = {
    * an ellipsis when truncation occurs
    */
   ellipsis?: boolean;
+  /**
+   * Optional custom styling to apply on the wrapper element
+   */
+  wrapperStyles?: React.CSSProperties;
 };
 
 /**
@@ -62,6 +69,7 @@ const TruncatedText: FC<Props> = ({
   maxCharacters = 10,
   underline = true,
   ellipsis = true,
+  wrapperStyles = {},
 }: Props) => {
   const isTruncated = text?.length > maxCharacters;
   const displayText = isTruncated
@@ -79,6 +87,7 @@ const TruncatedText: FC<Props> = ({
         truncated={isTruncated}
         underline={underline}
         data-testid="truncated-text-wrapper"
+        styles={wrapperStyles}
       >
         <StyledText data-testid="truncated-text-label">{displayText}</StyledText>
       </StyledTextWrapper>
@@ -86,4 +95,4 @@ const TruncatedText: FC<Props> = ({
   );
 };
 
-export default memo(TruncatedText);
+export default memo<Props>(TruncatedText);

--- a/src/graphql/getSubmission.ts
+++ b/src/graphql/getSubmission.ts
@@ -51,6 +51,7 @@ export const query = gql`
         reviewComment
         dateTime
         userID
+        userName
       }
       conciergeName
       conciergeEmail

--- a/src/setupTests.tsx
+++ b/src/setupTests.tsx
@@ -7,16 +7,6 @@ import failOnConsole from "jest-fail-on-console";
 import crypto from "crypto";
 
 /**
- * Mocks the MUI Fade component for testing.
- *
- * @note If the default fade type is changed, this must be updated to match.
- */
-jest.mock("@mui/material", () => ({
-  ...jest.requireActual("@mui/material"),
-  Fade: jest.fn(({ children }) => children),
-}));
-
-/**
  * Makes the global.crypto.getRandomValues function available in Jest
  *
  * @see https://stackoverflow.com/a/63749793

--- a/src/setupTests.tsx
+++ b/src/setupTests.tsx
@@ -7,6 +7,16 @@ import failOnConsole from "jest-fail-on-console";
 import crypto from "crypto";
 
 /**
+ * Mocks the MUI Fade component for testing.
+ *
+ * @note If the default fade type is changed, this must be updated to match.
+ */
+jest.mock("@mui/material", () => ({
+  ...jest.requireActual("@mui/material"),
+  Fade: jest.fn(({ children }) => children),
+}));
+
+/**
  * Makes the global.crypto.getRandomValues function available in Jest
  *
  * @see https://stackoverflow.com/a/63749793

--- a/src/types/Globals.d.ts
+++ b/src/types/Globals.d.ts
@@ -47,10 +47,32 @@ type FormGroupCheckboxOption = {
 type SelectOption = { label: string; value: string | number };
 
 type HistoryBase<T> = {
+  /**
+   * The transitioned status of the history event.
+   */
   status: T;
-  reviewComment?: string;
-  dateTime: string; // YYYY-MM-DDTHH:MM:SSZ format
+  /**
+   * The ISO 8601 date and time the history event occurred.
+   *
+   * @note This is in the format of `YYYY-MM-DDTHH:MM:SSZ`.
+   */
+  dateTime: string;
+  /**
+   * The ID of the user who initiated the history event.
+   */
   userID: string;
+  /**
+   * The name of the user who initiated the history event.
+   *
+   * @note This is not populated in all events.
+   */
+  userName?: string;
+  /**
+   * The comment associated with the history event.
+   *
+   * @note This is not populated in all events.
+   */
+  reviewComment?: string;
 };
 
 declare module "*.pdf";


### PR DESCRIPTION
### Overview

This PR introduces a rewrite of the History Dialog's underlying component, which incorporates a design update and an additional field indicating which user performed the history transition.

> [!NOTE]
> This design change impacts the Submission Request too, but the "User" column won't appear there (intentionally) since we don't get `userName` from the getApplication API.

### Change Details (Specifics)

- Rewrite the History Dialog to be slightly more efficient (memoization and optimizing usage of callbacks, etc)
- Rebuild the dialog UX without the MUI timeline (we essentially weren't using anything from it)
- Add support for custom styling on the TruncatedText component
- Minor updates to unit tests that were impacted by changes
- ~~Attempt to resolve transition-based ACT warnings by disabling MUI transitions~~ [Did not work](https://github.com/CBIIT/crdc-datahub-ui/actions/runs/11483531612/attempts/1)

### Related Ticket(s)

CRDCDH-1740 (FE Task)
CRDCDH-1741 (Design)
CRDCDH-1697 (User Story)