### PR TITLE
Fix add collaborators button

### DIFF
--- a/src/components/Contexts/CollaboratorsContext.test.tsx
+++ b/src/components/Contexts/CollaboratorsContext.test.tsx
@@ -758,6 +758,8 @@ describe("CollaboratorsContext", () => {
   });
 
   it("should handle updating an existing collaborator when they're no longer a potential collaborator", async () => {
+    mockSubmissionData = dummySubmissionData;
+
     const emptyPotentialCollaborators: MockedResponse<
       ListPotentialCollaboratorsResp,
       ListPotentialCollaboratorsInput
@@ -779,10 +781,15 @@ describe("CollaboratorsContext", () => {
       ),
     });
 
+    act(() => {
+      result.current.loadPotentialCollaborators();
+    });
+
     const existingCol = dummySubmissionData.getSubmission.collaborators[0];
 
     await waitFor(() => {
       expect(result.current.currentCollaborators.length).toBe(2);
+      expect(result.current.maxCollaborators).toBe(2);
     });
 
     expect(result.current.currentCollaborators[0].collaboratorID).toBe(existingCol.collaboratorID);

--- a/src/components/Contexts/CollaboratorsContext.tsx
+++ b/src/components/Contexts/CollaboratorsContext.tsx
@@ -98,8 +98,21 @@ export const CollaboratorsProvider: FC<ProviderProps> = ({ children }) => {
   >(LIST_POTENTIAL_COLLABORATORS, {
     fetchPolicy: "cache-and-network",
     onCompleted: (data) => {
-      setMaxCollaborators(data?.listPotentialCollaborators?.length || 0);
-      const collaborators = data?.listPotentialCollaborators?.map((user) =>
+      const potentialCollaboratorsIDs = (data?.listPotentialCollaborators || [])?.map(
+        (pc) => pc._id
+      );
+      const submissionCollaborators = submissionData?.getSubmission?.collaborators || [];
+
+      // Find collaborators in submission that are not in potential collaborators
+      const remaining = submissionCollaborators?.filter(
+        (c) => !potentialCollaboratorsIDs.includes(c.collaboratorID)
+      );
+
+      const totalPotential = data?.listPotentialCollaborators?.length || 0;
+      const totalRemaining = remaining?.length || 0;
+      setMaxCollaborators(totalPotential + totalRemaining);
+
+      const collaborators = (data?.listPotentialCollaborators || [])?.map((user) =>
         userToCollaborator(user)
       );
       setPotentialCollaborators(collaborators);


### PR DESCRIPTION
### Overview

When a user is no longer a valid potential collaborator, it will not consider the collaborators in the submission into the total maxCollaborators which results in the addCollaborator button disabling early. Added the missing submission collaborators to fix this issue.

### Change Details (Specifics)

N/A

### Related Ticket(s)

[CRDCDH-2025](https://tracker.nci.nih.gov/browse/CRDCDH-2025) (Original bug)
