### PR TITLE
CRDCDH-2067 Prevent invalid collaborators from being re-added

### DIFF
--- a/src/components/Contexts/CollaboratorsContext.test.tsx
+++ b/src/components/Contexts/CollaboratorsContext.test.tsx
@@ -813,5 +813,15 @@ describe("CollaboratorsContext", () => {
       existingCol.collaboratorName
     );
     expect(result.current.currentCollaborators[0].Organization).toBe(existingCol.Organization);
+
+    act(() => {
+      result.current.handleRemoveCollaborator(0);
+    });
+
+    // Verify preventing re-adding invalid potential collaborator
+    await waitFor(() => {
+      expect(result.current.currentCollaborators.length).toBe(1);
+      expect(result.current.maxCollaborators).toBe(1);
+    });
   });
 });

--- a/src/components/Contexts/CollaboratorsContext.tsx
+++ b/src/components/Contexts/CollaboratorsContext.tsx
@@ -83,7 +83,6 @@ export const CollaboratorsProvider: FC<ProviderProps> = ({ children }) => {
   const { enqueueSnackbar } = useSnackbar();
 
   const [potentialCollaborators, setPotentialCollaborators] = useState<Collaborator[]>([]);
-  const [maxCollaborators, setMaxCollaborators] = useState<number>(0);
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<ApolloError | null>(null);
   const [currentCollaborators, setCurrentCollaborators] = useState<Collaborator[]>([
@@ -92,26 +91,27 @@ export const CollaboratorsProvider: FC<ProviderProps> = ({ children }) => {
 
   const submissionID = submissionData?.getSubmission?._id;
 
+  // Collaborators that are no longer considered a 'potential collaborator' from submission
+  const unavailableCollaborators = submissionData?.getSubmission?.collaborators
+    ?.map((c) => c.collaboratorID)
+    ?.filter((c) => !potentialCollaborators?.map((pc) => pc.collaboratorID)?.includes(c));
+
+  const maxCollaborators = useMemo(() => {
+    const totalPotential = potentialCollaborators?.length || 0;
+    const totalRemaining =
+      unavailableCollaborators?.filter(
+        (uc) => currentCollaborators?.map((c) => c.collaboratorID)?.includes(uc)
+      )?.length || 0;
+
+    return totalPotential + totalRemaining;
+  }, [unavailableCollaborators, currentCollaborators, potentialCollaborators]);
+
   const [loadPotentialCollaboratorsQuery] = useLazyQuery<
     ListPotentialCollaboratorsResp,
     ListPotentialCollaboratorsInput
   >(LIST_POTENTIAL_COLLABORATORS, {
     fetchPolicy: "cache-and-network",
     onCompleted: (data) => {
-      const potentialCollaboratorsIDs = (data?.listPotentialCollaborators || [])?.map(
-        (pc) => pc._id
-      );
-      const submissionCollaborators = submissionData?.getSubmission?.collaborators || [];
-
-      // Find collaborators in submission that are not in potential collaborators
-      const remaining = submissionCollaborators?.filter(
-        (c) => !potentialCollaboratorsIDs.includes(c.collaboratorID)
-      );
-
-      const totalPotential = data?.listPotentialCollaborators?.length || 0;
-      const totalRemaining = remaining?.length || 0;
-      setMaxCollaborators(totalPotential + totalRemaining);
-
       const collaborators = (data?.listPotentialCollaborators || [])?.map((user) =>
         userToCollaborator(user)
       );


### PR DESCRIPTION
### Overview

When an invalid collaborator is removed, it shouldn't allow the user to re-add them. Therefore, the maxCollaborators logic was updated to take this into account to prevent showing an empty dropdown.

### Change Details (Specifics)

- Kept track of all 'unavailable' or invalid collaborators
- Used that as well as the ones currently displaying as a row. Once the invalid collaborator row is removed, it will lower the maxCollaborators count as well to prevent adding that row back

### Related Ticket(s)

[CRDCDH-2067](https://tracker.nci.nih.gov/browse/CRDCDH-2067) (Bug)
