### PR TITLE
Synchronize CDE parsing logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8897,7 +8897,7 @@
     },
     "node_modules/data-model-navigator": {
       "version": "1.1.34",
-      "resolved": "git+ssh://git@github.com/CBIIT/Data-Model-Navigator.git#4b5c21a892c84178088541f9a31717d74f048087",
+      "resolved": "git+ssh://git@github.com/CBIIT/Data-Model-Navigator.git#43c71e00ba42340567c632b4bb0c3f6753138342",
       "license": "ISC",
       "dependencies": {
         "@material-ui/core": "^4.12.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8897,7 +8897,7 @@
     },
     "node_modules/data-model-navigator": {
       "version": "1.1.34",
-      "resolved": "git+ssh://git@github.com/CBIIT/Data-Model-Navigator.git#43c71e00ba42340567c632b4bb0c3f6753138342",
+      "resolved": "git+ssh://git@github.com/CBIIT/Data-Model-Navigator.git#a1f5344d0dc06f2ec3d0b829805469602479d692",
       "license": "ISC",
       "dependencies": {
         "@material-ui/core": "^4.12.4",

--- a/src/graphql/retrieveCDEs.ts
+++ b/src/graphql/retrieveCDEs.ts
@@ -15,7 +15,7 @@ export const query = gql`
 `;
 
 export type Input = {
-  cdeInfo: CDEInfo[];
+  cdeInfo: Pick<CDEInfo, "CDECode" | "CDEVersion">[];
 };
 
 export type Response = {

--- a/src/hooks/useBuildReduxStore.ts
+++ b/src/hooks/useBuildReduxStore.ts
@@ -102,7 +102,7 @@ const useBuildReduxStore = (): ReduxStoreResult => {
       try {
         const CDEs = await retrieveCDEs({
           variables: {
-            cdeInfo,
+            cdeInfo: cdeInfo.map(({ CDECode, CDEVersion }) => ({ CDECode, CDEVersion })),
           },
         });
 

--- a/src/types/CDEs.d.ts
+++ b/src/types/CDEs.d.ts
@@ -1,4 +1,5 @@
 type CDEInfo = {
   CDECode: string;
   CDEVersion: string;
+  CDEOrigin: string;
 };

--- a/src/utils/dataModelUtils.test.ts
+++ b/src/utils/dataModelUtils.test.ts
@@ -356,12 +356,11 @@ describe("updateEnums", () => {
   const cdeMap = new Map([
     [
       "program.program_name;11444542.1.00",
-      [
-        {
-          CDECode: "11444542",
-          CDEVersion: "1.00",
-        },
-      ],
+      {
+        CDECode: "11444542",
+        CDEVersion: "1.00",
+        CDEOrigin: "caDSR",
+      },
     ],
   ]);
 
@@ -456,6 +455,26 @@ describe("updateEnums", () => {
     expect(nullPvResult.program.properties["program_name"].CDEOrigin).toEqual("caDSR");
   });
 
+  // NOTE: this is a temporary solution until 3.2.0 supports alternate CDE origins
+  it("should populate the CDE Origin from the CDEMap provided by Model Navigator", () => {
+    const testMap = new Map([
+      [
+        "program.program_name;11444542.1.00",
+        {
+          CDECode: "11444542",
+          CDEVersion: "1.00",
+          CDEOrigin: "fake origin that is not caDSR",
+        },
+      ],
+    ]);
+
+    const result = utils.updateEnums(testMap, dataList, [CDEresponse]);
+
+    expect(result.program.properties["program_name"].CDEOrigin).toEqual(
+      "fake origin that is not caDSR"
+    );
+  });
+
   it("should apply fallback message when response is empty and apiError is true", () => {
     const result = utils.updateEnums(cdeMap, dataList, [], true);
 
@@ -492,6 +511,7 @@ describe("traverseAndReplace", () => {
         CDEFullName: "Subject Legal Adult Or Pediatric Participant Type",
         CDECode: "11524549",
         CDEVersion: "1.00",
+        CDEOrigin: "caDSR",
         PermissibleValues: ["Pediatric", "Adult - legal age"],
         createdAt: "2024-09-24T11:45:42.313Z",
         updatedAt: "2024-09-24T11:45:42.313Z",

--- a/src/utils/dataModelUtils.ts
+++ b/src/utils/dataModelUtils.ts
@@ -119,7 +119,7 @@ export const buildFilterOptionsList = (dc: DataCommon): string[] => {
  * @params {void}
  */
 export const updateEnums = (
-  cdeMap: Map<string, CDEInfo[]>,
+  cdeMap: Map<string, CDEInfo>,
   dataList,
   response: RetrieveCDEsResp["retrieveCDEs"] = [],
   apiError = false
@@ -130,16 +130,17 @@ export const updateEnums = (
     responseMap.set(`${item.CDECode}.${item.CDEVersion}`, item)
   );
 
-  const resultMap: Map<string, RetrieveCDEsResp["retrieveCDEs"][0]> = new Map();
+  const resultMap: Map<string, RetrieveCDEsResp["retrieveCDEs"][0] & { CDEOrigin: string }> =
+    new Map();
   const mapKeyPrefixes: Map<string, string> = new Map();
   const mapKeyPrefixesNoValues: Map<string, string> = new Map();
 
-  cdeMap.forEach((_, key) => {
+  cdeMap.forEach((val, key) => {
     const [prefix, cdeCodeAndVersion] = key.split(";");
     const item = responseMap.get(cdeCodeAndVersion);
 
     if (item) {
-      resultMap.set(key, item);
+      resultMap.set(key, { ...item, CDEOrigin: val?.CDEOrigin || "" });
       mapKeyPrefixes.set(prefix, key);
     } else {
       mapKeyPrefixesNoValues.set(prefix, key);
@@ -155,7 +156,7 @@ export const updateEnums = (
 
 export const traverseAndReplace = (
   node,
-  resultMap: Map<string, RetrieveCDEsResp["retrieveCDEs"][0]>,
+  resultMap: Map<string, RetrieveCDEsResp["retrieveCDEs"][0] & { CDEOrigin: string }>,
   mapKeyPrefixes: Map<string, string>,
   mapKeyPrefixesNoValues: Map<string, string>,
   apiError: boolean,
@@ -178,7 +179,7 @@ export const traverseAndReplace = (
         ];
 
         if (prefixMatch) {
-          const { CDECode, CDEFullName, CDEVersion, PermissibleValues } =
+          const { CDECode, CDEFullName, CDEVersion, CDEOrigin, PermissibleValues } =
             resultMap.get(prefixMatch);
 
           // Populate CDE details
@@ -186,7 +187,7 @@ export const traverseAndReplace = (
           property.CDECode = CDECode;
           property.CDEPublicID = getCDEPublicID(CDECode, CDEVersion);
           property.CDEVersion = CDEVersion;
-          property.CDEOrigin = "caDSR";
+          property.CDEOrigin = CDEOrigin;
 
           // Populate Permissible Values if available from API
           if (Array.isArray(PermissibleValues) && PermissibleValues.length > 0) {


### PR DESCRIPTION
### Overview

This PR updates the CDE integration to sync the parsing logic. Specifically:

- Empty permissible values array – convert the property to a string
- API does not return anything for a specific CDE (it's not in the API response) – show an error for that CDE
- Search for the `Term` with caDSR origin, instead of just the first one (DH requirement change)
- Always show the CDE Origin from the MDF, even though it will always (in 3.1.0) be "caDSR" or akin

The first two logic updates are highlighted below, everything else in the table was already covered.

<details><summary>Details</summary>
<p>

<img width="629" alt="Screenshot 2024-11-01 at 4 05 20 PM" src="https://github.com/user-attachments/assets/c34fd7d3-1e9f-420b-9a20-0bddac784652">

</p>
</details> 

### Change Details (Specifics)

- Always populate CDE info (even if there's an issue with the PermissibleValues)
- Use the exact "CDE Origin" provided in the MDF for the caDSR CDE Term
- Update logic to match the matrix above
- Log an error when the CDE cannot be mapped

### Related Ticket(s)

N/A – Related to CRDCDH-1451
