### PR TITLE
CRDCDH-2064 Fix detecting change in ORCID for legacy forms 

### DIFF
--- a/src/components/Contexts/FormContext.tsx
+++ b/src/components/Contexts/FormContext.tsx
@@ -424,7 +424,9 @@ export const FormProvider: FC<ProviderProps> = ({ children, id }: ProviderProps)
       }
 
       // TODO: Remove in 3.2.0
-      questionnaireData.pi.ORCID = "";
+      if (questionnaireData.pi) {
+        questionnaireData.pi.ORCID = "";
+      }
 
       setState({
         status: Status.LOADED,

--- a/src/components/Contexts/FormContext.tsx
+++ b/src/components/Contexts/FormContext.tsx
@@ -423,6 +423,9 @@ export const FormProvider: FC<ProviderProps> = ({ children, id }: ProviderProps)
         };
       }
 
+      // TODO: Remove in 3.2.0
+      questionnaireData.pi.ORCID = "";
+
       setState({
         status: Status.LOADED,
         data: {

--- a/src/content/questionnaire/sections/A.tsx
+++ b/src/content/questionnaire/sections/A.tsx
@@ -91,6 +91,9 @@ const FormSectionA: FC<FormSectionProps> = ({ SectionOption, refs }: FormSection
       combinedData.primaryContact = null;
     }
 
+    // TODO: Remove in 3.2.0
+    combinedData.pi.ORCID = "";
+
     return { ref: formRef, data: combinedData };
   };
 


### PR DESCRIPTION
### Overview

Updated `questionnaireData` on API retrieval to be an empty string as well as the ORCID value in the form to be an empty string. This way it will treat ORCID property as unchanged and ignore the field.

### Change Details (Specifics)

N/A

### Related Ticket(s)

[CRDCDH-2064](https://tracker.nci.nih.gov/browse/CRDCDH-2064) (User Story)
