### PR TITLE
CRDCDH-2064 Remove ORCID input from Submission Request form

### DIFF
--- a/src/content/questionnaire/sections/A.tsx
+++ b/src/content/questionnaire/sections/A.tsx
@@ -11,13 +11,7 @@ import SectionGroup from "../../../components/Questionnaire/SectionGroup";
 import TextInput from "../../../components/Questionnaire/TextInput";
 import AutocompleteInput from "../../../components/Questionnaire/AutocompleteInput";
 import AddRemoveButton from "../../../components/AddRemoveButton";
-import {
-  filterForNumbers,
-  formatORCIDInput,
-  isValidORCID,
-  mapObjectWithKey,
-  validateEmail,
-} from "../../../utils";
+import { filterForNumbers, mapObjectWithKey, validateEmail } from "../../../utils";
 import TransitionGroupWrapper from "../../../components/Questionnaire/TransitionGroupWrapper";
 import { InitialQuestionnaire } from "../../../config/InitialValues";
 import SectionMetadata from "../../../config/SectionMetadata";
@@ -189,17 +183,6 @@ const FormSectionA: FC<FormSectionProps> = ({ SectionOption, refs }: FormSection
           validate={validateEmail}
           errorText="Please provide a valid email address"
           required
-          readOnly={readOnlyInputs}
-        />
-        <TextInput
-          id="section-a-pi-orcid"
-          label="ORCID"
-          name="pi[ORCID]"
-          value={pi?.ORCID}
-          placeholder="e.g. 0000-0001-2345-6789"
-          validate={(val) => val?.length === 0 || isValidORCID(val)}
-          filter={formatORCIDInput}
-          errorText="Please provide a valid ORCID"
           readOnly={readOnlyInputs}
         />
         <AutocompleteInput


### PR DESCRIPTION
### Overview

Temporarily removing ORCID input from Submission Request form, will be re-enabled in 3.2.0.

### Change Details (Specifics)

- ORCID input was removed, but the value for the ORCID property sent to the BE remains an empty string.

> [!Note]
> Just noticed we never added ORCID to the Review page. We should add that to the requirements when re-enabling in 3.2.0.

### Related Ticket(s)

[CRDCDH-2064](https://tracker.nci.nih.gov/browse/CRDCDH-2064) (User Story)
