### PR TITLE
CRDCDH-1862 Fix table row background colors to be solid

### DIFF
--- a/src/components/GenericTable/index.tsx
+++ b/src/components/GenericTable/index.tsx
@@ -44,7 +44,10 @@ const StyledTableContainer = styled(TableContainer)({
   marginBottom: "25px",
   position: "relative",
   overflow: "hidden",
-  "& .MuiTableRow-root:nth-of-type(2n)": {
+  "& .MuiTableBody-root .MuiTableRow-root:nth-of-type(odd)": {
+    background: "#FFF",
+  },
+  "& .MuiTableBody-root .MuiTableRow-root:nth-of-type(even)": {
     background: "#E3EEF9",
   },
   "& .MuiTableCell-root:first-of-type": {


### PR DESCRIPTION
### Overview

Updated GenericTable to have solid background colors for each row in the table body. Previously, the "odds" were transparent instead of solid.

### Change Details (Specifics)

N/A

### Related Ticket(s)

[CRDCDH-1862](https://tracker.nci.nih.gov/browse/CRDCDH-1862) (Related task, not implementation)
