### PR TITLE
CRDCDH-2025 Updating an existing collaborator can cause field clearing

### DIFF
--- a/src/components/Contexts/CollaboratorsContext.test.tsx
+++ b/src/components/Contexts/CollaboratorsContext.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { fireEvent, render, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, renderHook, waitFor } from "@testing-library/react";
 import { MockedProvider, MockedResponse } from "@apollo/client/testing";
 import userEvent from "@testing-library/user-event";
 import { useCollaboratorsContext, CollaboratorsProvider } from "./CollaboratorsContext";
@@ -755,5 +755,56 @@ describe("CollaboratorsContext", () => {
       orgID: "org-3",
       orgName: "Org 3",
     });
+  });
+
+  it("should handle updating an existing collaborator when they're no longer a potential collaborator", async () => {
+    const emptyPotentialCollaborators: MockedResponse<
+      ListPotentialCollaboratorsResp,
+      ListPotentialCollaboratorsInput
+    > = {
+      request: {
+        query: LIST_POTENTIAL_COLLABORATORS,
+        variables: { submissionID: "submission-id-123" },
+      },
+      result: {
+        data: {
+          listPotentialCollaborators: [],
+        },
+      },
+    };
+
+    const { result } = renderHook(() => useCollaboratorsContext(), {
+      wrapper: ({ children }) => (
+        <TestParent mocks={[emptyPotentialCollaborators]}>{children}</TestParent>
+      ),
+    });
+
+    const existingCol = dummySubmissionData.getSubmission.collaborators[0];
+
+    await waitFor(() => {
+      expect(result.current.currentCollaborators.length).toBe(2);
+    });
+
+    expect(result.current.currentCollaborators[0].collaboratorID).toBe(existingCol.collaboratorID);
+    expect(result.current.currentCollaborators[0].permission).toBe(existingCol.permission);
+
+    // Update an existing collaborator that NO LONGER exists in potential collaborators
+    act(() => {
+      result.current.handleUpdateCollaborator(0, {
+        collaboratorID: dummySubmissionData.getSubmission.collaborators[0].collaboratorID,
+        permission: "Can View", // current permission is Can Edit
+      });
+    });
+
+    await waitFor(() => {
+      // Verify the update propagated
+      expect(result.current.currentCollaborators[0].permission).toBe("Can View");
+    });
+
+    // Verify the user's details are carried over from the existing collaborators
+    expect(result.current.currentCollaborators[0].collaboratorName).toBe(
+      existingCol.collaboratorName
+    );
+    expect(result.current.currentCollaborators[0].Organization).toBe(existingCol.Organization);
   });
 });

--- a/src/components/Contexts/CollaboratorsContext.tsx
+++ b/src/components/Contexts/CollaboratorsContext.tsx
@@ -221,9 +221,21 @@ export const CollaboratorsProvider: FC<ProviderProps> = ({ children }) => {
       return;
     }
 
-    const potentialCollaborator = potentialCollaborators.find(
+    let potentialCollaborator = potentialCollaborators.find(
       (pc) => pc.collaboratorID === newCollaborator?.collaboratorID
     );
+
+    const existingCollaborator = currentCollaborators.find(
+      (c) => c.collaboratorID === newCollaborator?.collaboratorID
+    );
+
+    if (!potentialCollaborator?.collaboratorID && existingCollaborator?.collaboratorID) {
+      Logger.error(
+        `CollaboratorsContext: The collaborator ${newCollaborator?.collaboratorID} is no longer a valid potential collaborator. Using existing collaborator instead.`,
+        existingCollaborator
+      );
+      potentialCollaborator = { ...existingCollaborator };
+    }
 
     setCurrentCollaborators((prevCollaborators) => {
       const collaboratorsClone = [...prevCollaborators];


### PR DESCRIPTION
### Overview

This PR addresses an issue where:

1. A completely valid collaborator is added to a submission
2. The collaborator becomes invalid via some action, such as
  - Their role changes
  - Their org changes
  - A study is removed from their org
3. When the submitter goes to the manage collaborators table and changes their permission
4. The Name and Organization fields go blank until saved and reloaded

### Change Details (Specifics)

- If the user does not exist in the potential collaborators, backfill the information from the existing collaborator assignment
- Add an error log for when this occurs – This can be removed if desired
- Update test coverage for this scenario

### Related Ticket(s)

CRDCDH-2025
