### PR TITLE
CRDCDH-2086 Add OMB/PANS banner

### DIFF
--- a/src/components/PansBanner/index.test.tsx
+++ b/src/components/PansBanner/index.test.tsx
@@ -1,0 +1,40 @@
+import { render } from "@testing-library/react";
+import { axe } from "jest-axe";
+import dayjs from "dayjs";
+import PansBanner from "./index";
+
+describe("Accessibility", () => {
+  it("should have no violations", async () => {
+    const { container } = render(<PansBanner />);
+
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});
+
+describe("Basic Functionality", () => {
+  it("should render the PANS banner without crashing", () => {
+    expect(() => render(<PansBanner />)).not.toThrow();
+  });
+});
+
+describe("Implementation Requirements", () => {
+  it("should contain the OMB Approval Number", () => {
+    const { getByTestId } = render(<PansBanner />);
+
+    expect(getByTestId("pans-approval-number")).toHaveTextContent(/0925-7775/);
+  });
+
+  it("should contain the Expiration Date", () => {
+    const { getByTestId } = render(<PansBanner />);
+
+    expect(getByTestId("pans-expiration")).toHaveTextContent(/06\/30\/2025/);
+  });
+
+  // NOTE: Passive test to ensure the OMB Approval date is not outdated
+  it("should not contain an outdated OMB Approval date", () => {
+    const { getByTestId } = render(<PansBanner />);
+
+    const expirationDate = dayjs(getByTestId("pans-expiration").textContent, "MM/DD/YYYY");
+    expect(expirationDate.isAfter(dayjs())).toBe(true);
+  });
+});

--- a/src/components/PansBanner/index.test.tsx
+++ b/src/components/PansBanner/index.test.tsx
@@ -19,14 +19,16 @@ describe("Basic Functionality", () => {
 
 describe("Implementation Requirements", () => {
   it("should contain the OMB Approval Number", () => {
-    const { getByTestId } = render(<PansBanner />);
+    const { container, getByTestId } = render(<PansBanner />);
 
+    expect(container.textContent).toContain("OMB No.:");
     expect(getByTestId("pans-approval-number")).toHaveTextContent(/0925-7775/);
   });
 
   it("should contain the Expiration Date", () => {
-    const { getByTestId } = render(<PansBanner />);
+    const { container, getByTestId } = render(<PansBanner />);
 
+    expect(container.textContent).toContain("Expiration Date:");
     expect(getByTestId("pans-expiration")).toHaveTextContent(/06\/30\/2025/);
   });
 

--- a/src/components/PansBanner/index.tsx
+++ b/src/components/PansBanner/index.tsx
@@ -1,0 +1,74 @@
+import { Box, Stack, styled, Typography } from "@mui/material";
+import React, { memo } from "react";
+
+const StyledBox = styled(Box)({
+  padding: "20px",
+  borderBottom: "0.5px solid #6B7294",
+  marginBottom: "38px",
+});
+
+const StyledHeaderStack = styled(Stack)({
+  flexDirection: "row",
+  columnGap: "15px",
+  alignItems: "center",
+  marginBottom: "16px",
+});
+
+const StyledApprovalNumber = styled(Typography)({
+  fontWeight: 600,
+  fontSize: "17px",
+  color: "#5A7C81",
+});
+
+const StyledExpirationDate = styled(Typography)({
+  fontWeight: 400,
+  fontSize: "14px",
+  color: "#2A836D",
+  fontFamily: "'Inter', 'Nunito', sans-serif",
+});
+
+const StyledContent = styled(Typography)({
+  fontSize: "13px",
+  color: "#2A836D",
+});
+
+/**
+ * Handles the rendering of the Privacy Act Notification Statement (PANS) banner.
+ *
+ * @returns {React.FC}
+ */
+const PANSBanner: React.FC = (): React.ReactNode => (
+  <StyledBox>
+    <StyledHeaderStack>
+      <StyledApprovalNumber variant="h1" data-testid="pans-approval-number">
+        OMB No.: 0925-7775
+      </StyledApprovalNumber>
+      <StyledExpirationDate variant="h2" data-testid="pans-expiration">
+        Expiration Date: 06/30/2025
+      </StyledExpirationDate>
+    </StyledHeaderStack>
+    <StyledContent>
+      Collection of this information is authorized by The Public Health Service Act, Section 411 (42
+      USC 285a). Rights of participants are protected by The Privacy Act of 1974. Participation is
+      voluntary, and there are no penalties for not participating or withdrawing at any time.
+      Refusal to participate will not affect your benefits in any way. The information collected
+      will be kept private to the extent provided by law. Names and other identifiers will not
+      appear in any report. Information provided will be combined for all participants and reported
+      as summaries. You are being contacted online to complete this form so that NCI can consider
+      your study for submission into the Cancer Research Data Commons.
+      <br />
+      <br />
+      Public reporting burden for this collection of information is estimated to average 60 minutes
+      per response, including the time for reviewing instructions, searching existing data sources,
+      gathering and maintaining the data needed, and completing and reviewing the collection of
+      information. An agency may not conduct or sponsor, and a person is not required to respond to,
+      a collection of information unless it displays a currently valid OMB control number. Send
+      comments regarding this burden estimate or any other aspect of this collection of information,
+      including suggestions for reducing this burden to: NIH, Project Clearance Branch, 6705
+      Rockledge Drive, MSC 7974, Bethesda, MD 20892-7974, ATTN: PRA (0925-7775). Do not return the
+      completed form to this address.
+    </StyledContent>
+  </StyledBox>
+);
+
+export default memo(PANSBanner);

--- a/src/components/PansBanner/index.tsx
+++ b/src/components/PansBanner/index.tsx
@@ -37,7 +37,7 @@ const StyledContent = styled(Typography)({
  *
  * @returns {React.FC}
  */
-const PANSBanner: React.FC = (): React.ReactNode => (
+const PansBanner: React.FC = (): React.ReactNode => (
   <StyledBox>
     <StyledHeaderStack>
       <StyledApprovalNumber variant="h1" data-testid="pans-approval-number">
@@ -71,4 +71,4 @@ const PANSBanner: React.FC = (): React.ReactNode => (
   </StyledBox>
 );
 
-export default memo(PANSBanner);
+export default memo(PansBanner);

--- a/src/components/Questionnaire/FormContainer.tsx
+++ b/src/components/Questionnaire/FormContainer.tsx
@@ -7,20 +7,17 @@ import useFormMode from "../../hooks/useFormMode";
 const StyledButton = styled(Button, {
   shouldForwardProp: (prop) => prop !== "isVisible",
 })<ButtonProps & { isVisible: boolean }>(({ isVisible }) => ({
-  visibility: isVisible ? "visible" : "hidden",
+  display: isVisible ? "flex" : "none",
   fontWeight: 700,
   fontSize: "14px",
-  fontFamily: "'Nunito', 'Rubik', sans-serif",
   lineHeight: "19.6px",
   color: "#2E5481",
   padding: 0,
   marginTop: 0,
   marginBottom: "16px",
-  display: "flex",
   justifyContent: "flex-start",
   alignItems: "center",
   verticalAlign: "middle",
-  textTranform: "initial",
   "& svg": {
     marginRight: "8px",
   },
@@ -59,20 +56,36 @@ const StyledSectionTitle = styled(Typography)(() => ({
 }));
 
 type Props = {
+  /**
+   * Description of the form section
+   */
   description: string;
-  hideReturnToSubmissions?: boolean;
+  /**
+   * Form section content
+   */
   children: React.ReactNode;
+  /**
+   * Whether to hide the "Return to all Submissions" button
+   */
+  hideReturnToSubmissions?: boolean;
+  /**
+   * Element to be displayed before the section form content
+   */
+  prefixElement?: React.ReactNode;
+  /**
+   * Reference to the form element in the DOM
+   */
   formRef?: MutableRefObject<HTMLFormElement>;
 };
 
 /**
- * Generic Outtermost Form Section Container Element (e.g. Section A, ...)
+ * Generic Outermost Form Section Container Element (e.g. Section A, ...)
  *
  * @param {Props} props
  * @returns {JSX.Element}
  */
 const FormContainer = forwardRef<HTMLDivElement, Props>(
-  ({ description, children, formRef, hideReturnToSubmissions = true }, ref) => {
+  ({ prefixElement, description, children, formRef, hideReturnToSubmissions = true }, ref) => {
     const id = useId();
     const navigate = useNavigate();
     const { readOnlyInputs } = useFormMode();
@@ -91,6 +104,7 @@ const FormContainer = forwardRef<HTMLDivElement, Props>(
           <ArrowBackIcon fontSize="small" />
           Return to all Submissions
         </StyledButton>
+        {prefixElement}
         <div data-pdf-print-region="true">
           <StyledTitleGroup>
             <StyledSectionTitle variant="h2">{description}</StyledSectionTitle>

--- a/src/content/questionnaire/sections/A.tsx
+++ b/src/content/questionnaire/sections/A.tsx
@@ -17,6 +17,7 @@ import { InitialQuestionnaire } from "../../../config/InitialValues";
 import SectionMetadata from "../../../config/SectionMetadata";
 import useFormMode from "../../../hooks/useFormMode";
 import { useInstitutionList } from "../../../components/Contexts/InstitutionListContext";
+import PansBanner from "../../../components/PansBanner";
 
 export type KeyedContact = {
   key: string;
@@ -140,7 +141,12 @@ const FormSectionA: FC<FormSectionProps> = ({ SectionOption, refs }: FormSection
   }, [location]);
 
   return (
-    <FormContainer ref={formContainerRef} formRef={formRef} description={SectionOption.title}>
+    <FormContainer
+      ref={formContainerRef}
+      formRef={formRef}
+      description={SectionOption.title}
+      prefixElement={<PansBanner />}
+    >
       {/* Principal Investigator */}
       <SectionGroup
         title={SectionAMetadata.sections.PRINCIPAL_INVESTIGATOR.title}


### PR DESCRIPTION
### Overview

This PR adds a OMB banner to the Submission Request page, before the first question.

> [!NOTE]
> There is some slight styling differences between the implementation and design. In particular, the page banner background cuts off much higher up, rather than fading out. Since it's not directly related to this change, I left it untouched. 
>
> I also noticed that the sidebar (ProgressBar) no longer follows the top of the screen when scrolling, even though the styling for it has it set to `position: sticky`. Unsure if this is expected or when it broke, but I left it untouched.

> [!NOTE]
> I wanted to limit the changes since we're close to the 3.1.0 release, but in the future, I think we should migrate the FormContainer "Return to All Submissions" to a prefixElement instead (defined within the Review page). Just something to consider.

### Change Details (Specifics)

- Add OMB (official name is Privacy Act Notification Statement) banner to the Submission Request Section A
- Add related tests for testable requirements (approval number and expiration date)

### Related Ticket(s)

CRDCDH-2086 (FE Task)
CRDCDH-2085 (Design, Option 5)
CRDCDH-2068 (US)