### PR TITLE
CRDCDH-1978 Fix: Navbar breaks for names with multiple spaces

### DIFF
--- a/src/components/Header/components/HeaderTabletAndMobile.tsx
+++ b/src/components/Header/components/HeaderTabletAndMobile.tsx
@@ -202,7 +202,7 @@ const Header = () => {
   }
 
   const clickNavItem = (e) => {
-    const clickTitle = e.target.innerText;
+    const clickTitle = e.target.textContent;
     setSelectedList(navbarSublists[clickTitle]);
   };
 
@@ -275,7 +275,7 @@ const Header = () => {
               </div>
             )}
             <div className="navMobileContainer">
-              {selectedList.map((navMobileItem) => {
+              {selectedList?.map((navMobileItem) => {
                 // If the user is not logged in and the item requires a role, don't show it
                 if (
                   "roles" in navMobileItem &&

--- a/src/components/Header/components/NavbarDesktop.tsx
+++ b/src/components/Header/components/NavbarDesktop.tsx
@@ -336,10 +336,10 @@ const NavBar = () => {
   };
 
   const handleMenuClick = (e) => {
-    if (e.target.innerText === clickedTitle || !clickableTitle.includes(e.target.innerText)) {
+    if (e.target.textContent === clickedTitle || !clickableTitle.includes(e.target.textContent)) {
       setClickedTitle("");
     } else {
-      setClickedTitle(e.target.innerText);
+      setClickedTitle(e.target.textContent);
     }
   };
 
@@ -398,12 +398,12 @@ const NavBar = () => {
                     >
                       <div
                         id={navItem.id}
-                        onKeyDown={onKeyPressHandler}
                         role="button"
                         tabIndex={0}
                         className={`navText directLink ${
                           shouldBeUnderlined(navItem) ? "shouldBeUnderlined" : ""
                         }`}
+                        onKeyDown={onKeyPressHandler}
                         onClick={handleMenuClick}
                       >
                         {navItem.name}
@@ -414,12 +414,12 @@ const NavBar = () => {
                   <div className={clickedTitle === navItem.name ? "navTitleClicked" : "navTitle"}>
                     <div
                       id={navItem.id}
-                      onKeyDown={onKeyPressHandler}
                       role="button"
                       tabIndex={0}
                       className={`${
                         clickedTitle === navItem.name ? "navText clicked" : "navText"
                       } ${shouldBeUnderlined(navItem) ? "shouldBeUnderlined" : ""}`}
+                      onKeyDown={onKeyPressHandler}
                       onClick={handleMenuClick}
                     >
                       {navItem.name}
@@ -437,7 +437,6 @@ const NavBar = () => {
               >
                 <div
                   id="navbar-dropdown-name"
-                  onKeyDown={onKeyPressHandler}
                   role="button"
                   tabIndex={0}
                   className={
@@ -445,6 +444,7 @@ const NavBar = () => {
                       ? "navText displayName clicked"
                       : "navText displayName"
                   }
+                  onKeyDown={onKeyPressHandler}
                   onClick={handleMenuClick}
                 >
                   {displayName}


### PR DESCRIPTION
### Overview

This PR fixes an issue where the navbar uses `innerText` to determine which item was clicked – Which works fine until the rendered value is different from the actual value (HTML collapses extra whitespace natively). 

> [!NOTE]
> This is just a bandaid fix, the navigation bar elements should just call the onClick handler with the configuration-based name of the item since we have those details within the context.

### Change Details (Specifics)

- Migrate usage of `innerText` to `textContent`
- Fix mobile navbar crashing when no sublist exists

### Related Ticket(s)

CRDCDH-1978