### PR TITLE
CRDCDH-1763 Address DMN legibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8897,7 +8897,7 @@
     },
     "node_modules/data-model-navigator": {
       "version": "1.1.34",
-      "resolved": "git+ssh://git@github.com/CBIIT/Data-Model-Navigator.git#8a2cc78f7c9e3e9061e8ca52f7f0dbf2be488ee6",
+      "resolved": "git+ssh://git@github.com/CBIIT/Data-Model-Navigator.git#3e98c78e1f4ae95338472ee0171076bf5fdfcf35",
       "license": "ISC",
       "dependencies": {
         "@material-ui/core": "^4.12.4",


### PR DESCRIPTION
### Overview

This PR updates the core DMN package to address legibility concerns on the Table View tab and adjust the verbiage of the node/property counter.

> [!Warning]
> This PR is based off of CRDCDH-1744 (#505) since both of them update DMN. 

<details><summary>Node Level Comparison</summary>
<p>

<img width="1150" alt="New Primary" src="https://github.com/user-attachments/assets/39bb0ffa-6862-4516-b146-4c5d7c7eb2df">

<img width="1150" alt="Old Primary" src="https://github.com/user-attachments/assets/2cdb8519-3d7e-46c7-8478-a3e5714d4eca">

</p>
</details> 

<details><summary>Property Table Comparison</summary>
<p>

NOTE: Only the headers/padding changed here. The table content is already ~16px (equal to the rest).

<img width="1150" alt="New Table" src="https://github.com/user-attachments/assets/324c8d5f-aaea-413b-90f7-424dc0cc1925">

<img width="1150" alt="Old Table" src="https://github.com/user-attachments/assets/d97a3d9b-b297-4a08-895e-0542c0094009">

</p>
</details> 

<details><summary>(Unrelated) Added Padding to Component</summary>
<p>

This is unrelated to the user story, but I added padding to the bottom of the DMN component to address ugly spacing issues.

<img width="1504" alt="Screenshot 2024-10-28 at 10 41 55 AM" src="https://github.com/user-attachments/assets/dbcbea5a-321d-4aaa-9743-f3291e4db8a6">

<img width="1504" alt="Screenshot 2024-10-28 at 10 42 35 AM" src="https://github.com/user-attachments/assets/7b931332-ea32-43c6-851f-2ead58560c07">

</p>
</details> 

### Change Details (Specifics)

See comparison here – https://github.com/CBIIT/Data-Model-Navigator/compare/8a2cc78f7c9e3e9061e8ca52f7f0dbf2be488ee6...3e98c78e1f4ae95338472ee0171076bf5fdfcf35

### Related Ticket(s)

CRDCDH-1763 (FE Task)
CRDCDH-1758 (User Story)