### PR TITLE
CRDCDH-2113 Create a Data Submission – PBAC Studies Support

### DIFF
--- a/src/components/DataSubmissions/CreateDataSubmissionDialog.test.tsx
+++ b/src/components/DataSubmissions/CreateDataSubmissionDialog.test.tsx
@@ -10,13 +10,7 @@ import {
   ContextState as AuthCtxState,
   Status as AuthStatus,
 } from "../Contexts/AuthContext";
-import {
-  CREATE_SUBMISSION,
-  CreateSubmissionResp,
-  GetMyUserResp,
-  LIST_ORGS,
-  ListOrgsResp,
-} from "../../graphql";
+import { CREATE_SUBMISSION, CreateSubmissionResp, GetMyUserResp } from "../../graphql";
 
 const baseStudies: GetMyUserResp["getMyUser"]["studies"] = [
   {
@@ -66,42 +60,6 @@ const createSubmissionMocks: MockedResponse<CreateSubmissionResp>[] = [
   },
 ];
 
-const listOrgsMocks: MockedResponse<ListOrgsResp>[] = [
-  {
-    request: {
-      query: LIST_ORGS,
-    },
-    result: {
-      data: {
-        listOrganizations: [
-          {
-            _id: "some-org-1",
-            name: "org1",
-            status: "Active",
-            conciergeName: "",
-            abbreviation: "",
-            description: "",
-            studies: [
-              {
-                studyName: "study1",
-                studyAbbreviation: "SN",
-              },
-              {
-                studyName: "study2",
-                studyAbbreviation: "CS",
-              },
-            ],
-            createdAt: "2023-10-06T19:19:04.183Z",
-            updateAt: "2024-07-03T19:09:29.513Z",
-          },
-        ],
-      },
-    },
-  },
-];
-
-const baseMocks = [...createSubmissionMocks, ...listOrgsMocks];
-
 const baseUser: Omit<User, "role"> = {
   _id: "",
   firstName: "",
@@ -129,7 +87,7 @@ type ParentProps = {
 
 const TestParent: FC<ParentProps> = ({
   authCtxState = baseAuthCtx,
-  mocks = baseMocks,
+  mocks = [...createSubmissionMocks],
   children,
 }) => (
   <AuthCtx.Provider value={authCtxState}>
@@ -344,7 +302,6 @@ describe("Basic Functionality", () => {
 
   it("should show an error message when submission could not be created (network)", async () => {
     const mocks: MockedResponse[] = [
-      ...listOrgsMocks,
       {
         request: {
           query: CREATE_SUBMISSION,
@@ -425,7 +382,6 @@ describe("Basic Functionality", () => {
 
   it("should show an error message when submission could not be created (GraphQL)", async () => {
     const mocks: MockedResponse[] = [
-      ...listOrgsMocks,
       {
         request: {
           query: CREATE_SUBMISSION,
@@ -705,7 +661,6 @@ describe("Basic Functionality", () => {
       {
         wrapper: (p) => (
           <TestParent
-            mocks={baseMocks}
             authCtxState={{
               ...baseAuthCtx,
               user: { ...baseUser, role: "Submitter", studies: baseStudies },
@@ -776,7 +731,7 @@ describe("Implementation Requirements", () => {
       {
         wrapper: (p) => (
           <TestParent
-            mocks={[...listOrgsMocks]}
+            mocks={[]}
             authCtxState={{
               ...baseAuthCtx,
               user: { ...baseUser, role: "Submitter", studies: ApprovedStudyNoDbGaPID },
@@ -831,7 +786,7 @@ describe("Implementation Requirements", () => {
       {
         wrapper: (p) => (
           <TestParent
-            mocks={[...listOrgsMocks]}
+            mocks={[]}
             authCtxState={{
               ...baseAuthCtx,
               user: { ...baseUser, role: "Submitter", studies: ApprovedStudyNoDbGaPID },
@@ -904,7 +859,7 @@ describe("Implementation Requirements", () => {
       {
         wrapper: (p) => (
           <TestParent
-            mocks={[...listOrgsMocks]}
+            mocks={[]}
             authCtxState={{
               ...baseAuthCtx,
               user: { ...baseUser, role: "Submitter", studies: ApprovedStudyNoDbGaPID },
@@ -972,7 +927,7 @@ describe("Implementation Requirements", () => {
       {
         wrapper: (p) => (
           <TestParent
-            mocks={[...listOrgsMocks]}
+            mocks={[]}
             authCtxState={{
               ...baseAuthCtx,
               user: { ...baseUser, role: "Submitter", studies: ApprovedStudyNoDbGaPID },
@@ -1017,4 +972,120 @@ describe("Implementation Requirements", () => {
       { normalizeWhitespace: true }
     );
   });
+
+  // NOTE: We're just random-testing against the opposite of the RequiresStudiesAssigned variable
+  // it.each<UserRole>(["Data Curator", "Data Commons POC"])(
+  //   "should fetch all of the studies if the user's role is %s",
+  //   async (role) => {
+  //     const mockMatcher = jest.fn().mockImplementation(() => true);
+  //     const listApprovedStudiesMock: MockedResponse<
+  //       ListApprovedStudiesResp,
+  //       ListApprovedStudiesInput
+  //     > = {
+  //       request: {
+  //         query: LIST_APPROVED_STUDIES,
+  //       },
+  //       variableMatcher: mockMatcher,
+  //       result: {
+  //         data: {
+  //           listApprovedStudies: {
+  //             total: 1,
+  //             studies: [
+  //               {
+  //                 _id: "study1",
+  //                 studyName: "study-1-from-api",
+  //                 studyAbbreviation: "study-1-from-api-abbr",
+  //                 dbGaPID: "",
+  //                 controlledAccess: false,
+  //               },
+  //               {
+  //                 _id: "study2",
+  //                 studyName: "study-2-from-api",
+  //                 studyAbbreviation: "study-2-from-api-abbr",
+  //                 dbGaPID: "",
+  //                 controlledAccess: false,
+  //               },
+  //             ] as ApprovedStudy[],
+  //           },
+  //         },
+  //       },
+  //     };
+
+  //     const { getByRole } = render(<CreateDataSubmissionDialog onCreate={jest.fn()} />, {
+  //       wrapper: (p) => (
+  //         <TestParent
+  //           mocks={[listApprovedStudiesMock]}
+  //           authCtxState={{ ...baseAuthCtx, user: { ...baseUser, role } }}
+  //           {...p}
+  //         />
+  //       ),
+  //     });
+
+  //     userEvent.click(getByRole("button", { name: "Create a Data Submission" }));
+
+  //     await waitFor(() => {
+  //       expect(mockMatcher).toHaveBeenCalledTimes(1); // Ensure the listApprovedStudies query was called
+  //     });
+  //   }
+  // );
+
+  // it("should fetch all of the studies if the user's assigned studies contains the 'All' study", async () => {
+  //   const mockMatcher = jest.fn().mockImplementation(() => true);
+  //   const listApprovedStudiesMock: MockedResponse<
+  //     ListApprovedStudiesResp,
+  //     ListApprovedStudiesInput
+  //   > = {
+  //     request: {
+  //       query: LIST_APPROVED_STUDIES,
+  //     },
+  //     variableMatcher: mockMatcher,
+  //     result: {
+  //       data: {
+  //         listApprovedStudies: {
+  //           total: 1,
+  //           studies: [
+  //             {
+  //               _id: "study1",
+  //               studyName: "study-1-from-api",
+  //               studyAbbreviation: "study-1-from-api-abbr",
+  //               dbGaPID: "",
+  //               controlledAccess: false,
+  //             },
+  //           ] as ApprovedStudy[],
+  //         },
+  //       },
+  //     },
+  //   };
+
+  //   const { getByRole } = render(<CreateDataSubmissionDialog onCreate={jest.fn()} />, {
+  //     wrapper: (p) => (
+  //       <TestParent
+  //         mocks={[listApprovedStudiesMock]}
+  //         authCtxState={{
+  //           ...baseAuthCtx,
+  //           user: {
+  //             ...baseUser,
+  //             role: "Federal Lead",
+  //             studies: [
+  //               {
+  //                 _id: "All", // This is the important part
+  //                 studyAbbreviation: "",
+  //                 studyName: "",
+  //                 dbGaPID: "",
+  //                 controlledAccess: false,
+  //               },
+  //             ],
+  //           },
+  //         }}
+  //         {...p}
+  //       />
+  //     ),
+  //   });
+
+  //   userEvent.click(getByRole("button", { name: "Create a Data Submission" }));
+
+  //   await waitFor(() => {
+  //     expect(mockMatcher).toHaveBeenCalledTimes(1); // Ensure the listApprovedStudies query was called
+  //   });
+  // });
 });

--- a/src/components/DataSubmissions/CreateDataSubmissionDialog.tsx
+++ b/src/components/DataSubmissions/CreateDataSubmissionDialog.tsx
@@ -226,8 +226,8 @@ const CreateDataSubmissionDialog: FC<Props> = ({ onCreate }) => {
   const shouldFetchAllStudies = useMemo<boolean>(
     () =>
       creatingSubmission &&
-      !RequiresStudiesAssigned.includes(user?.role) &&
-      user?.studies?.findIndex((s) => s?._id === "All") !== -1,
+      (!RequiresStudiesAssigned.includes(user?.role) ||
+        (user?.studies || [])?.findIndex((s) => s?._id === "All") !== -1),
     [creatingSubmission, user?.role, user?.studies]
   );
 

--- a/src/config/AuthRoles.ts
+++ b/src/config/AuthRoles.ts
@@ -108,3 +108,8 @@ export const CanCreateSubmissionRequest: UserRole[] = ["User", "Submitter", "Org
  * A set of user roles that are allowed to Submit a Submission Request.
  */
 export const CanSubmitSubmissionRequestRoles: UserRole[] = ["User", "Submitter", "Federal Lead"];
+
+/**
+ * A set of roles that are constrained to a set of studies.
+ */
+export const RequiresStudiesAssigned: UserRole[] = ["Submitter", "Federal Monitor", "Federal Lead"];

--- a/src/hooks/useProfileFields.test.ts
+++ b/src/hooks/useProfileFields.test.ts
@@ -36,13 +36,14 @@ describe("Users View", () => {
   it.each<[FieldState, UserRole]>([
     ["HIDDEN", "User"],
     ["HIDDEN", "Organization Owner"],
-    ["HIDDEN", "Federal Lead"],
     ["HIDDEN", "Data Curator"],
     ["HIDDEN", "Data Commons POC"],
     ["HIDDEN", "Admin"],
     ["HIDDEN", "fake role" as UserRole],
-    ["UNLOCKED", "Submitter"], // NOTE: This role accepts studies
-    ["UNLOCKED", "Federal Monitor"], // NOTE: This role accepts studies
+    // NOTE: All of the following are assigned to studies
+    ["UNLOCKED", "Federal Lead"],
+    ["UNLOCKED", "Submitter"],
+    ["UNLOCKED", "Federal Monitor"],
   ])("should return %s for the studies field on the users page for role %s", (state, role) => {
     const user = { _id: "User-A", role: "Admin" } as User;
     const profileOf: Pick<User, "_id" | "role"> = { _id: "I-Am-User-B", role };
@@ -120,7 +121,8 @@ describe("Profile View", () => {
   it.each<UserRole>([
     "User",
     "Submitter",
-    "Federal Monitor", // NOTE: Only this role accepts studies
+    "Federal Monitor",
+    "Federal Lead",
     "Data Commons POC",
     "fake role" as UserRole,
   ])("should return HIDDEN for the studies field on the profile page for role %s", (role) => {

--- a/src/hooks/useProfileFields.ts
+++ b/src/hooks/useProfileFields.ts
@@ -1,4 +1,5 @@
 import { useAuthContext } from "../components/Contexts/AuthContext";
+import { RequiresStudiesAssigned } from "../config/AuthRoles";
 /**
  * Constrains the fields that this hook supports generating states for
  */
@@ -55,12 +56,8 @@ const useProfileFields = (
     fields.role = "UNLOCKED";
     fields.userStatus = "UNLOCKED";
 
-    // Editable for Admin viewing Federal Monitor or Submitter, otherwise hidden
-    // even for a user viewing their own profile
-    fields.studies =
-      profileOf?.role === "Submitter" || profileOf?.role === "Federal Monitor"
-        ? "UNLOCKED"
-        : "HIDDEN";
+    // Editable for Admin viewing certain roles, otherwise hidden (even for a user viewing their own profile)
+    fields.studies = RequiresStudiesAssigned.includes(profileOf?.role) ? "UNLOCKED" : "HIDDEN";
   }
 
   // Only applies to Data Commons POC


### PR DESCRIPTION
### Overview

This PR is preparation for Data Submission PBAC controls. Instead of explicitly utilizing the account's assigned studies, we now determine if the Create a Data Submission dialog should utilize the AuthCtx studies or the full list. 

### Change Details (Specifics)

- Cleanup unused mock queries for list orgs in the Create a DS dialog tests
- Define `RequiresStudiesAssigned` variable, which defines the roles that enforce a study selection
- Update Create a DS dialog to utilize the listApprovedStudies instead of their assigned studies based on:
  - Is the dialog even open?
  - Does the user role require studies be assigned? If not, we call the API
  - Does the account have the "All" study assigned? If yes, we call the API

### Related Ticket(s)

CRDCDH-2113 (Task)
CRDCDH-2023 (US 1 of 2)
CRDCDH-1886 (US 2 of 2)
