### PR TITLE
CRDCDH-1988 Data Submissions - Conditionally Approved Studies (2/2)

### DIFF
--- a/src/components/DataSubmissions/CreateDataSubmissionDialog.test.tsx
+++ b/src/components/DataSubmissions/CreateDataSubmissionDialog.test.tsx
@@ -824,10 +824,286 @@ describe("Basic Functionality", () => {
   });
 });
 
-// TODO: Implement the following tests
+describe("Implementation Requirements", () => {
+  it("should disable the Create button if dbGaP ID is required and not added to the study", async () => {
+    const ApprovedStudyNoDbGaPID: MockedResponse<ListApprovedStudiesOfMyOrgResp> = {
+      request: {
+        query: LIST_APPROVED_STUDIES_OF_MY_ORG,
+      },
+      result: {
+        data: {
+          listApprovedStudiesOfMyOrganization: [
+            {
+              _id: "controlled",
+              studyName: "controlled-study",
+              studyAbbreviation: "CS",
+              dbGaPID: null,
+              controlledAccess: true,
+            },
+          ],
+        },
+      },
+    };
 
-it.todo("should disable the Create button if dbGaP ID is required and not added to the study");
+    const { getByRole, getByTestId, getByText } = render(
+      <CreateDataSubmissionDialog onCreate={jest.fn()} />,
+      {
+        wrapper: (p) => (
+          <TestParent
+            mocks={[ApprovedStudyNoDbGaPID, ...listOrgsMocks]}
+            authCtxState={{ ...baseAuthCtx, user: { ...baseUser, role: "Submitter" } }}
+            {...p}
+          />
+        ),
+      }
+    );
 
-it.todo("should show an alert icon next to dbGaPID if it is required and not added to the study");
+    // Simulate opening dialog
+    const openDialogButton = getByRole("button", { name: "Create a Data Submission" });
 
-it.todo("should hide the dbGaPID field if controlledAccess is false");
+    await waitFor(() => expect(openDialogButton).toBeEnabled());
+
+    userEvent.click(openDialogButton);
+
+    await waitFor(() => {
+      expect(getByTestId("create-data-submission-dialog-study-id-input")).toBeInTheDocument();
+    });
+
+    const studySelectButton = within(
+      getByTestId("create-data-submission-dialog-study-id-input")
+    ).getByRole("button");
+
+    userEvent.click(studySelectButton);
+
+    await waitFor(() => {
+      expect(studySelectButton).toHaveAttribute("aria-expanded", "true");
+    });
+
+    userEvent.click(getByText("CS"));
+
+    await waitFor(() => {
+      expect(getByTestId("create-data-submission-dialog-create-button")).toBeDisabled();
+    });
+  });
+
+  it("should show an alert icon next to dbGaPID if it is required and not added to the study", async () => {
+    const ApprovedStudyNoDbGaPID: MockedResponse<ListApprovedStudiesOfMyOrgResp> = {
+      request: {
+        query: LIST_APPROVED_STUDIES_OF_MY_ORG,
+      },
+      result: {
+        data: {
+          listApprovedStudiesOfMyOrganization: [
+            {
+              _id: "controlled",
+              studyName: "controlled-study",
+              studyAbbreviation: "CS",
+              dbGaPID: null,
+              controlledAccess: true,
+            },
+          ],
+        },
+      },
+    };
+
+    const { getByRole, getByTestId, getByText } = render(
+      <CreateDataSubmissionDialog onCreate={jest.fn()} />,
+      {
+        wrapper: (p) => (
+          <TestParent
+            mocks={[ApprovedStudyNoDbGaPID, ...listOrgsMocks]}
+            authCtxState={{ ...baseAuthCtx, user: { ...baseUser, role: "Submitter" } }}
+            {...p}
+          />
+        ),
+      }
+    );
+
+    // Simulate opening dialog
+    const openDialogButton = getByRole("button", { name: "Create a Data Submission" });
+
+    await waitFor(() => expect(openDialogButton).toBeEnabled());
+
+    userEvent.click(openDialogButton);
+
+    await waitFor(() => {
+      expect(getByTestId("create-data-submission-dialog-study-id-input")).toBeInTheDocument();
+    });
+
+    const studySelectButton = within(
+      getByTestId("create-data-submission-dialog-study-id-input")
+    ).getByRole("button");
+
+    userEvent.click(studySelectButton);
+
+    await waitFor(() => {
+      expect(studySelectButton).toHaveAttribute("aria-expanded", "true");
+    });
+
+    userEvent.click(getByText("CS"));
+
+    await waitFor(() => {
+      expect(getByTestId("pending-conditions-icon")).toBeInTheDocument();
+    });
+
+    userEvent.hover(getByTestId("pending-conditions-icon"));
+
+    await waitFor(() => {
+      expect(getByRole("tooltip")).toBeInTheDocument();
+    });
+
+    expect(getByRole("tooltip")).toHaveTextContent(
+      "Please contact NCICRDC@mail.nih.gov to submit your dbGaP ID once you have registered your study on dbGap.",
+      { normalizeWhitespace: true }
+    );
+  });
+
+  it("should hide the dbGaPID field if controlledAccess is false", async () => {
+    const ApprovedStudyNoDbGaPID: MockedResponse<ListApprovedStudiesOfMyOrgResp> = {
+      request: {
+        query: LIST_APPROVED_STUDIES_OF_MY_ORG,
+      },
+      result: {
+        data: {
+          listApprovedStudiesOfMyOrganization: [
+            {
+              _id: "controlled",
+              studyName: "controlled-study",
+              studyAbbreviation: "CS",
+              dbGaPID: "phsTEST",
+              controlledAccess: true,
+            },
+            {
+              _id: "non-controlled",
+              studyName: "non-controlled-study",
+              studyAbbreviation: "NCS",
+              dbGaPID: null,
+              controlledAccess: false,
+            },
+          ],
+        },
+      },
+    };
+
+    const { getByRole, getByTestId, getByText } = render(
+      <CreateDataSubmissionDialog onCreate={jest.fn()} />,
+      {
+        wrapper: (p) => (
+          <TestParent
+            mocks={[ApprovedStudyNoDbGaPID, ...listOrgsMocks]}
+            authCtxState={{ ...baseAuthCtx, user: { ...baseUser, role: "Submitter" } }}
+            {...p}
+          />
+        ),
+      }
+    );
+
+    // Simulate opening dialog
+    const openDialogButton = getByRole("button", { name: "Create a Data Submission" });
+
+    await waitFor(() => expect(openDialogButton).toBeEnabled());
+
+    userEvent.click(openDialogButton);
+
+    await waitFor(() => {
+      expect(getByTestId("create-data-submission-dialog-study-id-input")).toBeInTheDocument();
+    });
+
+    // --- CONTROLLED STUDY ---
+    const studySelectButton = within(
+      getByTestId("create-data-submission-dialog-study-id-input")
+    ).getByRole("button");
+
+    userEvent.click(studySelectButton);
+
+    await waitFor(() => {
+      expect(studySelectButton).toHaveAttribute("aria-expanded", "true");
+    });
+
+    userEvent.click(getByText("CS"));
+    await waitFor(() => {
+      expect(getByTestId("create-data-submission-dialog-dbgap-id-input")).toBeVisible();
+    });
+
+    // --- NON-CONTROLLED STUDY ---
+    userEvent.click(studySelectButton);
+
+    await waitFor(() => {
+      expect(studySelectButton).toHaveAttribute("aria-expanded", "true");
+    });
+
+    userEvent.click(getByText("NCS"));
+
+    await waitFor(() => {
+      expect(getByTestId("create-data-submission-dialog-dbgap-id-input")).not.toBeVisible();
+    });
+  });
+
+  it("should have a tooltip for the dbGaPID field explaining why it is required", async () => {
+    const ApprovedStudyNoDbGaPID: MockedResponse<ListApprovedStudiesOfMyOrgResp> = {
+      request: {
+        query: LIST_APPROVED_STUDIES_OF_MY_ORG,
+      },
+      result: {
+        data: {
+          listApprovedStudiesOfMyOrganization: [
+            {
+              _id: "controlled",
+              studyName: "controlled-study",
+              studyAbbreviation: "CS",
+              dbGaPID: null,
+              controlledAccess: true,
+            },
+          ],
+        },
+      },
+    };
+
+    const { getByRole, getByTestId, getByText } = render(
+      <CreateDataSubmissionDialog onCreate={jest.fn()} />,
+      {
+        wrapper: (p) => (
+          <TestParent
+            mocks={[ApprovedStudyNoDbGaPID, ...listOrgsMocks]}
+            authCtxState={{ ...baseAuthCtx, user: { ...baseUser, role: "Submitter" } }}
+            {...p}
+          />
+        ),
+      }
+    );
+
+    // Simulate opening dialog
+    const openDialogButton = getByRole("button", { name: "Create a Data Submission" });
+
+    await waitFor(() => expect(openDialogButton).toBeEnabled());
+
+    userEvent.click(openDialogButton);
+
+    await waitFor(() => {
+      expect(getByTestId("create-data-submission-dialog-study-id-input")).toBeInTheDocument();
+    });
+
+    const studySelectButton = within(
+      getByTestId("create-data-submission-dialog-study-id-input")
+    ).getByRole("button");
+
+    userEvent.click(studySelectButton);
+
+    await waitFor(() => {
+      expect(studySelectButton).toHaveAttribute("aria-expanded", "true");
+    });
+
+    userEvent.click(getByText("CS"));
+
+    userEvent.hover(getByTestId("create-data-submission-dialog-dbgap-id-input"));
+
+    await waitFor(() => {
+      expect(getByRole("tooltip")).toBeInTheDocument();
+    });
+
+    expect(getByRole("tooltip")).toHaveTextContent(
+      "dbGapID is required for controlled-access studies.",
+      { normalizeWhitespace: true }
+    );
+  });
+});

--- a/src/components/DataSubmissions/CreateDataSubmissionDialog.test.tsx
+++ b/src/components/DataSubmissions/CreateDataSubmissionDialog.test.tsx
@@ -63,7 +63,6 @@ const createSubmissionMocks: MockedResponse<CreateSubmissionResp>[] = [
         studyID: "study1",
         dataCommons: "CDS",
         name: "Test Submission",
-        dbGaPID: "phsTEST001",
         intention: "New/Update",
         dataType: "Metadata and Data Files",
       },
@@ -232,15 +231,6 @@ describe("Basic Functionality", () => {
 
     expect(studySelectButton).toHaveTextContent("SN");
 
-    // Simulate typing into dbGaPID input
-    const dbGaPIDWrapper = getByTestId("create-data-submission-dialog-dbgap-id-input");
-    const dbGaPIDInput = within(dbGaPIDWrapper).getByRole("textbox");
-    userEvent.type(dbGaPIDInput, "001");
-
-    await waitFor(() => {
-      expect(dbGaPIDInput).toHaveValue("phsTEST001");
-    });
-
     // Simulate typing into Submission Name input
     const submissionNameWrapper = getByTestId(
       "create-data-submission-dialog-submission-name-input"
@@ -258,18 +248,10 @@ describe("Basic Functionality", () => {
     userEvent.click(createButton);
 
     await waitFor(() => {
-      expect(handleCreate).toHaveBeenCalledTimes(1);
       expect(createButton).not.toBeInTheDocument();
     });
 
-    expect(handleCreate).toHaveBeenCalledWith({
-      studyID: "study1",
-      dataCommons: "CDS",
-      name: "Test Submission",
-      dbGaPID: "phsTEST001",
-      intention: "New/Update",
-      dataType: "Metadata and Data Files",
-    });
+    expect(handleCreate).toHaveBeenCalledTimes(1);
   });
 
   it("should disable open dialog button and show tooltip if user has 'Inactive' org", async () => {
@@ -343,72 +325,7 @@ describe("Basic Functionality", () => {
     });
   });
 
-  it("handles form submission without onCreate defined", async () => {
-    const { getByTestId, getByRole, getByText } = render(
-      <TestParent authCtxState={{ ...baseAuthCtx, user: { ...baseUser, role: "Submitter" } }}>
-        <CreateDataSubmissionDialog onCreate={undefined} />
-      </TestParent>
-    );
-    // Simulate opening dialog
-    const openDialogButton = getByRole("button", { name: "Create a Data Submission" });
-    expect(openDialogButton).toBeInTheDocument();
-
-    await waitFor(() => expect(openDialogButton).toBeEnabled());
-
-    userEvent.click(openDialogButton);
-
-    await waitFor(() => {
-      expect(getByTestId("create-submission-dialog")).toBeInTheDocument();
-      const studySelectInput = getByTestId("create-data-submission-dialog-study-id-input");
-      expect(studySelectInput).toBeInTheDocument();
-    });
-
-    // Simulate selecting study from dropdown
-    const studySelectButton = within(
-      getByTestId("create-data-submission-dialog-study-id-input")
-    ).getByRole("button");
-    expect(studySelectButton).toBeInTheDocument();
-
-    userEvent.click(studySelectButton);
-
-    await waitFor(() => {
-      expect(studySelectButton).toHaveAttribute("aria-expanded", "true");
-    });
-    userEvent.click(getByText("SN"));
-
-    expect(studySelectButton).toHaveTextContent("SN");
-
-    // Simulate typing into dbGaPID input
-    const dbGaPIDWrapper = getByTestId("create-data-submission-dialog-dbgap-id-input");
-    const dbGaPIDInput = within(dbGaPIDWrapper).getByRole("textbox");
-    userEvent.type(dbGaPIDInput, "001");
-
-    await waitFor(() => {
-      expect(dbGaPIDInput).toHaveValue("phsTEST001");
-    });
-
-    // Simulate typing into Submission Name input
-    const submissionNameWrapper = getByTestId(
-      "create-data-submission-dialog-submission-name-input"
-    );
-    const submissionNameInput = within(submissionNameWrapper).getByRole("textbox");
-    userEvent.type(submissionNameInput, "Test Submission");
-
-    await waitFor(() => {
-      expect(submissionNameInput).toHaveValue("Test Submission");
-    });
-
-    // Simulate creating the new data submission and closing the dialog
-    const createButton = getByRole("button", { name: "Create" });
-    expect(createButton).toBeInTheDocument();
-    userEvent.click(createButton);
-
-    await waitFor(() => {
-      expect(createButton).not.toBeInTheDocument();
-    });
-  });
-
-  it("should make dbGaP ID required if study is controlled access", async () => {
+  it("should only show the dbGaP ID if study is controlled access", async () => {
     const { getByText, getByRole, getByTestId } = render(
       <TestParent authCtxState={{ ...baseAuthCtx, user: { ...baseUser, role: "Submitter" } }}>
         <CreateDataSubmissionDialog onCreate={handleCreate} />
@@ -444,8 +361,7 @@ describe("Basic Functionality", () => {
     // Non-Controlled study selected
     expect(studySelectButton).toHaveTextContent("SN");
 
-    const dbGaPIDLabel = getByTestId("dbGaP-id-label");
-    expect(dbGaPIDLabel.textContent).toBe("dbGaP ID");
+    expect(getByTestId("dbGaP-id-label")).not.toBeVisible();
 
     userEvent.click(studySelectButton);
 
@@ -457,7 +373,7 @@ describe("Basic Functionality", () => {
     // Controlled study selected
     expect(studySelectButton).toHaveTextContent("CS");
 
-    expect(dbGaPIDLabel.textContent).toBe("dbGaP ID*");
+    expect(getByTestId("dbGaP-id-label")).toBeVisible();
   });
 
   it("sets dbGaPID to an empty string and isDbGapRequired to false when studyID is not found", async () => {
@@ -514,7 +430,6 @@ describe("Basic Functionality", () => {
             studyID: "study1",
             dataCommons: "CDS",
             name: "Test Submission",
-            dbGaPID: "phsTEST001",
             intention: "New/Update",
             dataType: "Metadata and Data Files",
           },
@@ -560,15 +475,6 @@ describe("Basic Functionality", () => {
 
     expect(studySelectButton).toHaveTextContent("SN");
 
-    // Simulate typing into dbGaPID input
-    const dbGaPIDWrapper = getByTestId("create-data-submission-dialog-dbgap-id-input");
-    const dbGaPIDInput = within(dbGaPIDWrapper).getByRole("textbox");
-    userEvent.type(dbGaPIDInput, "001");
-
-    await waitFor(() => {
-      expect(dbGaPIDInput).toHaveValue("phsTEST001");
-    });
-
     // Simulate typing into Submission Name input
     const submissionNameWrapper = getByTestId(
       "create-data-submission-dialog-submission-name-input"
@@ -603,7 +509,6 @@ describe("Basic Functionality", () => {
             studyID: "study1",
             dataCommons: "CDS",
             name: "Test Submission",
-            dbGaPID: "phsTEST001",
             intention: "New/Update",
             dataType: "Metadata and Data Files",
           },
@@ -650,15 +555,6 @@ describe("Basic Functionality", () => {
     userEvent.click(getByText("SN"));
 
     expect(studySelectButton).toHaveTextContent("SN");
-
-    // Simulate typing into dbGaPID input
-    const dbGaPIDWrapper = getByTestId("create-data-submission-dialog-dbgap-id-input");
-    const dbGaPIDInput = within(dbGaPIDWrapper).getByRole("textbox");
-    userEvent.type(dbGaPIDInput, "001");
-
-    await waitFor(() => {
-      expect(dbGaPIDInput).toHaveValue("phsTEST001");
-    });
 
     // Simulate typing into Submission Name input
     const submissionNameWrapper = getByTestId(
@@ -814,32 +710,6 @@ describe("Basic Functionality", () => {
     });
   });
 
-  it("sets dbGaPID to an empty string when not provided", async () => {
-    const { getByTestId, getByRole } = render(
-      <TestParent authCtxState={{ ...baseAuthCtx, user: { ...baseUser, role: "Submitter" } }}>
-        <CreateDataSubmissionDialog onCreate={handleCreate} />
-      </TestParent>
-    );
-    // Simulate opening dialog
-    const openDialogButton = getByRole("button", { name: "Create a Data Submission" });
-    expect(openDialogButton).toBeInTheDocument();
-
-    await waitFor(() => expect(openDialogButton).toBeEnabled());
-
-    userEvent.click(openDialogButton);
-
-    await waitFor(() => {
-      expect(getByTestId("create-submission-dialog")).toBeInTheDocument();
-      const studySelectInput = getByTestId("create-data-submission-dialog-study-id-input");
-      expect(studySelectInput).toBeInTheDocument();
-    });
-
-    const dbGaPIDWrapper = getByTestId("create-data-submission-dialog-dbgap-id-input");
-    const dbGaPIDInput = within(dbGaPIDWrapper).getByRole("textbox");
-
-    expect(dbGaPIDInput).toHaveValue("");
-  });
-
   it("sets name to an empty string when not provided", async () => {
     const { getByTestId, getByRole } = render(
       <TestParent authCtxState={{ ...baseAuthCtx, user: { ...baseUser, role: "Submitter" } }}>
@@ -940,10 +810,6 @@ describe("Basic Functionality", () => {
 
     expect(studySelectButton).toHaveTextContent("SN");
 
-    const dbGaPIDWrapper = getByTestId("create-data-submission-dialog-dbgap-id-input");
-    const dbGaPIDInput = within(dbGaPIDWrapper).getByRole("textbox");
-    userEvent.type(dbGaPIDInput, "001");
-
     const submissionNameWrapper = getByTestId(
       "create-data-submission-dialog-submission-name-input"
     );
@@ -956,64 +822,12 @@ describe("Basic Functionality", () => {
       expect(getByText("This field contains invalid characters")).toBeInTheDocument();
     });
   });
-
-  it("should show an error if the dbGaP ID contains emojis", async () => {
-    const { getByTestId, getByRole, getByText } = render(
-      <CreateDataSubmissionDialog onCreate={handleCreate} />,
-      {
-        wrapper: (p) => (
-          <TestParent
-            mocks={baseMocks}
-            authCtxState={{ ...baseAuthCtx, user: { ...baseUser, role: "Submitter" } }}
-            {...p}
-          />
-        ),
-      }
-    );
-
-    const openDialogButton = getByRole("button", { name: "Create a Data Submission" });
-    expect(openDialogButton).toBeInTheDocument();
-
-    await waitFor(() => expect(openDialogButton).toBeEnabled());
-
-    userEvent.click(openDialogButton);
-
-    await waitFor(() => {
-      expect(getByTestId("create-submission-dialog")).toBeInTheDocument();
-    });
-
-    await waitFor(() => {
-      expect(getByTestId("create-data-submission-dialog-study-id-input")).toBeEnabled();
-    });
-
-    const studySelectButton = within(
-      getByTestId("create-data-submission-dialog-study-id-input")
-    ).getByRole("button");
-    expect(studySelectButton).toBeInTheDocument();
-
-    userEvent.click(studySelectButton);
-
-    await waitFor(() => {
-      expect(studySelectButton).toHaveAttribute("aria-expanded", "true");
-    });
-    userEvent.click(getByText("SN"));
-
-    expect(studySelectButton).toHaveTextContent("SN");
-
-    const dbGaPIDWrapper = getByTestId("create-data-submission-dialog-dbgap-id-input");
-    const dbGaPIDInput = within(dbGaPIDWrapper).getByRole("textbox");
-    userEvent.type(dbGaPIDInput, "🚧");
-
-    const submissionNameWrapper = getByTestId(
-      "create-data-submission-dialog-submission-name-input"
-    );
-    const submissionNameInput = within(submissionNameWrapper).getByRole("textbox");
-    userEvent.type(submissionNameInput, "this is a valid name");
-
-    userEvent.click(getByText("Create"));
-
-    await waitFor(() => {
-      expect(getByText("This field contains invalid characters")).toBeInTheDocument();
-    });
-  });
 });
+
+// TODO: Implement the following tests
+
+it.todo("should disable the Create button if dbGaP ID is required and not added to the study");
+
+it.todo("should show an alert icon next to dbGaPID if it is required and not added to the study");
+
+it.todo("should hide the dbGaPID field if controlledAccess is false");

--- a/src/components/DataSubmissions/CreateDataSubmissionDialog.tsx
+++ b/src/components/DataSubmissions/CreateDataSubmissionDialog.tsx
@@ -501,7 +501,7 @@ const CreateDataSubmissionDialog: FC<Props> = ({ onCreate }) => {
                   inputProps={{ "aria-labelledby": "dbGaPID" }}
                   placeholder="<Not Provided>"
                   data-testid="create-data-submission-dialog-dbgap-id-input"
-                  disabled
+                  readOnly
                 />
               </Tooltip>
               {!dbGaPID && (

--- a/src/components/DataSubmissions/CreateDataSubmissionDialog.tsx
+++ b/src/components/DataSubmissions/CreateDataSubmissionDialog.tsx
@@ -5,7 +5,6 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
-  Grid,
   IconButton,
   MenuItem,
   Stack,
@@ -375,26 +374,20 @@ const CreateDataSubmissionDialog: FC<Props> = ({ onCreate }) => {
                 control={control}
                 rules={{ required: "This field is required" }}
                 render={({ field }) => (
-                  <Grid container>
-                    <StyledRadioInput
-                      {...field}
-                      id="create-data-submission-dialog-submission-type"
-                      label="Submission Type"
-                      value={field.value}
-                      options={submissionTypeOptions}
-                      gridWidth={12}
-                      aria-describedby="submission-intention-helper-text"
-                      data-testid="create-data-submission-dialog-submission-type-input"
-                      inline
-                      required
-                      row
-                    />
-                  </Grid>
+                  <StyledRadioInput
+                    {...field}
+                    id="create-data-submission-dialog-submission-type"
+                    label="Submission Type"
+                    value={field.value}
+                    options={submissionTypeOptions}
+                    aria-describedby="submission-intention-helper-text"
+                    data-testid="create-data-submission-dialog-submission-type-input"
+                    inline
+                    required
+                    row
+                  />
                 )}
               />
-              <StyledHelperText id="submission-intention-helper-text">
-                {errors?.intention?.message}
-              </StyledHelperText>
             </StyledField>
             <StyledField>
               <Controller
@@ -402,21 +395,18 @@ const CreateDataSubmissionDialog: FC<Props> = ({ onCreate }) => {
                 control={control}
                 rules={{ required: "This field is required" }}
                 render={({ field }) => (
-                  <Grid container>
-                    <StyledRadioInput
-                      {...field}
-                      id="create-data-submission-dialog-data-type"
-                      label="Data Type"
-                      value={field.value}
-                      options={submissionDataTypeOptions}
-                      gridWidth={12}
-                      aria-describedby="submission-data-type-helper-text"
-                      data-testid="create-data-submission-dialog-data-type-input"
-                      inline
-                      required
-                      row
-                    />
-                  </Grid>
+                  <StyledRadioInput
+                    {...field}
+                    id="create-data-submission-dialog-data-type"
+                    label="Data Type"
+                    value={field.value}
+                    options={submissionDataTypeOptions}
+                    aria-describedby="submission-data-type-helper-text"
+                    data-testid="create-data-submission-dialog-data-type-input"
+                    inline
+                    required
+                    row
+                  />
                 )}
               />
               <StyledHelperText id="submission-data-type-helper-text">

--- a/src/components/DataSubmissions/CreateDataSubmissionDialog.tsx
+++ b/src/components/DataSubmissions/CreateDataSubmissionDialog.tsx
@@ -1,6 +1,5 @@
 import { FC, useEffect, useMemo, useState } from "react";
 import {
-  Box,
   Button,
   Dialog,
   DialogActions,
@@ -145,14 +144,14 @@ const StyledCloseDialogButton = styled(IconButton)(() => ({
   },
 }));
 
-const StyledFormWrapper = styled(Box)(() => ({
+const StyledFormStack = styled(Stack)<{ component: React.ElementType }>({
   width: "485px",
   marginTop: "24px",
   "& .formControl": {
     marginTop: "0 !important",
     marginBottom: "0 !important",
   },
-}));
+});
 
 const StyledRadioInput = styled(RadioInput)(() => ({
   marginLeft: "2px",
@@ -355,181 +354,182 @@ const CreateDataSubmissionDialog: FC<Props> = ({ onCreate }) => {
           </Stack>
         </StyledDialogTitle>
         <StyledDialogContent>
-          <StyledFormWrapper>
-            <form id="create-submission-dialog-form" onSubmit={handleSubmit(onSubmit)}>
-              <Stack direction="column">
-                <StyledField>
-                  <Controller
-                    name="intention"
-                    control={control}
-                    rules={{ required: "This field is required" }}
-                    render={({ field }) => (
-                      <Grid container>
-                        <StyledRadioInput
-                          {...field}
-                          id="create-data-submission-dialog-submission-type"
-                          label="Submission Type"
-                          value={field.value}
-                          options={submissionTypeOptions}
-                          gridWidth={12}
-                          aria-describedby="submission-intention-helper-text"
-                          data-testid="create-data-submission-dialog-submission-type-input"
-                          inline
-                          required
-                          row
-                        />
-                      </Grid>
-                    )}
-                  />
-                  <StyledHelperText id="submission-intention-helper-text">
-                    {errors?.intention?.message}
-                  </StyledHelperText>
-                </StyledField>
-                <StyledField>
-                  <Controller
-                    name="dataType"
-                    control={control}
-                    rules={{ required: "This field is required" }}
-                    render={({ field }) => (
-                      <Grid container>
-                        <StyledRadioInput
-                          {...field}
-                          id="create-data-submission-dialog-data-type"
-                          label="Data Type"
-                          value={field.value}
-                          options={submissionDataTypeOptions}
-                          gridWidth={12}
-                          aria-describedby="submission-data-type-helper-text"
-                          data-testid="create-data-submission-dialog-data-type-input"
-                          inline
-                          required
-                          row
-                        />
-                      </Grid>
-                    )}
-                  />
-                  <StyledHelperText id="submission-data-type-helper-text">
-                    {errors?.intention?.message}
-                  </StyledHelperText>
-                </StyledField>
-                <StyledOrganizationField>
-                  <StyledLabel id="organization">Organization</StyledLabel>
-                  <StyledOutlinedInput
-                    value={user?.organization?.orgName}
-                    inputProps={{ "aria-labelledby": "organization" }}
-                    readOnly
-                  />
-                </StyledOrganizationField>
-                <StyledField>
-                  <StyledLabel id="dataCommons">
-                    Data Commons
-                    <StyledAsterisk />
-                  </StyledLabel>
-                  <Controller
-                    name="dataCommons"
-                    control={control}
-                    rules={{ required: "This field is required" }}
-                    render={({ field }) => (
-                      <StyledSelect
-                        {...field}
-                        value={field.value}
-                        MenuProps={{ disablePortal: true }}
-                        aria-describedby="submission-data-commons-helper-text"
-                        inputProps={{ "aria-labelledby": "dataCommons" }}
-                        data-testid="create-data-submission-dialog-data-commons-input"
-                      >
-                        {DataCommons.map((dc) => (
-                          <MenuItem key={dc.name} value={dc.name}>
-                            {dc.name}
-                          </MenuItem>
-                        ))}
-                      </StyledSelect>
-                    )}
-                  />
-                  <StyledHelperText id="submission-data-commons-helper-text">
-                    {errors?.dataCommons?.message}
-                  </StyledHelperText>
-                </StyledField>
-                <StyledField>
-                  <StyledLabel id="study">
-                    Study
-                    <StyledAsterisk />
-                  </StyledLabel>
-                  <Controller
-                    name="studyID"
-                    control={control}
-                    rules={{ required: "This field is required" }}
-                    render={({ field }) => (
-                      <StyledSelect
-                        {...field}
-                        value={field.value || ""}
-                        MenuProps={{ disablePortal: true }}
-                        aria-describedby="submission-study-abbreviation-helper-text"
-                        inputProps={{ "aria-labelledby": "study" }}
-                        data-testid="create-data-submission-dialog-study-id-input"
-                      >
-                        {approvedStudiesData?.listApprovedStudiesOfMyOrganization?.map((study) => (
-                          <MenuItem key={study._id} value={study._id}>
-                            {study.studyAbbreviation}
-                          </MenuItem>
-                        ))}
-                      </StyledSelect>
-                    )}
-                  />
-                  <StyledHelperText id="submission-study-abbreviation-helper-text">
-                    {errors?.studyID?.message}
-                  </StyledHelperText>
-                </StyledField>
-                <StyledField sx={{ display: isDbGapRequired ? "flex" : "none" }}>
-                  <StyledLabel id="dbGaPID" data-testid="dbGaP-id-label">
-                    dbGaP ID
-                    <StyledAsterisk />
-                  </StyledLabel>
-                  <Tooltip
-                    title="dbGapID is required for controlled-access studies"
-                    open={undefined}
-                    disableHoverListener={false}
-                    placement="top"
-                    data-testid="dbGaPID-tooltip"
-                    arrow
-                  >
-                    <StyledOutlinedInput
-                      value={dbGaPID}
-                      inputProps={{ "aria-labelledby": "dbGaPID" }}
-                      placeholder="<Not Provided>"
-                      data-testid="create-data-submission-dialog-dbgap-id-input"
-                      disabled
+          <StyledFormStack
+            direction="column"
+            component="form"
+            id="create-submission-dialog-form"
+            onSubmit={handleSubmit(onSubmit)}
+          >
+            <StyledField>
+              <Controller
+                name="intention"
+                control={control}
+                rules={{ required: "This field is required" }}
+                render={({ field }) => (
+                  <Grid container>
+                    <StyledRadioInput
+                      {...field}
+                      id="create-data-submission-dialog-submission-type"
+                      label="Submission Type"
+                      value={field.value}
+                      options={submissionTypeOptions}
+                      gridWidth={12}
+                      aria-describedby="submission-intention-helper-text"
+                      data-testid="create-data-submission-dialog-submission-type-input"
+                      inline
+                      required
+                      row
                     />
-                    {/* TODO: Need the icon and tooltip from CRDCDH-1986 */}
-                  </Tooltip>
-                  <StyledHelperText />
-                </StyledField>
-                <StyledField>
-                  <StyledLabel id="submissionName">
-                    Submission Name
-                    <StyledAsterisk />
-                  </StyledLabel>
-                  <StyledOutlinedInputMultiline
-                    {...register("name", {
-                      maxLength: 25,
-                      validate: {
-                        empty: validateEmpty,
-                        emoji: validateEmoji,
-                      },
-                    })}
-                    rows={3}
-                    placeholder="25 characters allowed"
-                    inputProps={{ maxLength: 25, "aria-labelledby": "submissionName" }}
-                    aria-describedby="submission-name-helper-text"
-                    data-testid="create-data-submission-dialog-submission-name-input"
-                  />
-                  <StyledHelperText id="submission-name-helper-text">
-                    {errors?.name?.message}
-                  </StyledHelperText>
-                </StyledField>
-              </Stack>
-            </form>
-          </StyledFormWrapper>
+                  </Grid>
+                )}
+              />
+              <StyledHelperText id="submission-intention-helper-text">
+                {errors?.intention?.message}
+              </StyledHelperText>
+            </StyledField>
+            <StyledField>
+              <Controller
+                name="dataType"
+                control={control}
+                rules={{ required: "This field is required" }}
+                render={({ field }) => (
+                  <Grid container>
+                    <StyledRadioInput
+                      {...field}
+                      id="create-data-submission-dialog-data-type"
+                      label="Data Type"
+                      value={field.value}
+                      options={submissionDataTypeOptions}
+                      gridWidth={12}
+                      aria-describedby="submission-data-type-helper-text"
+                      data-testid="create-data-submission-dialog-data-type-input"
+                      inline
+                      required
+                      row
+                    />
+                  </Grid>
+                )}
+              />
+              <StyledHelperText id="submission-data-type-helper-text">
+                {errors?.intention?.message}
+              </StyledHelperText>
+            </StyledField>
+            <StyledOrganizationField>
+              <StyledLabel id="organization">Organization</StyledLabel>
+              <StyledOutlinedInput
+                value={user?.organization?.orgName}
+                inputProps={{ "aria-labelledby": "organization" }}
+                readOnly
+              />
+            </StyledOrganizationField>
+            <StyledField>
+              <StyledLabel id="dataCommons">
+                Data Commons
+                <StyledAsterisk />
+              </StyledLabel>
+              <Controller
+                name="dataCommons"
+                control={control}
+                rules={{ required: "This field is required" }}
+                render={({ field }) => (
+                  <StyledSelect
+                    {...field}
+                    value={field.value}
+                    MenuProps={{ disablePortal: true }}
+                    aria-describedby="submission-data-commons-helper-text"
+                    inputProps={{ "aria-labelledby": "dataCommons" }}
+                    data-testid="create-data-submission-dialog-data-commons-input"
+                  >
+                    {DataCommons.map((dc) => (
+                      <MenuItem key={dc.name} value={dc.name}>
+                        {dc.name}
+                      </MenuItem>
+                    ))}
+                  </StyledSelect>
+                )}
+              />
+              <StyledHelperText id="submission-data-commons-helper-text">
+                {errors?.dataCommons?.message}
+              </StyledHelperText>
+            </StyledField>
+            <StyledField>
+              <StyledLabel id="study">
+                Study
+                <StyledAsterisk />
+              </StyledLabel>
+              <Controller
+                name="studyID"
+                control={control}
+                rules={{ required: "This field is required" }}
+                render={({ field }) => (
+                  <StyledSelect
+                    {...field}
+                    value={field.value || ""}
+                    MenuProps={{ disablePortal: true }}
+                    aria-describedby="submission-study-abbreviation-helper-text"
+                    inputProps={{ "aria-labelledby": "study" }}
+                    data-testid="create-data-submission-dialog-study-id-input"
+                  >
+                    {approvedStudiesData?.listApprovedStudiesOfMyOrganization?.map((study) => (
+                      <MenuItem key={study._id} value={study._id}>
+                        {study.studyAbbreviation}
+                      </MenuItem>
+                    ))}
+                  </StyledSelect>
+                )}
+              />
+              <StyledHelperText id="submission-study-abbreviation-helper-text">
+                {errors?.studyID?.message}
+              </StyledHelperText>
+            </StyledField>
+            <StyledField sx={{ display: isDbGapRequired ? "flex" : "none" }}>
+              <StyledLabel id="dbGaPID" data-testid="dbGaP-id-label">
+                dbGaP ID
+                <StyledAsterisk />
+              </StyledLabel>
+              <Tooltip
+                title="dbGapID is required for controlled-access studies"
+                open={undefined}
+                disableHoverListener={false}
+                placement="top"
+                data-testid="dbGaPID-tooltip"
+                arrow
+              >
+                <StyledOutlinedInput
+                  value={dbGaPID}
+                  inputProps={{ "aria-labelledby": "dbGaPID" }}
+                  placeholder="<Not Provided>"
+                  data-testid="create-data-submission-dialog-dbgap-id-input"
+                  disabled
+                />
+                {/* TODO: Need the icon and tooltip from CRDCDH-1986 */}
+              </Tooltip>
+              <StyledHelperText />
+            </StyledField>
+            <StyledField>
+              <StyledLabel id="submissionName">
+                Submission Name
+                <StyledAsterisk />
+              </StyledLabel>
+              <StyledOutlinedInputMultiline
+                {...register("name", {
+                  maxLength: 25,
+                  validate: {
+                    empty: validateEmpty,
+                    emoji: validateEmoji,
+                  },
+                })}
+                rows={3}
+                placeholder="25 characters allowed"
+                inputProps={{ maxLength: 25, "aria-labelledby": "submissionName" }}
+                aria-describedby="submission-name-helper-text"
+                data-testid="create-data-submission-dialog-submission-name-input"
+              />
+              <StyledHelperText id="submission-name-helper-text">
+                {errors?.name?.message}
+              </StyledHelperText>
+            </StyledField>
+          </StyledFormStack>
         </StyledDialogContent>
         <StyledDialogActions>
           <StyledDialogButton

--- a/src/components/DataSubmissions/CreateDataSubmissionDialog.tsx
+++ b/src/components/DataSubmissions/CreateDataSubmissionDialog.tsx
@@ -146,17 +146,8 @@ const StyledCloseDialogButton = styled(IconButton)(() => ({
 }));
 
 const StyledFormWrapper = styled(Box)(() => ({
-  alignSelf: "center",
   width: "485px",
-  minHeight: "450px",
   marginTop: "24px",
-  fontSize: "16px",
-  fontWeight: 700,
-  lineHeight: "20px",
-  letterSpacing: 0,
-  textAlign: "left",
-  display: "flex",
-  flexDirection: "column",
   "& .formControl": {
     marginTop: "0 !important",
     marginBottom: "0 !important",
@@ -381,10 +372,11 @@ const CreateDataSubmissionDialog: FC<Props> = ({ onCreate }) => {
                           value={field.value}
                           options={submissionTypeOptions}
                           gridWidth={12}
-                          required
-                          row
                           aria-describedby="submission-intention-helper-text"
                           data-testid="create-data-submission-dialog-submission-type-input"
+                          inline
+                          required
+                          row
                         />
                       </Grid>
                     )}
@@ -407,10 +399,11 @@ const CreateDataSubmissionDialog: FC<Props> = ({ onCreate }) => {
                           value={field.value}
                           options={submissionDataTypeOptions}
                           gridWidth={12}
-                          required
-                          row
                           aria-describedby="submission-data-type-helper-text"
                           data-testid="create-data-submission-dialog-data-type-input"
+                          inline
+                          required
+                          row
                         />
                       </Grid>
                     )}
@@ -507,7 +500,7 @@ const CreateDataSubmissionDialog: FC<Props> = ({ onCreate }) => {
                       data-testid="create-data-submission-dialog-dbgap-id-input"
                       disabled
                     />
-                    {/* TODO: Need the icon from CRDCDH-1996 */}
+                    {/* TODO: Need the icon and tooltip from CRDCDH-1986 */}
                   </Tooltip>
                   <StyledHelperText />
                 </StyledField>

--- a/src/components/DataSubmissions/CreateDataSubmissionDialog.tsx
+++ b/src/components/DataSubmissions/CreateDataSubmissionDialog.tsx
@@ -147,10 +147,6 @@ const StyledCloseDialogButton = styled(IconButton)(() => ({
 const StyledFormStack = styled(Stack)<{ component: React.ElementType }>({
   width: "485px",
   marginTop: "24px",
-  "& .formControl": {
-    marginTop: "0 !important",
-    marginBottom: "0 !important",
-  },
 });
 
 const StyledRadioInput = styled(RadioInput)(() => ({

--- a/src/components/DataSubmissions/CreateDataSubmissionDialog.tsx
+++ b/src/components/DataSubmissions/CreateDataSubmissionDialog.tsx
@@ -24,6 +24,7 @@ import {
 import RadioInput, { Option } from "./RadioInput";
 import { DataCommons } from "../../config/DataCommons";
 import { ReactComponent as CloseIconSvg } from "../../assets/icons/close_icon.svg";
+import { ReactComponent as BellIcon } from "../../assets/icons/filled_bell_icon.svg";
 import { Status as AuthStatus, useAuthContext } from "../Contexts/AuthContext";
 import StyledSelect from "../StyledFormComponents/StyledSelect";
 import StyledOutlinedInput from "../StyledFormComponents/StyledOutlinedInput";
@@ -170,6 +171,7 @@ const StyledField = styled("div")({
   alignItems: "flex-start",
   justifyContent: "center",
   flexDirection: "column",
+  position: "relative",
 });
 
 const StyledOrganizationField = styled(StyledField)({
@@ -189,6 +191,13 @@ const StyledTooltipWrapper = styled(Stack)({
   position: "relative",
   bottom: "30px",
   right: "50px",
+});
+
+const StyledBellIcon = styled(BellIcon)({
+  width: "18px",
+  position: "absolute",
+  right: "-28px",
+  color: "#D82F00",
 });
 
 type Props = {
@@ -488,11 +497,11 @@ const CreateDataSubmissionDialog: FC<Props> = ({ onCreate }) => {
                 <StyledAsterisk />
               </StyledLabel>
               <Tooltip
-                title="dbGapID is required for controlled-access studies"
+                title="dbGapID is required for controlled-access studies."
                 open={undefined}
                 disableHoverListener={false}
                 placement="top"
-                data-testid="dbGaPID-tooltip"
+                disableInteractive
                 arrow
               >
                 <StyledOutlinedInput
@@ -502,8 +511,26 @@ const CreateDataSubmissionDialog: FC<Props> = ({ onCreate }) => {
                   data-testid="create-data-submission-dialog-dbgap-id-input"
                   disabled
                 />
-                {/* TODO: Need the icon and tooltip from CRDCDH-1986 */}
               </Tooltip>
+              {!dbGaPID && (
+                <Tooltip
+                  title={
+                    <span>
+                      Please contact{" "}
+                      <a href="mailto:NCICRDC@mail.nih.gov" target="_blank" rel="noreferrer">
+                        NCICRDC@mail.nih.gov
+                      </a>{" "}
+                      to submit your dbGaP ID once you have registered your study on dbGap.
+                    </span>
+                  }
+                  open={undefined}
+                  disableHoverListener={false}
+                  placement="top"
+                  arrow
+                >
+                  <StyledBellIcon data-testid="pending-conditions-icon" />
+                </Tooltip>
+              )}
               <StyledHelperText />
             </StyledField>
             <StyledField>
@@ -535,7 +562,7 @@ const CreateDataSubmissionDialog: FC<Props> = ({ onCreate }) => {
           <StyledDialogButton
             type="submit"
             tabIndex={0}
-            id="createSubmissionDialogCreateButton"
+            data-testid="create-data-submission-dialog-create-button"
             form="create-submission-dialog-form"
             disabled={(isDbGapRequired && !dbGaPID) || isSubmitting}
           >
@@ -556,7 +583,7 @@ const CreateDataSubmissionDialog: FC<Props> = ({ onCreate }) => {
           <Tooltip
             placement="top"
             title="Your associated organization is inactive. You cannot create a data submission at this time."
-            open={undefined} // will use hoverListener to open
+            open={undefined}
             disableHoverListener={!userHasInactiveOrg}
           >
             <span>

--- a/src/components/DataSubmissions/CreateDataSubmissionDialog.tsx
+++ b/src/components/DataSubmissions/CreateDataSubmissionDialog.tsx
@@ -20,7 +20,7 @@ import {
   ListApprovedStudiesOfMyOrgResp,
   LIST_APPROVED_STUDIES_OF_MY_ORG,
 } from "../../graphql";
-import RadioInput, { Option } from "./RadioInput";
+import RadioInput, { RadioOption } from "./RadioInput";
 import { DataCommons } from "../../config/DataCommons";
 import { ReactComponent as CloseIconSvg } from "../../assets/icons/close_icon.svg";
 import { ReactComponent as BellIcon } from "../../assets/icons/filled_bell_icon.svg";
@@ -113,6 +113,7 @@ const StyledDialogActions = styled(DialogActions)({
 const StyledDialogError = styled(Typography)({
   color: "#c93f08",
   textAlign: "center",
+  marginTop: "25px",
 });
 
 const StyledDialogButton = styled(Button)({
@@ -247,7 +248,7 @@ const CreateDataSubmissionDialog: FC<Props> = ({ onCreate }) => {
     [user?.organization?.status]
   );
 
-  const submissionTypeOptions: Option[] = [
+  const submissionTypeOptions: RadioOption[] = [
     {
       label: "New/Update",
       value: "New/Update",
@@ -259,16 +260,22 @@ const CreateDataSubmissionDialog: FC<Props> = ({ onCreate }) => {
       label: "Delete",
       value: "Delete",
       disabled: false,
+      optionSx: {
+        marginLeft: "74.5px",
+      },
       tooltipContent:
         "Select this option if you want to delete existing data from the destination data commons.",
     },
   ];
 
-  const submissionDataTypeOptions: Option[] = [
+  const submissionDataTypeOptions: RadioOption[] = [
     {
       label: "Metadata and Data Files",
       value: "Metadata and Data Files",
       disabled: intention === "Delete",
+      optionSx: {
+        marginLeft: "38.2px",
+      },
       tooltipContent:
         "Select this option to create a submission that includes both metadata and data files.",
     },
@@ -364,7 +371,7 @@ const CreateDataSubmissionDialog: FC<Props> = ({ onCreate }) => {
             id="create-submission-dialog-form"
             onSubmit={handleSubmit(onSubmit)}
           >
-            <StyledField>
+            <StyledField sx={{ marginRight: "-80px" }}>
               <Controller
                 name="intention"
                 control={control}
@@ -376,7 +383,6 @@ const CreateDataSubmissionDialog: FC<Props> = ({ onCreate }) => {
                     label="Submission Type"
                     value={field.value}
                     options={submissionTypeOptions}
-                    aria-describedby="submission-intention-helper-text"
                     data-testid="create-data-submission-dialog-submission-type-input"
                     inline
                     required
@@ -385,7 +391,7 @@ const CreateDataSubmissionDialog: FC<Props> = ({ onCreate }) => {
                 )}
               />
             </StyledField>
-            <StyledField>
+            <StyledField sx={{ marginRight: "-80px" }}>
               <Controller
                 name="dataType"
                 control={control}

--- a/src/components/DataSubmissions/RadioInput.tsx
+++ b/src/components/DataSubmissions/RadioInput.tsx
@@ -6,6 +6,7 @@ import {
   RadioGroupProps,
   Stack,
   styled,
+  SxProps,
 } from "@mui/material";
 import { updateInputValidity } from "../../utils";
 import StyledRadioButton from "../Questionnaire/StyledRadioButton";
@@ -60,10 +61,11 @@ const StyledFormControlLabel = styled(FormControlLabel)(() => ({
   },
 }));
 
-export type Option = {
+export type RadioOption = {
   label: string;
   value: string;
   disabled?: boolean;
+  optionSx?: SxProps;
   tooltipContent: string | ReactNode;
 };
 
@@ -71,7 +73,7 @@ type Props = {
   label: string;
   name?: string;
   value: string | boolean;
-  options: Option[];
+  options: RadioOption[];
   id: string;
   inline?: boolean;
   helpText?: string;
@@ -124,7 +126,7 @@ const RadioInput = forwardRef<HTMLDivElement, Props>(
           id={radioId}
           {...rest}
         >
-          {options?.map((option: Option, idx: number) => (
+          {options?.map((option: RadioOption, idx: number) => (
             <StyledTooltip
               key={`${option.label}-${option.value}}`}
               title={option.tooltipContent}
@@ -133,6 +135,7 @@ const RadioInput = forwardRef<HTMLDivElement, Props>(
               <StyledFormControlLabel
                 value={option.value}
                 label={option.label}
+                sx={option.optionSx}
                 color="#1D91AB"
                 control={
                   <StyledRadioButton

--- a/src/components/DataSubmissions/RadioInput.tsx
+++ b/src/components/DataSubmissions/RadioInput.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useRef, useEffect, useId, forwardRef, ReactNode } from "react";
 import {
-  Grid,
   FormControl,
   FormControlLabel,
   RadioGroup,
@@ -14,11 +13,9 @@ import StyledTooltip from "../StyledFormComponents/StyledTooltip";
 import { StyledLabel } from "../Questionnaire/TextInput";
 import StyledAsterisk from "../StyledFormComponents/StyledAsterisk";
 
-const GridStyled = styled(Grid)({
-  "& .formControl": {
-    marginTop: "8px",
-    marginBottom: "4px",
-  },
+const StyledFormControl = styled(Stack)<{ component: React.ElementType }>({
+  marginTop: "0",
+  marginBottom: "0",
   "& .css-hsm3ra-MuiFormLabel-root": {
     color: "rgba(0, 0, 0, 0.6) !important",
   },
@@ -67,7 +64,7 @@ export type Option = {
   label: string;
   value: string;
   disabled?: boolean;
-  tooltipContent?: string | ReactNode;
+  tooltipContent: string | ReactNode;
 };
 
 type Props = {
@@ -82,8 +79,7 @@ type Props = {
 } & RadioGroupProps;
 
 /**
- * @deprecated Do not use this component, this is a legacy component copied from the Questionnaire with
- * many unused functionalities.
+ * @deprecated Do not use this component. It is deprecated and will be removed in a future release.
  */
 const RadioInput = forwardRef<HTMLDivElement, Props>(
   ({ label, name, value, options, id, inline, helpText, required, ...rest }, ref) => {
@@ -111,64 +107,46 @@ const RadioInput = forwardRef<HTMLDivElement, Props>(
     }, [value]);
 
     return (
-      <GridStyled md={12} xs={12} container>
-        <FormControl className="formControl">
-          <Stack direction={inline ? "row" : "column"} alignItems={inline ? "center" : "initial"}>
-            <StyledFormLabel className="radio-label" htmlFor={radioId}>
-              {label}
-              {required ? <StyledAsterisk /> : ""}
-            </StyledFormLabel>
-            <RadioGroup
-              ref={ref}
-              name={name}
-              value={val}
-              onChange={onChangeWrapper}
-              id={radioId}
-              {...rest}
+      <StyledFormControl
+        component={FormControl}
+        direction={inline ? "row" : "column"}
+        alignItems={inline ? "center" : "initial"}
+      >
+        <StyledFormLabel className="radio-label" htmlFor={radioId}>
+          {label}
+          {required ? <StyledAsterisk /> : ""}
+        </StyledFormLabel>
+        <RadioGroup
+          ref={ref}
+          name={name}
+          value={val}
+          onChange={onChangeWrapper}
+          id={radioId}
+          {...rest}
+        >
+          {options?.map((option: Option, idx: number) => (
+            <StyledTooltip
+              key={`${option.label}-${option.value}}`}
+              title={option.tooltipContent}
+              disableInteractive
             >
-              {options?.map((option: Option, idx: number) => {
-                const isFirstOption = idx === 0;
-
-                return !option.tooltipContent ? (
-                  <StyledFormControlLabel
-                    value={option.value}
-                    label={option.label}
-                    color="#1D91AB"
-                    control={
-                      <StyledRadioButton
-                        id={id.concat(`-${option.label}-radio-button`)}
-                        readOnly={option.disabled}
-                        disabled={option.disabled}
-                        {...(isFirstOption && { inputRef: radioGroupInputRef })}
-                      />
-                    }
+              <StyledFormControlLabel
+                value={option.value}
+                label={option.label}
+                color="#1D91AB"
+                control={
+                  <StyledRadioButton
+                    id={id.concat(`-${option.label}-radio-button`)}
+                    readOnly={option.disabled}
+                    disabled={option.disabled}
+                    {...(idx === 0 && { inputRef: radioGroupInputRef })}
                   />
-                ) : (
-                  <StyledTooltip
-                    key={`${option.label}-${option.value}}`}
-                    title={option.tooltipContent}
-                    disableInteractive
-                  >
-                    <StyledFormControlLabel
-                      value={option.value}
-                      label={option.label}
-                      color="#1D91AB"
-                      control={
-                        <StyledRadioButton
-                          id={id.concat(`-${option.label}-radio-button`)}
-                          readOnly={option.disabled}
-                          disabled={option.disabled}
-                          {...(isFirstOption && { inputRef: radioGroupInputRef })}
-                        />
-                      }
-                    />
-                  </StyledTooltip>
-                );
-              })}
-            </RadioGroup>
-          </Stack>
-        </FormControl>
-      </GridStyled>
+                }
+              />
+            </StyledTooltip>
+          ))}
+        </RadioGroup>
+      </StyledFormControl>
     );
   }
 );

--- a/src/components/DataSubmissions/RadioInput.tsx
+++ b/src/components/DataSubmissions/RadioInput.tsx
@@ -5,19 +5,16 @@ import {
   FormControlLabel,
   RadioGroup,
   RadioGroupProps,
-  FormHelperText,
   Stack,
   styled,
-  GridProps,
 } from "@mui/material";
 import { updateInputValidity } from "../../utils";
 import StyledRadioButton from "../Questionnaire/StyledRadioButton";
 import StyledTooltip from "../StyledFormComponents/StyledTooltip";
+import { StyledLabel } from "../Questionnaire/TextInput";
+import StyledAsterisk from "../StyledFormComponents/StyledAsterisk";
 
-const GridStyled = styled(Grid, {
-  shouldForwardProp: (prop) => prop !== "containerWidth",
-})<GridProps & { containerWidth?: string }>(({ containerWidth }) => ({
-  width: containerWidth,
+const GridStyled = styled(Grid)({
   "& .formControl": {
     marginTop: "8px",
     marginBottom: "4px",
@@ -45,22 +42,11 @@ const GridStyled = styled(Grid, {
   "& .displayNone": {
     display: "none !important",
   },
-}));
+});
 
-const StyledFormLabel = styled("label")(() => ({
-  fontWeight: 700,
-  fontSize: "16px",
-  lineHeight: "19.6px",
-  minHeight: "20px",
-  color: "#083A50",
+const StyledFormLabel = styled(StyledLabel)({
   marginRight: "10px",
-}));
-
-const StyledAsterisk = styled("span")(() => ({
-  marginLeft: "2px",
-  marginRight: "2px",
-  color: "#C93F08",
-}));
+});
 
 const StyledFormControlLabel = styled(FormControlLabel)(() => ({
   "&.MuiFormControlLabel-root": {
@@ -87,51 +73,29 @@ export type Option = {
 type Props = {
   label: string;
   name?: string;
-  containerWidth?: string;
   value: string | boolean;
   options: Option[];
   id: string;
   inline?: boolean;
   helpText?: string;
   required?: boolean;
-  readOnly?: boolean;
-  gridWidth?: 2 | 4 | 6 | 8 | 10 | 12;
-  parentProps?: GridProps;
 } & RadioGroupProps;
 
+/**
+ * @deprecated Do not use this component, this is a legacy component copied from the Questionnaire with
+ * many unused functionalities.
+ */
 const RadioInput = forwardRef<HTMLDivElement, Props>(
-  (
-    {
-      label,
-      name,
-      gridWidth,
-      containerWidth,
-      value,
-      options,
-      id,
-      inline,
-      helpText,
-      required,
-      readOnly,
-      parentProps,
-      ...rest
-    },
-    ref
-  ) => {
+  ({ label, name, value, options, id, inline, helpText, required, ...rest }, ref) => {
     const radioId = id || useId();
     const [val, setVal] = useState<string>(
       value?.toString() === "" || value?.toString() === undefined ? null : value?.toString()
     );
-    const [error, setError] = useState(false);
     const radioGroupInputRef = useRef<HTMLInputElement>(null);
 
     const onChangeWrapper = (event: React.ChangeEvent<HTMLInputElement>) => {
-      if (readOnly) {
-        return;
-      }
       const newValue = (event.target as HTMLInputElement).value;
       setVal(newValue === "" ? null : newValue);
-      setError(false);
     };
 
     useEffect(() => {
@@ -143,25 +107,16 @@ const RadioInput = forwardRef<HTMLDivElement, Props>(
     }, [val]);
 
     useEffect(() => {
-      const invalid = () => setError(true);
-
-      radioGroupInputRef.current?.addEventListener("invalid", invalid);
-      return () => {
-        radioGroupInputRef.current?.removeEventListener("invalid", invalid);
-      };
-    }, [radioGroupInputRef]);
-
-    useEffect(() => {
       setVal(value?.toString() ?? null);
     }, [value]);
 
     return (
-      <GridStyled md={gridWidth || 6} xs={12} item containerWidth={containerWidth} {...parentProps}>
-        <FormControl className="formControl" error={error}>
+      <GridStyled md={12} xs={12} container>
+        <FormControl className="formControl">
           <Stack direction={inline ? "row" : "column"} alignItems={inline ? "center" : "initial"}>
             <StyledFormLabel className="radio-label" htmlFor={radioId}>
               {label}
-              {required ? <StyledAsterisk>*</StyledAsterisk> : ""}
+              {required ? <StyledAsterisk /> : ""}
             </StyledFormLabel>
             <RadioGroup
               ref={ref}
@@ -169,7 +124,6 @@ const RadioInput = forwardRef<HTMLDivElement, Props>(
               value={val}
               onChange={onChangeWrapper}
               id={radioId}
-              data-type="string"
               {...rest}
             >
               {options?.map((option: Option, idx: number) => {
@@ -183,7 +137,7 @@ const RadioInput = forwardRef<HTMLDivElement, Props>(
                     control={
                       <StyledRadioButton
                         id={id.concat(`-${option.label}-radio-button`)}
-                        readOnly={readOnly || option.disabled}
+                        readOnly={option.disabled}
                         disabled={option.disabled}
                         {...(isFirstOption && { inputRef: radioGroupInputRef })}
                       />
@@ -193,6 +147,7 @@ const RadioInput = forwardRef<HTMLDivElement, Props>(
                   <StyledTooltip
                     key={`${option.label}-${option.value}}`}
                     title={option.tooltipContent}
+                    disableInteractive
                   >
                     <StyledFormControlLabel
                       value={option.value}
@@ -201,7 +156,7 @@ const RadioInput = forwardRef<HTMLDivElement, Props>(
                       control={
                         <StyledRadioButton
                           id={id.concat(`-${option.label}-radio-button`)}
-                          readOnly={readOnly || option.disabled}
+                          readOnly={option.disabled}
                           disabled={option.disabled}
                           {...(isFirstOption && { inputRef: radioGroupInputRef })}
                         />
@@ -212,9 +167,6 @@ const RadioInput = forwardRef<HTMLDivElement, Props>(
               })}
             </RadioGroup>
           </Stack>
-          <FormHelperText className={(!readOnly && error ? "" : "displayNone") || ""}>
-            {(!readOnly && error ? "This field is required" : null) || " "}
-          </FormHelperText>
         </FormControl>
       </GridStyled>
     );

--- a/src/graphql/createSubmission.ts
+++ b/src/graphql/createSubmission.ts
@@ -5,7 +5,6 @@ export const mutation = gql`
     $studyID: String!
     $dataCommons: String!
     $name: String!
-    $dbGaPID: String
     $intention: String!
     $dataType: String!
   ) {
@@ -13,7 +12,6 @@ export const mutation = gql`
       studyID: $studyID
       dataCommons: $dataCommons
       name: $name
-      dbGaPID: $dbGaPID
       intention: $intention
       dataType: $dataType
     ) {
@@ -28,7 +26,6 @@ export type Input = {
   studyID: string;
   dataCommons: string;
   name: string;
-  dbGaPID: string | null;
   intention: SubmissionIntention;
   dataType: SubmissionDataType;
 };


### PR DESCRIPTION
### Overview

This PR extends the "conditionally approved study" functionality by restricting Data Submission creation for a controlledAccess study that has no dbGaPID provided yet. 

> [!Warning]
> This PR marks the Data Submission's "RadioInput" component as deprecated. This component was copied directly from the Questionnaire, and is mostly legacy code. It's only used on the Create a Data Submission dialog, but should not be used going forward.

### Change Details (Specifics)

- Autofill dbGaPID field for controlled access studies, and mark it as readOnly (always)
- If no dbGaPID is populated, show an error next to the dbGaPID field with a tooltip
- Cleanup unused code from RadioInput and fine-tune it for the creation dialog use-case
- Cleanup unnecessary component nesting in the creation dialog
- Refactor the "createSubmission" handler functionality to simplify it for our current use-case
- Update test coverage for changes

### Related Ticket(s)

CRDCDH-1988 (Task)
CRDCDH-1851 (US)
