### PR TITLE
Support `model-files` array

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,8 +46,6 @@
         "react-transition-group": "^4.4.5",
         "recharts": "^2.12.0",
         "redux": "^4.2.1",
-        "redux-logger": "^3.0.6",
-        "redux-thunk": "^2.4.2",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -40,8 +40,6 @@
     "react-transition-group": "^4.4.5",
     "recharts": "^2.12.0",
     "redux": "^4.2.1",
-    "redux-logger": "^3.0.6",
-    "redux-thunk": "^2.4.2",
     "web-vitals": "^2.1.4"
   },
   "overrides": {

--- a/src/hooks/useBuildReduxStore.ts
+++ b/src/hooks/useBuildReduxStore.ts
@@ -91,7 +91,11 @@ const useBuildReduxStore = (): [
 
     const assets = buildAssetUrls(datacommon);
 
-    const response = await getModelExploreData(assets.model, assets.props)?.catch((e) => {
+    // TODO: This is a very temporary work-around until DMN supports N != 2 files
+    const modelFile = assets.model_files[0];
+    const propFile = assets.model_files.length > 1 ? assets.model_files[1] : assets.model_files[0];
+
+    const response = await getModelExploreData(modelFile, propFile)?.catch((e) => {
       Logger.error(e);
       return null;
     });

--- a/src/hooks/useBuildReduxStore.ts
+++ b/src/hooks/useBuildReduxStore.ts
@@ -1,13 +1,11 @@
 import { useState } from "react";
-import { createStore, applyMiddleware, combineReducers, Store } from "redux";
+import { createStore, combineReducers, Store } from "redux";
 import {
   ddgraph,
   moduleReducers as submission,
   versionInfo,
   getModelExploreData,
 } from "data-model-navigator";
-import ReduxThunk from "redux-thunk";
-import { createLogger } from "redux-logger";
 import { useLazyQuery } from "@apollo/client";
 import { defaultTo } from "lodash";
 import { baseConfiguration, defaultReadMeTitle, graphViewConfig } from "../config/ModelNavigator";
@@ -20,16 +18,17 @@ import {
 } from "../utils";
 import { RETRIEVE_CDEs, RetrieveCDEsInput, RetrieveCDEsResp } from "../graphql";
 
-export type Status = "waiting" | "loading" | "error" | "success";
+export type ReduxStoreStatus = "waiting" | "loading" | "error" | "success";
+
+export type ReduxStoreResult = [
+  { status: ReduxStoreStatus; store: Store },
+  () => void,
+  (assets: DataCommon) => void,
+];
 
 const makeStore = (): Store => {
   const reducers = { ddgraph, versionInfo, submission };
-  const loggerMiddleware = createLogger();
-
-  const newStore = createStore(
-    combineReducers(reducers),
-    applyMiddleware(ReduxThunk, loggerMiddleware)
-  );
+  const newStore = createStore(combineReducers(reducers));
 
   // @ts-ignore
   newStore.injectReducer = (key, reducer) => {
@@ -45,12 +44,8 @@ const makeStore = (): Store => {
  *
  * @params {void}
  */
-const useBuildReduxStore = (): [
-  { status: Status; store: Store },
-  () => void,
-  (assets: DataCommon) => void,
-] => {
-  const [status, setStatus] = useState<Status>("waiting");
+const useBuildReduxStore = (): ReduxStoreResult => {
+  const [status, setStatus] = useState<ReduxStoreStatus>("waiting");
   const [store, setStore] = useState<Store>(makeStore());
 
   const [retrieveCDEs, { error: retrieveCDEsError }] = useLazyQuery<
@@ -90,12 +85,7 @@ const useBuildReduxStore = (): [
     setStatus("loading");
 
     const assets = buildAssetUrls(datacommon);
-
-    // TODO: This is a very temporary work-around until DMN supports N != 2 files
-    const modelFile = assets.model_files[0];
-    const propFile = assets.model_files.length > 1 ? assets.model_files[1] : assets.model_files[0];
-
-    const response = await getModelExploreData(modelFile, propFile)?.catch((e) => {
+    const response = await getModelExploreData(...assets.model_files)?.catch((e) => {
       Logger.error(e);
       return null;
     });

--- a/src/types/DataCommon.d.ts
+++ b/src/types/DataCommon.d.ts
@@ -45,17 +45,13 @@ type DataModelManifest = {
  */
 type ManifestAssets = {
   /**
-   * The file name of the Data Model file.
+   * An array of strings with an arbitrary length containing the
+   * Data Model file names.
    *
-   * @example "cds-model.yaml"
+   * @example ["cds-model.yaml", "cds-model-props.yaml"]
+   * @since 3.1.0
    */
-  "model-file": string;
-  /**
-   * The file name of the Data Model properties file.
-   *
-   * @example "cds-model-props.yaml"
-   */
-  "prop-file": string;
+  "model-files": string[];
   /**
    * The file name of the Data Model README file.
    *

--- a/src/types/DataModelNavigator.d.ts
+++ b/src/types/DataModelNavigator.d.ts
@@ -52,13 +52,10 @@ type ModelNavigatorConfig = {
  */
 type ModelAssetUrls = {
   /**
-   * The URL to the Data Model file
+   * An array of fully-qualified URLs to the Data Model files.
+   * Arbitrary length, but must have at least one item.
    */
-  model: string;
-  /**
-   * The URL to the Data Model properties file
-   */
-  props: string;
+  model_files: string[];
   /**
    * The URL to the Data Model README file
    * If this is null, the README button will not be displayed

--- a/src/utils/dataModelUtils.test.ts
+++ b/src/utils/dataModelUtils.test.ts
@@ -17,8 +17,7 @@ describe("fetchManifest cases", () => {
   it("should return manifest from sessionStorage if it exists", async () => {
     const fakeManifest: DataModelManifest = {
       CDS: {
-        "model-file": "cds-model.yaml",
-        "prop-file": "cds-model-props.yaml",
+        "model-files": ["cds-model.yaml", "cds-model-props.yaml"],
         "readme-file": "cds-model-readme.md",
         "loading-file": "cds-loading.zip",
         "current-version": "1.0",
@@ -36,8 +35,7 @@ describe("fetchManifest cases", () => {
   it("should fetch manifest from server if it does not exist in sessionStorage", async () => {
     const fakeManifest: DataModelManifest = {
       CDS: {
-        "model-file": "cds-model.yaml",
-        "prop-file": "cds-model-props.yaml",
+        "model-files": ["cds-model.yaml", "cds-model-props.yaml"],
         "readme-file": "cds-model-readme.md",
         "loading-file": "cds-loading.zip",
         "current-version": "1.0",
@@ -58,8 +56,7 @@ describe("fetchManifest cases", () => {
   it("should cache manifest in sessionStorage after fetching", async () => {
     const fakeManifest: DataModelManifest = {
       CDS: {
-        "model-file": "cds-model.yaml",
-        "prop-file": "cds-model-props.yaml",
+        "model-files": ["cds-model.yaml", "cds-model-props.yaml"],
         "readme-file": "cds-model-readme.md",
         "loading-file": "cds-loading.zip",
         "current-version": "1.0",
@@ -115,8 +112,7 @@ describe("buildAssetUrls cases", () => {
       name: "test-name",
       assets: {
         "current-version": "1.0",
-        "model-file": "model-file",
-        "prop-file": "prop-file",
+        "model-files": ["model-file", "prop-file"],
         "readme-file": "readme-file",
         "loading-file": "loading-file-zip-name",
       } as ManifestAssets,
@@ -125,12 +121,51 @@ describe("buildAssetUrls cases", () => {
     const result = utils.buildAssetUrls(dc);
 
     expect(result).toEqual({
-      model: `${MODEL_FILE_REPO}prod/cache/test-name/1.0/model-file`,
-      props: `${MODEL_FILE_REPO}prod/cache/test-name/1.0/prop-file`,
+      model_files: [
+        `${MODEL_FILE_REPO}prod/cache/test-name/1.0/model-file`,
+        `${MODEL_FILE_REPO}prod/cache/test-name/1.0/prop-file`,
+      ],
       readme: `${MODEL_FILE_REPO}prod/cache/test-name/1.0/readme-file`,
       loading_file: `${MODEL_FILE_REPO}prod/cache/test-name/1.0/loading-file-zip-name`,
       navigator_icon: expect.any(String),
     });
+  });
+
+  it("should include every model file in the model_files array", () => {
+    const dc: DataCommon = {
+      name: "test-name",
+      assets: {
+        "current-version": "1.0",
+        "model-files": ["model-file", "prop-file", "other-file", "fourth-file"],
+        "readme-file": "readme-file",
+        "loading-file": "loading-file-zip-name",
+      } as ManifestAssets,
+    } as DataCommon;
+
+    const result = utils.buildAssetUrls(dc);
+
+    expect(result.model_files).toEqual([
+      `${MODEL_FILE_REPO}prod/cache/test-name/1.0/model-file`,
+      `${MODEL_FILE_REPO}prod/cache/test-name/1.0/prop-file`,
+      `${MODEL_FILE_REPO}prod/cache/test-name/1.0/other-file`,
+      `${MODEL_FILE_REPO}prod/cache/test-name/1.0/fourth-file`,
+    ]);
+  });
+
+  it("should handle empty model-files array", () => {
+    const dc: DataCommon = {
+      name: "test-name",
+      assets: {
+        "current-version": "1.0",
+        "model-files": [],
+        "readme-file": "readme-file",
+        "loading-file": "loading-file-zip-name",
+      } as ManifestAssets,
+    } as DataCommon;
+
+    const result = utils.buildAssetUrls(dc);
+
+    expect(result.model_files).toEqual([]);
   });
 
   const readMeValues = ["", null, undefined, false];
@@ -139,8 +174,7 @@ describe("buildAssetUrls cases", () => {
       name: "test-name",
       assets: {
         "current-version": "1.0",
-        "model-file": "model-file",
-        "prop-file": "prop-file",
+        "model-files": ["model-file", "prop-file"],
         "readme-file": readme,
       } as ManifestAssets,
     } as DataCommon;
@@ -155,8 +189,7 @@ describe("buildAssetUrls cases", () => {
       name: "test-name",
       assets: {
         "current-version": "1.0",
-        "model-file": "model-file",
-        "prop-file": "prop-file",
+        "model-files": ["model-file", "prop-file"],
         "readme-file": "readme-file",
         "loading-file": "loading-file-zip-name",
         // "model-navigator-logo" - not defined, aka no logo
@@ -173,8 +206,7 @@ describe("buildAssetUrls cases", () => {
       name: "test-name",
       assets: {
         "current-version": "1.0",
-        "model-file": "model-file",
-        "prop-file": "prop-file",
+        "model-files": ["model-file", "prop-file"],
         "readme-file": "readme-file",
         "loading-file": "loading-file-zip-name",
         "model-navigator-logo": "", // empty string - aka no logo
@@ -191,8 +223,7 @@ describe("buildAssetUrls cases", () => {
       name: "test-name",
       assets: {
         "current-version": "1.0",
-        "model-file": "model-file",
-        "prop-file": "prop-file",
+        "model-files": ["model-file", "prop-file"],
         "readme-file": "readme-file",
         "loading-file": "loading-file-zip-name",
         "model-navigator-logo": "custom-logo.png", // defined - must exist

--- a/src/utils/dataModelUtils.ts
+++ b/src/utils/dataModelUtils.ts
@@ -34,12 +34,13 @@ export const fetchManifest = async (): Promise<DataModelManifest> => {
  * @returns ModelAssetUrls
  */
 export const buildAssetUrls = (dc: DataCommon): ModelAssetUrls => ({
-  model: `${MODEL_FILE_REPO}${env.REACT_APP_DEV_TIER || "prod"}/cache/${dc?.name}/${dc?.assets?.[
-    "current-version"
-  ]}/${dc?.assets?.["model-file"]}`,
-  props: `${MODEL_FILE_REPO}${env.REACT_APP_DEV_TIER || "prod"}/cache/${dc?.name}/${dc?.assets?.[
-    "current-version"
-  ]}/${dc?.assets?.["prop-file"]}`,
+  model_files:
+    dc?.assets?.["model-files"].map(
+      (file) =>
+        `${MODEL_FILE_REPO}${env.REACT_APP_DEV_TIER || "prod"}/cache/${dc?.name}/${dc?.assets?.[
+          "current-version"
+        ]}/${file}`
+    ) || [],
   readme: dc?.assets?.["readme-file"]
     ? `${MODEL_FILE_REPO}${env.REACT_APP_DEV_TIER || "prod"}/cache/${dc?.name}/${dc?.assets?.[
         "current-version"


### PR DESCRIPTION
### Overview

This is a temporary work-around for the frontend to support an array of model-files, rather than just the model/prop combination. More changes for this will be introduced with CRDCDH-1744, but this workaround is so BE isn't blocked.

> [!Warning]
> This PR is ready for review, but shouldn't be merged yet.
> 
> Related to https://github.com/CBIIT/crdc-datahub-models/pull/153

### Change Details (Specifics)

- Update type definitions for the Model Repository content.json structure
- Update the buildAssetUrls util to support any arbitrary number of model-files (N >= 1)
- Update test coverage for related utils
- Explicitly pass only 2 files to DMN (this will change very soon, but DMN can only handle exactly 2)

### Related Ticket(s)

N/A
