### PR TITLE
CRDCDH-1773 Fix rendering of long Study Names

### DIFF
--- a/src/components/ExportRequestButton/pdf/Generate.ts
+++ b/src/components/ExportRequestButton/pdf/Generate.ts
@@ -75,12 +75,17 @@ const writeHeader = (doc: JsPDF, request: Application): number => {
   doc.text("STUDY NAME", CONTENT_MARGIN, y);
 
   const formattedName = formatFullStudyName(study?.name, study?.abbreviation);
-  const splitName = doc.splitTextToSize(formattedName, RIGHT_EDGE - CONTENT_MARGIN);
+  const maxNameWidth = RIGHT_EDGE - CONTENT_MARGIN - 85;
   doc.setFont("Nunito", "normal", 400);
   doc.setFontSize(12);
   doc.setTextColor(...COLOR_FIELD_BASE);
-  doc.text(splitName, CONTENT_MARGIN + 85, y);
-  y += splitName.length * 8 + 10;
+  doc.text(formattedName, CONTENT_MARGIN + 85, y, {
+    // NOTE – Take the full width of the page and subtract the margins/offsets
+    maxWidth: maxNameWidth,
+  });
+
+  const computedNameLines = doc.splitTextToSize(formattedName, maxNameWidth);
+  y += (computedNameLines?.length || 1) * 8 + 11;
 
   // Submitted Date
   doc.setFont("Nunito", "normal", 600);


### PR DESCRIPTION
### Overview

This PR resolves a bug where Submission Requests with a long study name + abbreviation don't properly wrap in the PDF export and it causes text to be cut off.

<img width="816" alt="Screenshot 2024-10-31 at 2 34 49 PM" src="https://github.com/user-attachments/assets/bf8eed09-5508-4c3b-8349-8dae37aa4d3a">

<img width="816" alt="Screenshot 2024-10-31 at 2 34 29 PM" src="https://github.com/user-attachments/assets/37d8455c-2974-45a7-933d-9e8dd0be0b1f">

<img width="816" alt="Screenshot 2024-10-31 at 2 34 12 PM" src="https://github.com/user-attachments/assets/42e92cb2-02a5-4dbc-adc0-f9fc60a1e593">

<img width="816" alt="Screenshot 2024-10-31 at 2 33 42 PM" src="https://github.com/user-attachments/assets/cc2d2532-f5ed-4d0c-bea1-36247e58285d">

### Change Details (Specifics)

- Fine-tune the handling of text-wrapping for the Study Name in the PDF header

### Related Ticket(s)

CRDCDH-1773