### PR TITLE
CRDCDH-1738 Data Submission List - Unlock Organization dropdown

### DIFF
--- a/src/components/DataSubmissions/DataSubmissionListFilters.test.tsx
+++ b/src/components/DataSubmissions/DataSubmissionListFilters.test.tsx
@@ -10,7 +10,6 @@ import {
   ContextState as AuthContextState,
   Status as AuthContextStatus,
 } from "../Contexts/AuthContext";
-import { useOrganizationListContext } from "../Contexts/OrganizationListContext";
 import { Column } from "../GenericTable";
 import { ListSubmissionsResp } from "../../graphql";
 
@@ -82,27 +81,14 @@ describe("DataSubmissionListFilters Component", () => {
 
   const submitterNames = ["Submitter1", "Submitter2"];
   const dataCommons = ["DataCommon1", "DataCommon2"];
+  const organizations: Organization[] = [
+    { _id: "Org1", name: "Organization 1" } as Organization,
+    { _id: "Org2", name: "Organization 2" } as Organization,
+  ];
   const columnVisibilityModel = { name: true, status: true };
 
   const mockOnChange = jest.fn();
   const mockOnColumnVisibilityModelChange = jest.fn();
-
-  beforeEach(() => {
-    // Set up default mock for useOrganizationListContext
-    (useOrganizationListContext as jest.Mock).mockReturnValue({
-      activeOrganizations: [
-        { _id: "Org1", name: "Organization 1" },
-        { _id: "Org2", name: "Organization 2" },
-      ],
-      status: "LOADED",
-      data: {
-        activeOrganizations: [
-          { _id: "Org1", name: "Organization 1" },
-          { _id: "Org2", name: "Organization 2" },
-        ],
-      },
-    });
-  });
 
   afterEach(() => {
     jest.clearAllMocks();
@@ -114,6 +100,7 @@ describe("DataSubmissionListFilters Component", () => {
       <TestParent>
         <DataSubmissionListFilters
           columns={columns}
+          organizations={organizations}
           submitterNames={submitterNames}
           dataCommons={dataCommons}
           columnVisibilityModel={columnVisibilityModel}
@@ -133,6 +120,7 @@ describe("DataSubmissionListFilters Component", () => {
       <TestParent userRole="Admin">
         <DataSubmissionListFilters
           columns={columns}
+          organizations={organizations}
           submitterNames={submitterNames}
           dataCommons={dataCommons}
           columnVisibilityModel={columnVisibilityModel}
@@ -162,6 +150,7 @@ describe("DataSubmissionListFilters Component", () => {
       <TestParent>
         <DataSubmissionListFilters
           columns={columns}
+          organizations={organizations}
           submitterNames={submitterNames}
           dataCommons={dataCommons}
           columnVisibilityModel={columnVisibilityModel}
@@ -189,6 +178,7 @@ describe("DataSubmissionListFilters Component", () => {
       <TestParent userRole="Admin">
         <DataSubmissionListFilters
           columns={columns}
+          organizations={organizations}
           submitterNames={submitterNames}
           dataCommons={dataCommons}
           columnVisibilityModel={columnVisibilityModel}
@@ -221,11 +211,12 @@ describe("DataSubmissionListFilters Component", () => {
     });
   });
 
-  it("prevents non-admin users from changing the organization select", async () => {
+  it("should allow non-admin users from changing the organization select", async () => {
     const { getByTestId } = render(
       <TestParent userRole="Submitter">
         <DataSubmissionListFilters
           columns={columns}
+          organizations={organizations}
           submitterNames={submitterNames}
           dataCommons={dataCommons}
           columnVisibilityModel={columnVisibilityModel}
@@ -242,7 +233,7 @@ describe("DataSubmissionListFilters Component", () => {
     const organizationSelectInput = getByTestId("organization-select");
 
     const button = within(organizationSelectInput).getByRole("button");
-    expect(button).toHaveClass("Mui-readOnly");
+    expect(button).not.toHaveClass("Mui-readOnly");
   });
 
   it("resets all filters and clears URL searchParams when reset button is clicked", async () => {
@@ -250,6 +241,7 @@ describe("DataSubmissionListFilters Component", () => {
       <TestParent userRole="Admin">
         <DataSubmissionListFilters
           columns={columns}
+          organizations={organizations}
           submitterNames={submitterNames}
           dataCommons={dataCommons}
           columnVisibilityModel={columnVisibilityModel}
@@ -377,6 +369,7 @@ describe("DataSubmissionListFilters Component", () => {
       <TestParent userRole="Admin">
         <DataSubmissionListFilters
           columns={columns}
+          organizations={organizations}
           submitterNames={submitterNames}
           dataCommons={dataCommons}
           columnVisibilityModel={columnVisibilityModel}
@@ -404,6 +397,7 @@ describe("DataSubmissionListFilters Component", () => {
       <TestParent userRole="Admin">
         <DataSubmissionListFilters
           columns={columns}
+          organizations={organizations}
           submitterNames={submitterNames}
           dataCommons={dataCommons}
           columnVisibilityModel={columnVisibilityModel}
@@ -439,6 +433,7 @@ describe("DataSubmissionListFilters Component", () => {
       <TestParent userRole="Admin">
         <DataSubmissionListFilters
           columns={columns}
+          organizations={organizations}
           submitterNames={submitterNames}
           dataCommons={dataCommons}
           columnVisibilityModel={columnVisibilityModel}
@@ -468,6 +463,7 @@ describe("DataSubmissionListFilters Component", () => {
       <TestParent userRole="Admin">
         <DataSubmissionListFilters
           columns={columns}
+          organizations={organizations}
           submitterNames={submitterNames}
           dataCommons={dataCommons}
           columnVisibilityModel={columnVisibilityModel}
@@ -503,6 +499,7 @@ describe("DataSubmissionListFilters Component", () => {
       <TestParent userRole="Admin">
         <DataSubmissionListFilters
           columns={columns}
+          organizations={organizations}
           submitterNames={submitterNames}
           dataCommons={dataCommons}
           columnVisibilityModel={columnVisibilityModel}
@@ -540,6 +537,7 @@ describe("DataSubmissionListFilters Component", () => {
       <TestParent userRole="Admin">
         <DataSubmissionListFilters
           columns={columns}
+          organizations={organizations}
           submitterNames={submitterNames}
           dataCommons={dataCommons}
           columnVisibilityModel={columnVisibilityModel}
@@ -581,6 +579,7 @@ describe("DataSubmissionListFilters Component", () => {
       <TestParent userRole="Admin">
         <DataSubmissionListFilters
           columns={columns}
+          organizations={organizations}
           submitterNames={submitterNames}
           dataCommons={dataCommons}
           columnVisibilityModel={columnVisibilityModel}
@@ -624,6 +623,7 @@ describe("DataSubmissionListFilters Component", () => {
       <TestParent initialEntries={initialEntries} userRole="Admin">
         <DataSubmissionListFilters
           columns={columns}
+          organizations={organizations}
           submitterNames={submitterNames}
           dataCommons={dataCommons}
           columnVisibilityModel={columnVisibilityModel}
@@ -667,6 +667,7 @@ describe("DataSubmissionListFilters Component", () => {
       <TestParent initialEntries={initialEntries} userRole="Admin">
         <DataSubmissionListFilters
           columns={columns}
+          organizations={organizations}
           submitterNames={submitterNames}
           dataCommons={dataCommons}
           columnVisibilityModel={columnVisibilityModel}
@@ -707,6 +708,7 @@ describe("DataSubmissionListFilters Component", () => {
       <TestParent initialEntries={initialEntries} userRole="Admin">
         <DataSubmissionListFilters
           columns={columns}
+          organizations={organizations}
           submitterNames={submitterNames}
           dataCommons={dataCommons}
           columnVisibilityModel={columnVisibilityModel}
@@ -739,6 +741,7 @@ describe("DataSubmissionListFilters Component", () => {
       <TestParent initialEntries={initialEntries} userRole="Admin">
         <DataSubmissionListFilters
           columns={columns}
+          organizations={organizations}
           submitterNames={submitterNames}
           dataCommons={[]} // Empty dataCommons
           columnVisibilityModel={columnVisibilityModel}
@@ -782,6 +785,7 @@ describe("DataSubmissionListFilters Component", () => {
       <TestParent>
         <DataSubmissionListFilters
           columns={columns}
+          organizations={organizations}
           submitterNames={submitterNames}
           dataCommons={["DataCommon1", "DataCommon2"]} // Non-empty dataCommons
           columnVisibilityModel={columnVisibilityModel}
@@ -826,6 +830,7 @@ describe("DataSubmissionListFilters Component", () => {
       <TestParent>
         <DataSubmissionListFilters
           columns={columns}
+          organizations={organizations}
           submitterNames={[]} // Empty submitterNames
           dataCommons={dataCommons}
           columnVisibilityModel={columnVisibilityModel}
@@ -863,6 +868,7 @@ describe("DataSubmissionListFilters Component", () => {
       <TestParent>
         <DataSubmissionListFilters
           columns={columns}
+          organizations={organizations}
           submitterNames={["Submitter1", "Submitter2"]} // Non-empty submitterNames
           dataCommons={dataCommons}
           columnVisibilityModel={columnVisibilityModel}

--- a/src/components/DataSubmissions/DataSubmissionListFilters.test.tsx
+++ b/src/components/DataSubmissions/DataSubmissionListFilters.test.tsx
@@ -813,13 +813,12 @@ describe("DataSubmissionListFilters Component", () => {
 
     await waitFor(() => {
       expect(getByTestId("data-commons-select-input")).toHaveValue("DataCommon1");
+      expect(mockOnChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          dataCommons: "DataCommon1",
+        })
+      );
     });
-
-    expect(mockOnChange).toHaveBeenCalledWith(
-      expect.objectContaining({
-        dataCommons: "DataCommon1",
-      })
-    );
   });
 
   it("sets submitterNames select to 'All' when submitterNames prop is empty", async () => {
@@ -896,13 +895,12 @@ describe("DataSubmissionListFilters Component", () => {
 
     await waitFor(() => {
       expect(getByTestId("submitter-name-select-input")).toHaveValue("Submitter1");
+      expect(mockOnChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          submitterName: "Submitter1",
+        })
+      );
     });
-
-    expect(mockOnChange).toHaveBeenCalledWith(
-      expect.objectContaining({
-        submitterName: "Submitter1",
-      })
-    );
   });
 
   it("sets organization select to 'All' when organizations prop is empty", async () => {
@@ -975,12 +973,11 @@ describe("DataSubmissionListFilters Component", () => {
 
     await waitFor(() => {
       expect(getByTestId("organization-select-input")).toHaveValue("Org1");
+      expect(mockOnChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          organization: "Org1",
+        })
+      );
     });
-
-    expect(mockOnChange).toHaveBeenCalledWith(
-      expect.objectContaining({
-        organization: "Org1",
-      })
-    );
   });
 });

--- a/src/components/DataSubmissions/DataSubmissionListFilters.test.tsx
+++ b/src/components/DataSubmissions/DataSubmissionListFilters.test.tsx
@@ -211,7 +211,7 @@ describe("DataSubmissionListFilters Component", () => {
     });
   });
 
-  it("should allow non-admin users from changing the organization select", async () => {
+  it("allows non-admin users to select an organization", async () => {
     const { getByTestId } = render(
       <TestParent userRole="Submitter">
         <DataSubmissionListFilters
@@ -901,6 +901,85 @@ describe("DataSubmissionListFilters Component", () => {
     expect(mockOnChange).toHaveBeenCalledWith(
       expect.objectContaining({
         submitterName: "Submitter1",
+      })
+    );
+  });
+
+  it("sets organization select to 'All' when organizations prop is empty", async () => {
+    const mockOnChange = jest.fn();
+    const mockOnColumnVisibilityModelChange = jest.fn();
+
+    const { getByTestId, getByRole } = render(
+      <TestParent>
+        <DataSubmissionListFilters
+          columns={columns}
+          organizations={[]}
+          submitterNames={submitterNames}
+          dataCommons={dataCommons}
+          columnVisibilityModel={columnVisibilityModel}
+          onColumnVisibilityModelChange={mockOnColumnVisibilityModelChange}
+          onChange={mockOnChange}
+        />
+      </TestParent>
+    );
+
+    await waitFor(() => {
+      expect(getByTestId("organization-select-input")).toHaveValue("All");
+    });
+
+    const organizationSelect = within(getByTestId("organization-select")).getByRole("button");
+    userEvent.click(organizationSelect);
+
+    const organizationList = within(getByRole("listbox", { hidden: true }));
+
+    await waitFor(() => {
+      expect(organizationList.getByTestId("organization-option-All")).toBeInTheDocument();
+      expect(organizationList.queryByTestId("organization-option-Org1")).not.toBeInTheDocument();
+      expect(organizationList.queryByTestId("organization-option-Org2")).not.toBeInTheDocument();
+    });
+  });
+
+  it("sets organization select to field.value when organizations prop is non-empty", async () => {
+    const mockOnChange = jest.fn();
+    const mockOnColumnVisibilityModelChange = jest.fn();
+
+    const { getByTestId, getByRole } = render(
+      <TestParent>
+        <DataSubmissionListFilters
+          columns={columns}
+          organizations={organizations}
+          submitterNames={submitterNames}
+          dataCommons={dataCommons}
+          columnVisibilityModel={columnVisibilityModel}
+          onColumnVisibilityModelChange={mockOnColumnVisibilityModelChange}
+          onChange={mockOnChange}
+        />
+      </TestParent>
+    );
+
+    await waitFor(() => {
+      expect(getByTestId("organization-select-input")).toHaveValue("All");
+    });
+
+    const organizationSelect = within(getByTestId("organization-select")).getByRole("button");
+    userEvent.click(organizationSelect);
+
+    const organizationList = within(getByRole("listbox", { hidden: true }));
+
+    await waitFor(() => {
+      expect(organizationList.getByTestId("organization-option-Org1")).toBeInTheDocument();
+      expect(organizationList.getByTestId("organization-option-Org2")).toBeInTheDocument();
+    });
+
+    userEvent.click(getByTestId("organization-option-Org1"));
+
+    await waitFor(() => {
+      expect(getByTestId("organization-select-input")).toHaveValue("Org1");
+    });
+
+    expect(mockOnChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        organization: "Org1",
       })
     );
   });

--- a/src/components/DataSubmissions/DataSubmissionListFilters.tsx
+++ b/src/components/DataSubmissions/DataSubmissionListFilters.tsx
@@ -151,6 +151,9 @@ const DataSubmissionListFilters = ({
   const debouncedOnChangeRef = useRef(
     debounce((form: FilterForm) => handleFormChange(form), 500)
   ).current;
+  const debouncedDropdownRef = useRef(
+    debounce((form: FilterForm) => handleFormChange(form), 0)
+  ).current;
 
   useEffect(() => {
     // Reset submitterName filter if it is no longer a valid option
@@ -268,6 +271,12 @@ const DataSubmissionListFilters = ({
 
   useEffect(() => {
     const subscription = watch((formValue: FilterForm, { name }) => {
+      const isDebouncedDropdown = ["submitterName", "dataCommons", "organization"].includes(name);
+      if (isDebouncedDropdown) {
+        debouncedDropdownRef(formValue);
+        return;
+      }
+
       // Add debounce for input fields
       const isDebounceField = debounceAfter3CharsInputs.includes(name as FilterFormKey);
       // Debounce if value has at least 3 characters

--- a/src/components/DataSubmissions/DataSubmissionListFilters.tsx
+++ b/src/components/DataSubmissions/DataSubmissionListFilters.tsx
@@ -115,7 +115,7 @@ type TouchedState = { [K in FilterFormKey]: boolean };
 
 type Props = {
   columns: Column<T>[];
-  organizations: Organization[];
+  organizations: Pick<Organization, "_id" | "name">[];
   submitterNames: string[];
   dataCommons: string[];
   columnVisibilityModel: ColumnVisibilityModel;

--- a/src/components/DataSubmissions/DataSubmissionListFilters.tsx
+++ b/src/components/DataSubmissions/DataSubmissionListFilters.tsx
@@ -192,8 +192,10 @@ const DataSubmissionListFilters = ({
     const submitterName = searchParams.get("submitterName");
 
     handleStatusChange(status);
-    handleOrganizationChange(organizationId);
 
+    if (organizationId && organizationId !== orgFilter) {
+      setValue("organization", organizationId);
+    }
     if (dataCommon && dataCommon !== dataCommonsFilter) {
       setValue("dataCommons", dataCommon);
     }
@@ -295,20 +297,8 @@ const DataSubmissionListFilters = ({
     };
   }, [watch, debouncedOnChangeRef]);
 
-  const isValidOrg = (orgId: string) => orgId && !!organizations?.find((org) => org._id === orgId);
-
   const isStatusFilterOption = (status: string): status is FilterForm["status"] =>
     ["All", ...statusValues].includes(status);
-
-  const handleOrganizationChange = (organizationId: string) => {
-    if (organizationId === orgFilter) {
-      return;
-    }
-
-    if (isValidOrg(organizationId)) {
-      setValue("organization", organizationId);
-    }
-  };
 
   const handleStatusChange = (status: string) => {
     if (status === statusFilter) {

--- a/src/components/DataSubmissions/DataSubmissionListFilters.tsx
+++ b/src/components/DataSubmissions/DataSubmissionListFilters.tsx
@@ -184,10 +184,6 @@ const DataSubmissionListFilters = ({
   }, [organizations, orgFilter, touchedFilters]);
 
   useEffect(() => {
-    if (!organizations?.length) {
-      return;
-    }
-
     const organizationId = searchParams.get("organization");
     const status = searchParams.get("status");
     const dataCommon = searchParams.get("dataCommons");

--- a/src/components/DataSubmissions/SubmissionHeaderProperty.tsx
+++ b/src/components/DataSubmissions/SubmissionHeaderProperty.tsx
@@ -32,7 +32,7 @@ const SubmissionHeaderProperty = ({ label, value, truncateAfter = 16 }: Props) =
   <Grid lg={6} xs={12} item>
     <Stack direction="row" alignItems="center" width="100%" maxWidth="100%" spacing={2.75}>
       <StyledLabel variant="body1">{label}</StyledLabel>
-      <Box flexGrow={1} overflow="hidden">
+      <Box flexGrow={1} overflow="hidden" lineHeight="16px">
         {typeof value === "string" ? (
           <StyledValue variant="body1" data-testid="property-value">
             {truncateAfter && truncateAfter > 0 ? (
@@ -41,6 +41,7 @@ const SubmissionHeaderProperty = ({ label, value, truncateAfter = 16 }: Props) =
                 maxCharacters={truncateAfter}
                 underline={false}
                 ellipsis
+                wrapperStyles={{ lineHeight: "19.6px" }}
               />
             ) : (
               value

--- a/src/content/dataSubmissions/Controller.tsx
+++ b/src/content/dataSubmissions/Controller.tsx
@@ -2,15 +2,14 @@ import React, { memo } from "react";
 import { useParams } from "react-router-dom";
 import DataSubmission from "./DataSubmission";
 import ListView from "./DataSubmissionsListView";
-import { OrganizationProvider } from "../../components/Contexts/OrganizationListContext";
 import { SubmissionProvider } from "../../components/Contexts/SubmissionContext";
 
 /**
- * A memoized version of OrganizationProvider
+ * A memoized version of SubmissionProvider
  *
  * @see OrganizationProvider
  */
-const MemorizedProvider = memo(OrganizationProvider);
+const MemorizedProvider = memo(SubmissionProvider);
 
 /**
  * Render the correct view based on the URL
@@ -23,17 +22,13 @@ const DataSubmissionController = () => {
 
   if (submissionId) {
     return (
-      <SubmissionProvider _id={submissionId}>
+      <MemorizedProvider _id={submissionId}>
         <DataSubmission submissionId={submissionId} tab={tab} />
-      </SubmissionProvider>
+      </MemorizedProvider>
     );
   }
 
-  return (
-    <MemorizedProvider preload>
-      <ListView />
-    </MemorizedProvider>
-  );
+  return <ListView />;
 };
 
 export default DataSubmissionController;

--- a/src/content/dataSubmissions/DataSubmissionsListView.tsx
+++ b/src/content/dataSubmissions/DataSubmissionsListView.tsx
@@ -1,7 +1,7 @@
-import React, { FC, useEffect, useRef, useState } from "react";
+import React, { FC, useRef, useState } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { Alert, Container, Stack, styled, TableCell, TableHead, Box } from "@mui/material";
-import { debounce, isEqual } from "lodash";
+import { isEqual } from "lodash";
 import { useSnackbar } from "notistack";
 import { useLazyQuery } from "@apollo/client";
 import bannerSvg from "../../assets/banner/submission_banner.png";

--- a/src/content/dataSubmissions/DataSubmissionsListView.tsx
+++ b/src/content/dataSubmissions/DataSubmissionsListView.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useRef, useState } from "react";
+import React, { FC, useEffect, useRef, useState } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { Alert, Container, Stack, styled, TableCell, TableHead, Box } from "@mui/material";
 import { isEqual } from "lodash";
@@ -252,6 +252,7 @@ const ListingView: FC = () => {
     dbGaPID: "",
     submitterName: "All",
   });
+  const previousFilters = useRef<FilterForm>(filtersRef.current);
 
   const [listSubmissions, { refetch }] = useLazyQuery<ListSubmissionsResp, ListSubmissionsInput>(
     LIST_SUBMISSIONS,
@@ -340,13 +341,23 @@ const ListingView: FC = () => {
     });
   };
 
+  useEffect(() => {
+    if (isEqual(filtersRef.current, previousFilters.current)) {
+      return;
+    }
+
+    // Necessary to avoid race-condition while filters are resetting
+    // and current page is not the first page
+    previousFilters.current = { ...filtersRef.current };
+    setTablePage(0);
+  }, [filtersRef.current]);
+
   const handleOnFiltersChange = (data: FilterForm) => {
     if (isEqual(data, filtersRef.current)) {
       return;
     }
 
     filtersRef.current = { ...data };
-    setTablePage(0);
   };
 
   return (

--- a/src/content/dataSubmissions/DataSubmissionsListView.tsx
+++ b/src/content/dataSubmissions/DataSubmissionsListView.tsx
@@ -305,7 +305,11 @@ const ListingView: FC = () => {
       }
 
       setData(d.listSubmissions.submissions);
-      setOrganizations(d.listSubmissions.organizations?.filter((org) => !!org.name.trim()));
+      setOrganizations(
+        d.listSubmissions.organizations
+          ?.filter((org) => !!org.name.trim())
+          ?.sort((a, b) => a.name?.localeCompare(b.name))
+      );
       setSubmitterNames(d.listSubmissions.submitterNames?.filter((sn) => !!sn.trim()));
       setDataCommons(d.listSubmissions.dataCommons?.filter((dc) => !!dc.trim()));
       setTotalData(d.listSubmissions.total);

--- a/src/content/dataSubmissions/DataSubmissionsListView.tsx
+++ b/src/content/dataSubmissions/DataSubmissionsListView.tsx
@@ -244,6 +244,7 @@ const ListingView: FC = () => {
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<boolean>(false);
   const [data, setData] = useState<T[]>([]);
+  const [organizations, setOrganizations] = useState<Organization[]>([]);
   const [submitterNames, setSubmitterNames] = useState<string[]>([]);
   const [dataCommons, setDataCommons] = useState<string[]>([]);
   const [totalData, setTotalData] = useState<number>(0);
@@ -304,6 +305,7 @@ const ListingView: FC = () => {
       }
 
       setData(d.listSubmissions.submissions);
+      setOrganizations(d.listSubmissions.organizations?.filter((org) => !!org.name.trim()));
       setSubmitterNames(d.listSubmissions.submitterNames?.filter((sn) => !!sn.trim()));
       setDataCommons(d.listSubmissions.dataCommons?.filter((dc) => !!dc.trim()));
       setTotalData(d.listSubmissions.total);
@@ -376,6 +378,7 @@ const ListingView: FC = () => {
         <StyledFilterTableWrapper>
           <DataSubmissionListFilters
             columns={columns}
+            organizations={organizations}
             submitterNames={submitterNames}
             dataCommons={dataCommons}
             columnVisibilityModel={columnVisibilityModel}

--- a/src/content/dataSubmissions/DataSubmissionsListView.tsx
+++ b/src/content/dataSubmissions/DataSubmissionsListView.tsx
@@ -1,7 +1,7 @@
-import React, { FC, useRef, useState } from "react";
+import React, { FC, useEffect, useRef, useState } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { Alert, Container, Stack, styled, TableCell, TableHead, Box } from "@mui/material";
-import { isEqual } from "lodash";
+import { debounce, isEqual } from "lodash";
 import { useSnackbar } from "notistack";
 import { useLazyQuery } from "@apollo/client";
 import bannerSvg from "../../assets/banner/submission_banner.png";
@@ -252,7 +252,6 @@ const ListingView: FC = () => {
     dbGaPID: "",
     submitterName: "All",
   });
-  const previousFilters = useRef<FilterForm>(filtersRef.current);
 
   const [listSubmissions, { refetch }] = useLazyQuery<ListSubmissionsResp, ListSubmissionsInput>(
     LIST_SUBMISSIONS,
@@ -354,14 +353,6 @@ const ListingView: FC = () => {
     }
 
     filtersRef.current = { ...data };
-
-    if (isEqual(filtersRef.current, previousFilters.current)) {
-      return;
-    }
-
-    // Necessary to avoid race-condition while filters are resetting
-    // and current page is not the first page
-    previousFilters.current = { ...filtersRef.current };
     setTablePage(0);
   };
 

--- a/src/content/dataSubmissions/DataSubmissionsListView.tsx
+++ b/src/content/dataSubmissions/DataSubmissionsListView.tsx
@@ -239,7 +239,7 @@ const ListingView: FC = () => {
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<boolean>(false);
   const [data, setData] = useState<T[]>([]);
-  const [organizations, setOrganizations] = useState<Organization[]>([]);
+  const [organizations, setOrganizations] = useState<Pick<Organization, "_id" | "name">[]>([]);
   const [submitterNames, setSubmitterNames] = useState<string[]>([]);
   const [dataCommons, setDataCommons] = useState<string[]>([]);
   const [totalData, setTotalData] = useState<number>(0);

--- a/src/content/dataSubmissions/DataSubmissionsListView.tsx
+++ b/src/content/dataSubmissions/DataSubmissionsListView.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useRef, useState } from "react";
+import React, { FC, useRef, useState } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { Alert, Container, Stack, styled, TableCell, TableHead, Box } from "@mui/material";
 import { isEqual } from "lodash";

--- a/src/content/dataSubmissions/DataSubmissionsListView.tsx
+++ b/src/content/dataSubmissions/DataSubmissionsListView.tsx
@@ -341,7 +341,13 @@ const ListingView: FC = () => {
     });
   };
 
-  useEffect(() => {
+  const handleOnFiltersChange = (data: FilterForm) => {
+    if (isEqual(data, filtersRef.current)) {
+      return;
+    }
+
+    filtersRef.current = { ...data };
+
     if (isEqual(filtersRef.current, previousFilters.current)) {
       return;
     }
@@ -350,14 +356,6 @@ const ListingView: FC = () => {
     // and current page is not the first page
     previousFilters.current = { ...filtersRef.current };
     setTablePage(0);
-  }, [filtersRef.current]);
-
-  const handleOnFiltersChange = (data: FilterForm) => {
-    if (isEqual(data, filtersRef.current)) {
-      return;
-    }
-
-    filtersRef.current = { ...data };
   };
 
   return (

--- a/src/content/dataSubmissions/DataSubmissionsListView.tsx
+++ b/src/content/dataSubmissions/DataSubmissionsListView.tsx
@@ -10,10 +10,6 @@ import { FormatDate } from "../../utils";
 import { useAuthContext, Status as AuthStatus } from "../../components/Contexts/AuthContext";
 import usePageTitle from "../../hooks/usePageTitle";
 import CreateDataSubmissionDialog from "../../components/DataSubmissions/CreateDataSubmissionDialog";
-import {
-  Status as OrgStatus,
-  useOrganizationListContext,
-} from "../../components/Contexts/OrganizationListContext";
 import GenericTable, { Column } from "../../components/GenericTable";
 import { LIST_SUBMISSIONS, ListSubmissionsInput, ListSubmissionsResp } from "../../graphql";
 import TruncatedText from "../../components/TruncatedText";
@@ -230,7 +226,6 @@ const ListingView: FC = () => {
   const { state } = useLocation();
   const { status: authStatus } = useAuthContext();
   const { enqueueSnackbar } = useSnackbar();
-  const { status: orgStatus, activeOrganizations } = useOrganizationListContext();
   // Only org owners/submitters with organizations assigned can create data submissions
 
   const { columnVisibilityModel, setColumnVisibilityModel, visibleColumns } = useColumnVisibility<
@@ -271,7 +266,7 @@ const ListingView: FC = () => {
     try {
       setLoading(true);
 
-      if (!activeOrganizations?.length || !filtersRef.current) {
+      if (!filtersRef.current) {
         return;
       }
 
@@ -325,10 +320,6 @@ const ListingView: FC = () => {
   };
 
   const handleOnCreateSubmission = async () => {
-    if (!activeOrganizations?.length) {
-      return;
-    }
-
     try {
       setLoading(true);
 
@@ -395,9 +386,7 @@ const ListingView: FC = () => {
             columns={visibleColumns}
             data={data || []}
             total={totalData || 0}
-            loading={
-              loading || orgStatus === OrgStatus.LOADING || authStatus === AuthStatus.LOADING
-            }
+            loading={loading || authStatus === AuthStatus.LOADING}
             defaultRowsPerPage={20}
             defaultOrder="desc"
             disableUrlParams={false}

--- a/src/content/dataSubmissions/DataSubmissionsListView.tsx
+++ b/src/content/dataSubmissions/DataSubmissionsListView.tsx
@@ -329,6 +329,13 @@ const ListingView: FC = () => {
         throw new Error("Unable to retrieve Data Submission List results.");
       }
       setData(d.listSubmissions.submissions);
+      setOrganizations(
+        d.listSubmissions.organizations
+          ?.filter((org) => !!org.name.trim())
+          ?.sort((a, b) => a.name?.localeCompare(b.name))
+      );
+      setSubmitterNames(d.listSubmissions.submitterNames?.filter((sn) => !!sn.trim()));
+      setDataCommons(d.listSubmissions.dataCommons?.filter((dc) => !!dc.trim()));
       setTotalData(d.listSubmissions.total);
     } catch (err) {
       setError(true);

--- a/src/graphql/listSubmissions.ts
+++ b/src/graphql/listSubmissions.ts
@@ -73,7 +73,7 @@ export type Response = {
   listSubmissions: {
     total: number;
     submissions: Omit<Submission, "submitterID" | "bucketName" | "rootPath" | "history">[];
-    organizations: Organization[];
+    organizations: Pick<Organization, "_id" | "name">[];
     submitterNames: string[];
     dataCommons: string[];
   };

--- a/src/graphql/listSubmissions.ts
+++ b/src/graphql/listSubmissions.ts
@@ -46,6 +46,10 @@ export const query = gql`
         updatedAt
         intention
       }
+      organizations {
+        _id
+        name
+      }
       submitterNames
       dataCommons
     }
@@ -69,6 +73,7 @@ export type Response = {
   listSubmissions: {
     total: number;
     submissions: Omit<Submission, "submitterID" | "bucketName" | "rootPath" | "history">[];
+    organizations: Organization[];
     submitterNames: string[];
     dataCommons: string[];
   };


### PR DESCRIPTION
### Overview

Update the Organization select dropdown from the Data Submission List table filters so that any user can select from relevant Organizations.

### Change Details (Specifics)

- Updated listSubmissions API to retrieve Organizations
- Updated Data Submission List filters to not use OrganizationListContext, and replace with orgs from listSubmissions API
- Updated Org dropdown to reset to "All" when the selected org is no longer an option
- After a new submission is created, update the orgs, submitter names, and dataCommons lists
- Updated tests to match new implementation
- Fixed lineHeight issue in Data Submission summary section. The collaborators property was taller than all the other properties
- Added a bandage fix for an existing bug. Unsure of cause, but please test to ensure it is fixed for you as well. Added comment with more details below
 
### Related Ticket(s)

[CRDCDH-1639](https://tracker.nci.nih.gov/browse/CRDCDH-1639) (Task)
[CRDCDH-1639](https://tracker.nci.nih.gov/browse/CRDCDH-1639) (User Story)
