### PR TITLE
CRDCDH-2083 Fix Cancer Types Half-Filled Input

### DIFF
--- a/src/components/Questionnaire/CustomAutocomplete.tsx
+++ b/src/components/Questionnaire/CustomAutocomplete.tsx
@@ -25,6 +25,7 @@ const StyledFormControl = styled(FormControl)({
 
 const StyledTag = styled("div")({
   paddingLeft: "12px",
+  position: "absolute",
 });
 
 const ProxySelect = styled("select")({


### PR DESCRIPTION
### Overview

This PR restores the disabled background color on the Cancer Types autocomplete. I think this issue was introduced in #499, but I'm not 100% sure. 

<img width="509" alt="Screenshot 2024-11-29 at 10 20 09 AM" src="https://github.com/user-attachments/assets/2fae77bf-78c0-4177-8814-e28ed711a41f">

### Change Details (Specifics)

N/A

### Related Ticket(s)

CRDCDH-2083 (Bug)
