### PR TITLE
CRDCDH-1826 Add a fake data model

### DIFF
--- a/src/config/DataCommons.ts
+++ b/src/config/DataCommons.ts
@@ -332,6 +332,42 @@ const DataCommons: DataCommon[] = [
     },
   },
   {
+    name: "Hidden Model",
+    assets: null,
+    configuration: {
+      pageTitle: "Hidden Data Model",
+      pdfConfig: {
+        fileType: "pdf",
+        prefix: "Hidden Model_",
+        downloadPrefix: "Hidden Model_",
+        fileTransferManifestName: "Hidden Model_",
+        iconSrc: logo,
+        footnote: "https://hub.datacommons.cancer.gov/model-navigator/Hidden Model",
+        landscape: true,
+      },
+      facetFilterSearchData: [
+        {
+          groupName: "Category",
+          datafield: "category",
+          section: "Filter By Nodes",
+          tooltip: "category",
+          show: true,
+          checkboxItems: [{ name: "Administrative", isChecked: false, group: "category" }],
+        },
+      ],
+      facetFilterSectionVariables: {
+        "Filter By Nodes": {
+          color: "#0D71A3",
+          checkBoxColorsOne: "#E3F4FD",
+          checkBoxColorsTwo: "#f0f8ff",
+          checkBoxBorderColor: "#0D71A3",
+          height: "7px",
+          isExpanded: true,
+        },
+      },
+    },
+  },
+  {
     name: "ICDC",
     assets: null,
     configuration: {

--- a/src/config/HeaderConfig.ts
+++ b/src/config/HeaderConfig.ts
@@ -62,7 +62,7 @@ export const navMobileList: NavBarItem[] = [
 export const navbarSublists: Record<string, NavBarSubItem[]> = {
   "Model Navigator": DataCommons.map((dc) => ({
     id: `model-navigator-${dc.name}`,
-    name: `${dc.name} Model`,
+    name: `${dc.name}${dc.name.indexOf("Model") === -1 ? " Model" : ""}`,
     link: `/model-navigator/${dc.name}`,
     className: "navMobileSubItem",
   })),


### PR DESCRIPTION
### Overview

This PR introduces a fake data model "Hidden Model" so that we can test the hiding functionality on lower tiers without using a real data model. After a DevOps change, this model will be hidden permanently.

> [!Note]
> This model does not have any actual model files defined ATM, so it will not load in model navigator.

### Change Details (Specifics)

- Add a fake data model with bare minimum configuration
- Change the NavBar config to not append "Model" after the DC name if it includes "Model" already (e.g. "Hidden Model Model")

### Related Ticket(s)

CRDCDH-1826 (FE Task)
