### PR TITLE
CRDCDH-1882 QuickSight – Role-Based Content Filtering

### DIFF
--- a/src/components/Contexts/SubmissionContext.tsx
+++ b/src/components/Contexts/SubmissionContext.tsx
@@ -2,7 +2,7 @@ import React, { FC, createContext, useCallback, useContext, useMemo, useState } 
 import { ApolloError, ApolloQueryResult, useQuery } from "@apollo/client";
 import { cloneDeep, isEqual } from "lodash";
 import { GetSubmissionResp, GET_SUBMISSION, GetSubmissionInput } from "../../graphql";
-import { compareNodeStats } from "../../utils";
+import { compareNodeStats, Logger } from "../../utils";
 
 export type SubmissionCtxState = {
   /**
@@ -131,6 +131,9 @@ export const SubmissionProvider: FC<ProviderProps> = ({ _id, children }: Provide
         startApolloPolling(1000);
         setIsPolling(true);
       }
+    },
+    onError: (e) => {
+      Logger.error("Error fetching submission data", e);
     },
     variables: { id: _id },
     context: { clientName: "backend" },

--- a/src/content/operationDashboard/DashboardView.test.tsx
+++ b/src/content/operationDashboard/DashboardView.test.tsx
@@ -1,12 +1,47 @@
 import { render } from "@testing-library/react";
 import { axe } from "jest-axe";
 import { MemoryRouter } from "react-router-dom";
-import { FC } from "react";
+import { FC, useMemo } from "react";
+import {
+  Context as AuthContext,
+  ContextState as AuthContextState,
+  Status as AuthContextStatus,
+} from "../../components/Contexts/AuthContext";
 import DashboardView from "./DashboardView";
 
-const MockParent: FC<{ children: React.ReactElement }> = ({ children }) => (
-  <MemoryRouter basename="/">{children}</MemoryRouter>
-);
+const baseUser: Omit<User, "role"> = {
+  _id: "",
+  firstName: "",
+  lastName: "",
+  userStatus: "Active",
+  IDP: "nih",
+  email: "",
+  organization: null,
+  dataCommons: [],
+  createdAt: "",
+  updateAt: "",
+  studies: null,
+};
+
+const MockParent: FC<{ role?: UserRole; children: React.ReactElement }> = ({
+  role = "Admin",
+  children,
+}) => {
+  const baseAuthCtx: AuthContextState = useMemo<AuthContextState>(
+    () => ({
+      status: AuthContextStatus.LOADED,
+      isLoggedIn: role !== null,
+      user: { ...baseUser, role },
+    }),
+    [role]
+  );
+
+  return (
+    <AuthContext.Provider value={baseAuthCtx}>
+      <MemoryRouter basename="/">{children}</MemoryRouter>
+    </AuthContext.Provider>
+  );
+};
 
 describe("Accessibility", () => {
   it("should not have any accessibility violations when loading", async () => {


### PR DESCRIPTION
### Overview

This PR updates the QuickSight implementation to provide contextual information to the dashboard. In particular, it provides the assigned list of Studies or Data Commons assigned to the user, which QuickSight then uses to filter the Data Submission Dashboard content. 

Related to this, I also updated the error handling of the Data Submission page to be consistent with the Submission Request Page, Organization Page, Profile Page, etc by redirecting back to the Data Submission List page.

> [!NOTE]
> The Data Submission page still has 1 inconsistency with most of the other features – There is no full screen loader while fetching the submission data initially. I didn't address this as it may have significant side-effects, but it's something we might want to address eventually. 

### Change Details (Specifics)

- Revamp the DashboardView to include additional Data Commons or Study parameters
- Log edge cases when the Federal Monitor or Data Curator don't have studies or data commons assigned and fallback to empty content
  - NOTE: Technically it's acceptable for a Fed Monitor to not have any studies, but QuickSight interprets [] as "show everything, which we definitely don't want.
- Update the Data Submission page to handle errors consistent with the rest of the app (redirect to list page)
  - NOTE: I hard-coded the error message because the APIs return very obscure error messages that have no value to the user (IMO)
- Update the submission action error handler to show a snackbar instead of a error at the top of the data submission summary
- Update the Data Submission Ctx to log any errors using the Logger util (for debugging)

### Related Ticket(s)

CRDCDH-1882 (FE Task)
CRDCDH-1881 (User Story 2)
CRDCDH-1880 (User Story 1)
CRDCDH-1848 (Bug 1)
CRDCDH-1849 (Bug 2)
