### PR TITLE
CRDCDH-1763 (v2) Fix Assignment label overlap

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8897,7 +8897,7 @@
     },
     "node_modules/data-model-navigator": {
       "version": "1.1.34",
-      "resolved": "git+ssh://git@github.com/CBIIT/Data-Model-Navigator.git#f750e2f42f8913b7dfc7a8bdf39c98f2513692b4",
+      "resolved": "git+ssh://git@github.com/CBIIT/Data-Model-Navigator.git#4b5c21a892c84178088541f9a31717d74f048087",
       "license": "ISC",
       "dependencies": {
         "@material-ui/core": "^4.12.4",


### PR DESCRIPTION
### Overview

Minor styling fix for the "Assignment: Extended" label extending beyond the border of the pill (ICDC has a lot of this). 

Old (on DEV):

<img width="368" alt="Screenshot 2024-10-30 at 9 59 19 AM" src="https://github.com/user-attachments/assets/a35a3697-2da0-447e-b962-76a51c027c1f">

New (in PR):

<img width="368" alt="Screenshot 2024-10-30 at 9 58 49 AM" src="https://github.com/user-attachments/assets/1c8d419a-9f83-4bf2-b2bd-c0fbc46e3729">


### Change Details (Specifics)

N/A – See DMN changes https://github.com/CBIIT/Data-Model-Navigator/compare/f750e2f42f8913b7dfc7a8bdf39c98f2513692b4...4b5c21a892c84178088541f9a31717d74f048087

### Related Ticket(s)

CRDCDH-1763 (Task)
CRDCDH-1758 (User Story)
