### PR TITLE
CRDCDH-2074 Rename Node to Record and Incr. dbGaPID length

### DIFF
--- a/src/content/dataSubmissions/DataSubmissionsListView.tsx
+++ b/src/content/dataSubmissions/DataSubmissionsListView.tsx
@@ -153,7 +153,7 @@ const columns: Column<T>[] = [
 
   {
     label: "dbGaP ID",
-    renderValue: (a) => <TruncatedText text={a.dbGaPID} />,
+    renderValue: (a) => <TruncatedText text={a.dbGaPID} maxCharacters={15} />,
     field: "dbGaPID",
     hideable: true,
   },
@@ -175,7 +175,7 @@ const columns: Column<T>[] = [
   },
 
   {
-    label: "Node Count",
+    label: "Record Count",
     renderValue: (a) =>
       Intl.NumberFormat("en-US", { maximumFractionDigits: 0 }).format(a.nodeCount || 0),
     field: "nodeCount",


### PR DESCRIPTION
### Overview

This PR addresses two concerns brought up during the 3.1.0 Release Demo; Increase dbGaPID maximum length and rename "node" to "record" for the node count column.

### Change Details (Specifics)

N/A

### Related Ticket(s)

CRDCDH-2074 (Task)
CRDCDH-2070 (Story)
