### PR TITLE
CRDCDH-1990 Hotfix to remove Federal Lead Review actions from the 'Submitted' status 

### DIFF
--- a/src/utils/formModeUtils.test.ts
+++ b/src/utils/formModeUtils.test.ts
@@ -112,12 +112,10 @@ describe("getFormMode tests based on provided requirements", () => {
   describe("getFormMode > Fed Lead tests", () => {
     const user: User = { ...baseUser, role: "Federal Lead" };
 
-    it("should set Review mode for Fed Lead when status is Submitted or In Review", () => {
-      const statuses: ApplicationStatus[] = ["Submitted", "In Review"];
-
-      statuses.forEach((status) => {
-        expect(utils.getFormMode(user, { ...baseSubmission, status })).toBe(utils.FormModes.REVIEW);
-      });
+    it("should set Review mode for Fed Lead when status is 'In Review'", () => {
+      expect(utils.getFormMode(user, { ...baseSubmission, status: "In Review" })).toBe(
+        utils.FormModes.REVIEW
+      );
     });
 
     it("should set View Only mode for Fed Lead for all other statuses", () => {
@@ -127,6 +125,7 @@ describe("getFormMode tests based on provided requirements", () => {
         "In Progress",
         "Rejected",
         "Inquired",
+        "Submitted",
       ];
 
       statuses.forEach((status) => {

--- a/src/utils/formModeUtils.ts
+++ b/src/utils/formModeUtils.ts
@@ -1,7 +1,7 @@
 export type FormMode = "Unauthorized" | "Edit" | "View Only" | "Review";
 
 export const EditStatuses = ["New", "In Progress", "Inquired"];
-export const ReviewStatuses = ["Submitted", "In Review"];
+export const ReviewStatuses = ["In Review"];
 export const FormModes = {
   UNAUTHORIZED: "Unauthorized",
   EDIT: "Edit",


### PR DESCRIPTION
### Overview

Previously, the Federal Lead could perform Review actions while the Submission Request was in "Submitted" status, such as transitioning from "Submitted" => "Approved". 

I have removed this ability as it will mess up the history workflow. Now the Federal Lead will need to navigate back to Submissions List and click the "Review" button to navigate to "In Review" status before they can see those actions.

### Change Details (Specifics)

N/A

### Related Ticket(s)

[CRDCDH-1990](https://tracker.nci.nih.gov/browse/CRDCDH-1990) (Task)
[CRDCDH-1845](https://tracker.nci.nih.gov/browse/CRDCDH-1845) (US)
