### PR TITLE
CRDCDH-1756 Filter "Data File" from Cross Validation Node Types

### DIFF
--- a/src/components/DataSubmissions/CrossValidationFilters.test.tsx
+++ b/src/components/DataSubmissions/CrossValidationFilters.test.tsx
@@ -738,4 +738,80 @@ describe("CrossValidationFilters cases", () => {
       })
     ); // Called without advancing timers
   });
+
+  it("should filter out the 'Data File' node type if present", async () => {
+    const nodesMock: MockedResponse<SubmissionStatsResp, SubmissionStatsInput> = {
+      request: {
+        query: SUBMISSION_STATS,
+      },
+      variableMatcher: () => true,
+      result: {
+        data: {
+          submissionStats: {
+            stats: [
+              {
+                nodeName: "study",
+                total: 0,
+                new: 0,
+                passed: 0,
+                warning: 0,
+                error: 0,
+              },
+              {
+                nodeName: "enrollment",
+                total: 0,
+                new: 0,
+                passed: 0,
+                warning: 0,
+                error: 0,
+              },
+              {
+                nodeName: "data file",
+                total: 0,
+                new: 0,
+                passed: 0,
+                warning: 0,
+                error: 0,
+              },
+            ],
+          },
+        },
+      },
+    };
+    const batchesMock: MockedResponse<ListBatchesResp<true>, ListBatchesInput> = {
+      request: {
+        query: LIST_BATCHES,
+      },
+      variableMatcher: () => true,
+      result: {
+        data: {
+          listBatches: {
+            total: 0,
+            batches: [],
+          },
+          batchStatusList: {
+            batches: null,
+          },
+        },
+      },
+    };
+
+    const { getByTestId, queryByTestId } = render(
+      <TestParent mocks={[batchesMock, nodesMock]} submissionId="test-immediate-dispatch">
+        <Filters />
+      </TestParent>
+    );
+
+    const muiSelectBox = within(getByTestId("cross-validation-nodeType-filter")).getByRole(
+      "button"
+    );
+
+    userEvent.click(muiSelectBox);
+
+    await waitFor(() => {
+      expect(getByTestId("nodeType-study")).toBeInTheDocument();
+      expect(getByTestId("nodeType-enrollment")).toBeInTheDocument();
+      expect(queryByTestId("nodeType-data file")).not.toBeInTheDocument();
+    });
+  });
 });

--- a/src/components/DataSubmissions/CrossValidationFilters.tsx
+++ b/src/components/DataSubmissions/CrossValidationFilters.tsx
@@ -86,7 +86,8 @@ const CrossValidationFilters = forwardRef<null, FilterProps>(({ onChange }, ref)
     () =>
       cloneDeep(submissionStats?.submissionStats?.stats)
         ?.sort(compareNodeStats)
-        ?.map((stat) => stat.nodeName),
+        ?.map((stat) => stat.nodeName)
+        .filter((nodeType) => nodeType?.toLowerCase() !== "data file"),
     [submissionStats?.submissionStats?.stats]
   );
 


### PR DESCRIPTION
### Overview

This PR fixes an issue where "Data File" incorrectly appears in the Node Type filter dropdown for Cross Validation; Since cross validation is never performed against Data Files, this option shouldn't be visible.

> [!NOTE]
> The submission `cca9cf14-14ac-4f3f-8d7f-7e1e18e47f79` can be used for testing, which has Data Files uploaded.

### Change Details (Specifics)

- Filter data files from the nodeTypes dropdown
- Add test coverage for this requirement

### Related Ticket(s)

CRDCDH-1756
