### PR TITLE
CRDCDH-2115 Fix Multiple Submit of Create Submission Form

### DIFF
--- a/src/components/DataSubmissions/CreateDataSubmissionDialog.tsx
+++ b/src/components/DataSubmissions/CreateDataSubmissionDialog.tsx
@@ -212,7 +212,7 @@ const CreateDataSubmissionDialog: FC<Props> = ({ onCreate }) => {
     register,
     control,
     watch,
-    formState: { errors },
+    formState: { isSubmitting, errors },
     setValue,
     reset,
   } = useForm<CreateSubmissionInput>({
@@ -298,8 +298,8 @@ const CreateDataSubmissionDialog: FC<Props> = ({ onCreate }) => {
     dbGaPID,
     intention,
     dataType,
-  }: CreateSubmissionInput) => {
-    await createDataSubmission({
+  }: CreateSubmissionInput) =>
+    createDataSubmission({
       variables: {
         studyID,
         dataCommons,
@@ -328,10 +328,9 @@ const CreateDataSubmissionDialog: FC<Props> = ({ onCreate }) => {
         setError(true);
         Logger.error("Error creating submission", e);
       });
-  };
 
-  const onSubmit: SubmitHandler<CreateSubmissionInput> = (data) => {
-    createSubmission(data);
+  const onSubmit: SubmitHandler<CreateSubmissionInput> = async (data) => {
+    await createSubmission(data);
   };
 
   const validateEmpty = (value: string): string | null =>
@@ -564,6 +563,7 @@ const CreateDataSubmissionDialog: FC<Props> = ({ onCreate }) => {
             tabIndex={0}
             id="createSubmissionDialogCreateButton"
             form="create-submission-dialog-form"
+            disabled={isSubmitting}
           >
             Create
           </StyledDialogButton>

--- a/src/components/DataSubmissions/CreateDataSubmissionDialog.tsx
+++ b/src/components/DataSubmissions/CreateDataSubmissionDialog.tsx
@@ -310,6 +310,7 @@ const CreateDataSubmissionDialog: FC<Props> = ({ onCreate }) => {
       },
     })
       .then(() => {
+        reset();
         setCreatingSubmission(false);
         setError(false);
         if (onCreate) {


### PR DESCRIPTION
### Overview

This PR attempts to resolve the ability for users to create >1 Data Submissions by rapidly clicking the Create button or pressing enter multiple times quickly.

React hook form already has functionality to prevent multiple concurrent form submissions, but it requires that the submit handler be async. 

> [!NOTE] 
> This change probably shouldn't be merged directly into 3.2.0, since I made some changes to the dialog there, I don't think this is forward-compatible.

### Change Details (Specifics)

N/A

### Related Ticket(s)

CRDCDH-2115