### PR TITLE
CRDCDH-1744 Support arbitrary number of Model Files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8896,8 +8896,8 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/data-model-navigator": {
-      "version": "1.1.33",
-      "resolved": "git+ssh://git@github.com/CBIIT/Data-Model-Navigator.git#d3e10a458e166230ee0eb6bc88154c733dd8fe3a",
+      "version": "1.1.34",
+      "resolved": "git+ssh://git@github.com/CBIIT/Data-Model-Navigator.git#8a2cc78f7c9e3e9061e8ca52f7f0dbf2be488ee6",
       "license": "ISC",
       "dependencies": {
         "@material-ui/core": "^4.12.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,8 +46,6 @@
         "react-transition-group": "^4.4.5",
         "recharts": "^2.12.0",
         "redux": "^4.2.1",
-        "redux-logger": "^3.0.6",
-        "redux-thunk": "^2.4.2",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -40,8 +40,6 @@
     "react-transition-group": "^4.4.5",
     "recharts": "^2.12.0",
     "redux": "^4.2.1",
-    "redux-logger": "^3.0.6",
-    "redux-thunk": "^2.4.2",
     "web-vitals": "^2.1.4"
   },
   "overrides": {

--- a/src/hooks/useBuildReduxStore.ts
+++ b/src/hooks/useBuildReduxStore.ts
@@ -91,7 +91,11 @@ const useBuildReduxStore = (): [
 
     const assets = buildAssetUrls(datacommon);
 
-    const response = await getModelExploreData(assets.model, assets.props)?.catch((e) => {
+    // TODO: This is a very temporary work-around until DMN supports N != 2 files
+    const modelFile = assets.model_files[0];
+    const propFile = assets.model_files.length > 1 ? assets.model_files[1] : assets.model_files[0];
+
+    const response = await getModelExploreData(modelFile, propFile)?.catch((e) => {
       Logger.error(e);
       return null;
     });

--- a/src/hooks/useBuildReduxStore.ts
+++ b/src/hooks/useBuildReduxStore.ts
@@ -1,13 +1,11 @@
 import { useState } from "react";
-import { createStore, applyMiddleware, combineReducers, Store } from "redux";
+import { createStore, combineReducers, Store } from "redux";
 import {
   ddgraph,
   moduleReducers as submission,
   versionInfo,
   getModelExploreData,
 } from "data-model-navigator";
-import ReduxThunk from "redux-thunk";
-import { createLogger } from "redux-logger";
 import { useLazyQuery } from "@apollo/client";
 import { defaultTo } from "lodash";
 import { baseConfiguration, defaultReadMeTitle, graphViewConfig } from "../config/ModelNavigator";
@@ -20,16 +18,17 @@ import {
 } from "../utils";
 import { RETRIEVE_CDEs, RetrieveCDEsInput, RetrieveCDEsResp } from "../graphql";
 
-export type Status = "waiting" | "loading" | "error" | "success";
+export type ReduxStoreStatus = "waiting" | "loading" | "error" | "success";
+
+export type ReduxStoreResult = [
+  { status: ReduxStoreStatus; store: Store },
+  () => void,
+  (assets: DataCommon) => void,
+];
 
 const makeStore = (): Store => {
   const reducers = { ddgraph, versionInfo, submission };
-  const loggerMiddleware = createLogger();
-
-  const newStore = createStore(
-    combineReducers(reducers),
-    applyMiddleware(ReduxThunk, loggerMiddleware)
-  );
+  const newStore = createStore(combineReducers(reducers));
 
   // @ts-ignore
   newStore.injectReducer = (key, reducer) => {
@@ -45,12 +44,8 @@ const makeStore = (): Store => {
  *
  * @params {void}
  */
-const useBuildReduxStore = (): [
-  { status: Status; store: Store },
-  () => void,
-  (assets: DataCommon) => void,
-] => {
-  const [status, setStatus] = useState<Status>("waiting");
+const useBuildReduxStore = (): ReduxStoreResult => {
+  const [status, setStatus] = useState<ReduxStoreStatus>("waiting");
   const [store, setStore] = useState<Store>(makeStore());
 
   const [retrieveCDEs, { error: retrieveCDEsError }] = useLazyQuery<
@@ -90,12 +85,7 @@ const useBuildReduxStore = (): [
     setStatus("loading");
 
     const assets = buildAssetUrls(datacommon);
-
-    // TODO: This is a very temporary work-around until DMN supports N != 2 files
-    const modelFile = assets.model_files[0];
-    const propFile = assets.model_files.length > 1 ? assets.model_files[1] : assets.model_files[0];
-
-    const response = await getModelExploreData(modelFile, propFile)?.catch((e) => {
+    const response = await getModelExploreData(...assets.model_files)?.catch((e) => {
       Logger.error(e);
       return null;
     });

--- a/src/types/DataCommon.d.ts
+++ b/src/types/DataCommon.d.ts
@@ -45,17 +45,13 @@ type DataModelManifest = {
  */
 type ManifestAssets = {
   /**
-   * The file name of the Data Model file.
+   * An array of strings with an arbitrary length containing the
+   * Data Model file names.
    *
-   * @example "cds-model.yaml"
+   * @example ["cds-model.yaml", "cds-model-props.yaml"]
+   * @since 3.1.0
    */
-  "model-file": string;
-  /**
-   * The file name of the Data Model properties file.
-   *
-   * @example "cds-model-props.yaml"
-   */
-  "prop-file": string;
+  "model-files": string[];
   /**
    * The file name of the Data Model README file.
    *

--- a/src/types/DataModelNavigator.d.ts
+++ b/src/types/DataModelNavigator.d.ts
@@ -52,13 +52,10 @@ type ModelNavigatorConfig = {
  */
 type ModelAssetUrls = {
   /**
-   * The URL to the Data Model file
+   * An array of fully-qualified URLs to the Data Model files.
+   * Arbitrary length, but must have at least one item.
    */
-  model: string;
-  /**
-   * The URL to the Data Model properties file
-   */
-  props: string;
+  model_files: string[];
   /**
    * The URL to the Data Model README file
    * If this is null, the README button will not be displayed

--- a/src/utils/dataModelUtils.test.ts
+++ b/src/utils/dataModelUtils.test.ts
@@ -242,6 +242,20 @@ describe("buildAssetUrls cases", () => {
     expect(() => utils.buildAssetUrls({} as DataCommon)).not.toThrow();
     expect(() => utils.buildAssetUrls(undefined)).not.toThrow();
   });
+
+  it("should not throw an exception if `model_files` is not defined", () => {
+    const dc: DataCommon = {
+      name: "test-name",
+      assets: {
+        "current-version": "1.0",
+        "readme-file": "readme-file",
+        "loading-file": "loading-file-zip-name",
+      } as ManifestAssets,
+    } as DataCommon;
+
+    expect(() => utils.buildAssetUrls(dc)).not.toThrow();
+    expect(utils.buildAssetUrls(dc)).toEqual(expect.objectContaining({ model_files: [] }));
+  });
 });
 
 describe("buildBaseFilterContainers tests", () => {

--- a/src/utils/dataModelUtils.test.ts
+++ b/src/utils/dataModelUtils.test.ts
@@ -17,8 +17,7 @@ describe("fetchManifest cases", () => {
   it("should return manifest from sessionStorage if it exists", async () => {
     const fakeManifest: DataModelManifest = {
       CDS: {
-        "model-file": "cds-model.yaml",
-        "prop-file": "cds-model-props.yaml",
+        "model-files": ["cds-model.yaml", "cds-model-props.yaml"],
         "readme-file": "cds-model-readme.md",
         "loading-file": "cds-loading.zip",
         "current-version": "1.0",
@@ -36,8 +35,7 @@ describe("fetchManifest cases", () => {
   it("should fetch manifest from server if it does not exist in sessionStorage", async () => {
     const fakeManifest: DataModelManifest = {
       CDS: {
-        "model-file": "cds-model.yaml",
-        "prop-file": "cds-model-props.yaml",
+        "model-files": ["cds-model.yaml", "cds-model-props.yaml"],
         "readme-file": "cds-model-readme.md",
         "loading-file": "cds-loading.zip",
         "current-version": "1.0",
@@ -58,8 +56,7 @@ describe("fetchManifest cases", () => {
   it("should cache manifest in sessionStorage after fetching", async () => {
     const fakeManifest: DataModelManifest = {
       CDS: {
-        "model-file": "cds-model.yaml",
-        "prop-file": "cds-model-props.yaml",
+        "model-files": ["cds-model.yaml", "cds-model-props.yaml"],
         "readme-file": "cds-model-readme.md",
         "loading-file": "cds-loading.zip",
         "current-version": "1.0",
@@ -115,8 +112,7 @@ describe("buildAssetUrls cases", () => {
       name: "test-name",
       assets: {
         "current-version": "1.0",
-        "model-file": "model-file",
-        "prop-file": "prop-file",
+        "model-files": ["model-file", "prop-file"],
         "readme-file": "readme-file",
         "loading-file": "loading-file-zip-name",
       } as ManifestAssets,
@@ -125,12 +121,51 @@ describe("buildAssetUrls cases", () => {
     const result = utils.buildAssetUrls(dc);
 
     expect(result).toEqual({
-      model: `${MODEL_FILE_REPO}prod/cache/test-name/1.0/model-file`,
-      props: `${MODEL_FILE_REPO}prod/cache/test-name/1.0/prop-file`,
+      model_files: [
+        `${MODEL_FILE_REPO}prod/cache/test-name/1.0/model-file`,
+        `${MODEL_FILE_REPO}prod/cache/test-name/1.0/prop-file`,
+      ],
       readme: `${MODEL_FILE_REPO}prod/cache/test-name/1.0/readme-file`,
       loading_file: `${MODEL_FILE_REPO}prod/cache/test-name/1.0/loading-file-zip-name`,
       navigator_icon: expect.any(String),
     });
+  });
+
+  it("should include every model file in the model_files array", () => {
+    const dc: DataCommon = {
+      name: "test-name",
+      assets: {
+        "current-version": "1.0",
+        "model-files": ["model-file", "prop-file", "other-file", "fourth-file"],
+        "readme-file": "readme-file",
+        "loading-file": "loading-file-zip-name",
+      } as ManifestAssets,
+    } as DataCommon;
+
+    const result = utils.buildAssetUrls(dc);
+
+    expect(result.model_files).toEqual([
+      `${MODEL_FILE_REPO}prod/cache/test-name/1.0/model-file`,
+      `${MODEL_FILE_REPO}prod/cache/test-name/1.0/prop-file`,
+      `${MODEL_FILE_REPO}prod/cache/test-name/1.0/other-file`,
+      `${MODEL_FILE_REPO}prod/cache/test-name/1.0/fourth-file`,
+    ]);
+  });
+
+  it("should handle empty model-files array", () => {
+    const dc: DataCommon = {
+      name: "test-name",
+      assets: {
+        "current-version": "1.0",
+        "model-files": [],
+        "readme-file": "readme-file",
+        "loading-file": "loading-file-zip-name",
+      } as ManifestAssets,
+    } as DataCommon;
+
+    const result = utils.buildAssetUrls(dc);
+
+    expect(result.model_files).toEqual([]);
   });
 
   const readMeValues = ["", null, undefined, false];
@@ -139,8 +174,7 @@ describe("buildAssetUrls cases", () => {
       name: "test-name",
       assets: {
         "current-version": "1.0",
-        "model-file": "model-file",
-        "prop-file": "prop-file",
+        "model-files": ["model-file", "prop-file"],
         "readme-file": readme,
       } as ManifestAssets,
     } as DataCommon;
@@ -155,8 +189,7 @@ describe("buildAssetUrls cases", () => {
       name: "test-name",
       assets: {
         "current-version": "1.0",
-        "model-file": "model-file",
-        "prop-file": "prop-file",
+        "model-files": ["model-file", "prop-file"],
         "readme-file": "readme-file",
         "loading-file": "loading-file-zip-name",
         // "model-navigator-logo" - not defined, aka no logo
@@ -173,8 +206,7 @@ describe("buildAssetUrls cases", () => {
       name: "test-name",
       assets: {
         "current-version": "1.0",
-        "model-file": "model-file",
-        "prop-file": "prop-file",
+        "model-files": ["model-file", "prop-file"],
         "readme-file": "readme-file",
         "loading-file": "loading-file-zip-name",
         "model-navigator-logo": "", // empty string - aka no logo
@@ -191,8 +223,7 @@ describe("buildAssetUrls cases", () => {
       name: "test-name",
       assets: {
         "current-version": "1.0",
-        "model-file": "model-file",
-        "prop-file": "prop-file",
+        "model-files": ["model-file", "prop-file"],
         "readme-file": "readme-file",
         "loading-file": "loading-file-zip-name",
         "model-navigator-logo": "custom-logo.png", // defined - must exist

--- a/src/utils/dataModelUtils.ts
+++ b/src/utils/dataModelUtils.ts
@@ -34,12 +34,13 @@ export const fetchManifest = async (): Promise<DataModelManifest> => {
  * @returns ModelAssetUrls
  */
 export const buildAssetUrls = (dc: DataCommon): ModelAssetUrls => ({
-  model: `${MODEL_FILE_REPO}${env.REACT_APP_DEV_TIER || "prod"}/cache/${dc?.name}/${dc?.assets?.[
-    "current-version"
-  ]}/${dc?.assets?.["model-file"]}`,
-  props: `${MODEL_FILE_REPO}${env.REACT_APP_DEV_TIER || "prod"}/cache/${dc?.name}/${dc?.assets?.[
-    "current-version"
-  ]}/${dc?.assets?.["prop-file"]}`,
+  model_files:
+    dc?.assets?.["model-files"].map(
+      (file) =>
+        `${MODEL_FILE_REPO}${env.REACT_APP_DEV_TIER || "prod"}/cache/${dc?.name}/${dc?.assets?.[
+          "current-version"
+        ]}/${file}`
+    ) || [],
   readme: dc?.assets?.["readme-file"]
     ? `${MODEL_FILE_REPO}${env.REACT_APP_DEV_TIER || "prod"}/cache/${dc?.name}/${dc?.assets?.[
         "current-version"

--- a/src/utils/dataModelUtils.ts
+++ b/src/utils/dataModelUtils.ts
@@ -35,7 +35,7 @@ export const fetchManifest = async (): Promise<DataModelManifest> => {
  */
 export const buildAssetUrls = (dc: DataCommon): ModelAssetUrls => ({
   model_files:
-    dc?.assets?.["model-files"].map(
+    dc?.assets?.["model-files"]?.map(
       (file) =>
         `${MODEL_FILE_REPO}${env.REACT_APP_DEV_TIER || "prod"}/cache/${dc?.name}/${dc?.assets?.[
           "current-version"


### PR DESCRIPTION
### Overview

This PR updates DMN to support an arbitrary number of Data Model Files (1 or more) by combining them into one aggregate object. Additionally, I also removed redux logger as CRDC FE doesn't have any purpose for logging the redux store state and it pollutes our console. 

> [!NOTE]
> To test the parsing and combination of the model files:
> 
> 1. Set the env variable `REACT_APP_DEV_TIER="model-with-3-files"`
> 2. That branch contains the "Test MDF" model with [4 separate model files](https://github.com/CBIIT/crdc-datahub-models/tree/model-with-3-files/cache/Test%20MDF/1.0.0) that have overlapping content
> 3. Run the FE and open the "Test MDF" model in DMN
> 4. You should see the various content from different model files aggregated correctly

### Change Details (Specifics)

- Upgrade Data Model Navigator – https://github.com/CBIIT/Data-Model-Navigator/compare/d3e10a458e166230ee0eb6bc88154c733dd8fe3a...8a2cc78f7c9e3e9061e8ca52f7f0dbf2be488ee6
- Remove redux-logger and redux-thunk which are now unused dependencies
- Adjust types and implementation to reflect the new content.json manifest structure (https://github.com/CBIIT/crdc-datahub-models/pull/153)

### Related Ticket(s)

CRDCDH-1744 (FE Task)
CRDCDH-1681 (User Story)