### PR TITLE
CRDCDH-2123 Support "All" studies for Federal Leads

### DIFF
--- a/src/content/users/ProfileView.tsx
+++ b/src/content/users/ProfileView.tsx
@@ -302,10 +302,10 @@ const ProfileView: FC<Props> = ({ _id, viewType }: Props) => {
   ) => {
     let updatedData = [...data];
 
-    // Previous studies included all but the user selected other studies
+    // Previous studies included "All", but the user selected something different
     if (prevStudiesRef.current?.includes(ALL_STUDIES_OPTION)) {
       updatedData = updatedData.filter((v) => v !== ALL_STUDIES_OPTION);
-      // User selected all studies, remove all other studies
+      // User selected "All" studies, remove any other studies
     } else if (data.includes(ALL_STUDIES_OPTION)) {
       updatedData = [ALL_STUDIES_OPTION];
     }

--- a/src/content/users/ProfileView.tsx
+++ b/src/content/users/ProfileView.tsx
@@ -2,7 +2,7 @@ import { FC, useEffect, useMemo, useRef, useState } from "react";
 import { useLazyQuery, useMutation, useQuery } from "@apollo/client";
 import { LoadingButton } from "@mui/lab";
 import { Box, Container, MenuItem, Stack, TextField, Typography, styled } from "@mui/material";
-import { Controller, ControllerRenderProps, useForm } from "react-hook-form";
+import { Controller, ControllerRenderProps, SubmitHandler, useForm } from "react-hook-form";
 import { useNavigate } from "react-router-dom";
 import { useSnackbar } from "notistack";
 import bannerSvg from "../../assets/banner/profile_banner.png";
@@ -228,7 +228,7 @@ const ProfileView: FC<Props> = ({ _id, viewType }: Props) => {
     return studyIdMap;
   }, [approvedStudies?.listApprovedStudies?.studies, roleField]);
 
-  const onSubmit = async (data: FormInput) => {
+  const onSubmit: SubmitHandler<FormInput> = async (data: FormInput) => {
     setSaving(true);
 
     // Save profile changes

--- a/src/content/users/ProfileView.tsx
+++ b/src/content/users/ProfileView.tsx
@@ -158,7 +158,7 @@ const ProfileView: FC<Props> = ({ _id, viewType }: Props) => {
   const { enqueueSnackbar } = useSnackbar();
   const { user: currentUser, setData, logout, status: authStatus } = useAuthContext();
   const { lastSearchParams } = useSearchParamsContext();
-  const { handleSubmit, register, reset, watch, control } = useForm<FormInput>();
+  const { handleSubmit, register, reset, watch, setValue, control } = useForm<FormInput>();
 
   const ALL_STUDIES_OPTION = "All";
   const manageUsersPageUrl = `/users${lastSearchParams?.["/users"] ?? ""}`;
@@ -170,6 +170,7 @@ const ProfileView: FC<Props> = ({ _id, viewType }: Props) => {
   const [studyOptions, setStudyOptions] = useState<string[]>([]);
 
   const roleField = watch("role");
+  const prevRoleRef = useRef<UserRole>(roleField);
   const studiesField = watch("studies");
   const prevStudiesRef = useRef<string[]>(studiesField);
   const fieldset = useProfileFields({ _id: user?._id, role: roleField }, viewType);
@@ -330,6 +331,10 @@ const ProfileView: FC<Props> = ({ _id, viewType }: Props) => {
     }
   }, [formattedStudyMap]);
 
+  useEffect(() => {
+    prevRoleRef.current = roleField;
+  }, [roleField]);
+
   if (!user || authStatus === AuthStatus.LOADING) {
     return <SuspenseLoader />;
   }
@@ -412,6 +417,18 @@ const ProfileView: FC<Props> = ({ _id, viewType }: Props) => {
                       <StyledSelect
                         {...field}
                         size="small"
+                        onChange={(e) => {
+                          if (prevRoleRef.current === "Federal Lead") {
+                            setValue(
+                              "studies",
+                              studiesField.filter((v) => v !== ALL_STUDIES_OPTION)
+                            );
+                          } else if (e.target.value === "Federal Lead") {
+                            setValue("studies", [ALL_STUDIES_OPTION]);
+                          }
+
+                          field.onChange(e.target.value);
+                        }}
                         MenuProps={{ disablePortal: true }}
                         inputProps={{ "aria-labelledby": "userRoleLabel" }}
                       >

--- a/src/content/users/ProfileView.tsx
+++ b/src/content/users/ProfileView.tsx
@@ -496,7 +496,12 @@ const ProfileView: FC<Props> = ({ _id, viewType }: Props) => {
                             </StyledTag>
                           );
                         }}
-                        options={studyOptions}
+                        options={
+                          roleField === "Federal Lead" &&
+                          !studyOptions?.includes(ALL_STUDIES_OPTION)
+                            ? [ALL_STUDIES_OPTION, ...studyOptions]
+                            : studyOptions
+                        }
                         getOptionLabel={(option: string) => formattedStudyMap[option]}
                         onChange={(_, data: string[]) => handleStudyChange(field, data)}
                         disabled={fieldset.studies === "DISABLED"}

--- a/src/content/users/ProfileView.tsx
+++ b/src/content/users/ProfileView.tsx
@@ -31,7 +31,7 @@ import { useSearchParamsContext } from "../../components/Contexts/SearchParamsCo
 import BaseSelect from "../../components/StyledFormComponents/StyledSelect";
 import BaseOutlinedInput from "../../components/StyledFormComponents/StyledOutlinedInput";
 import BaseAutocomplete from "../../components/StyledFormComponents/StyledAutocomplete";
-import useProfileFields, { FieldState } from "../../hooks/useProfileFields";
+import useProfileFields, { VisibleFieldState } from "../../hooks/useProfileFields";
 import AccessRequest from "../../components/AccessRequest";
 
 type Props = {
@@ -169,8 +169,6 @@ const ProfileView: FC<Props> = ({ _id, viewType }: Props) => {
 
   const roleField = watch("role");
   const fieldset = useProfileFields({ _id: user?._id, role: roleField }, viewType);
-  const visibleFieldState: FieldState[] = ["UNLOCKED", "DISABLED"];
-
   const manageUsersPageUrl = `/users${lastSearchParams?.["/users"] ?? ""}`;
 
   const canRequestRole: boolean = useMemo<boolean>(() => {
@@ -368,7 +366,7 @@ const ProfileView: FC<Props> = ({ _id, viewType }: Props) => {
               </StyledField>
               <StyledField>
                 <StyledLabel id="firstNameLabel">First name</StyledLabel>
-                {visibleFieldState.includes(fieldset.firstName) ? (
+                {VisibleFieldState.includes(fieldset.firstName) ? (
                   <StyledTextField
                     {...register("firstName", {
                       required: true,
@@ -385,7 +383,7 @@ const ProfileView: FC<Props> = ({ _id, viewType }: Props) => {
               </StyledField>
               <StyledField>
                 <StyledLabel id="lastNameLabel">Last name</StyledLabel>
-                {visibleFieldState.includes(fieldset.lastName) ? (
+                {VisibleFieldState.includes(fieldset.lastName) ? (
                   <StyledTextField
                     {...register("lastName", {
                       required: true,
@@ -402,7 +400,7 @@ const ProfileView: FC<Props> = ({ _id, viewType }: Props) => {
               </StyledField>
               <StyledField>
                 <StyledLabel id="userRoleLabel">Role</StyledLabel>
-                {visibleFieldState.includes(fieldset.role) ? (
+                {VisibleFieldState.includes(fieldset.role) ? (
                   <Controller
                     name="role"
                     control={control}
@@ -431,7 +429,7 @@ const ProfileView: FC<Props> = ({ _id, viewType }: Props) => {
               </StyledField>
               <StyledField visible={fieldset.studies !== "HIDDEN"}>
                 <StyledLabel id="userStudies">Studies</StyledLabel>
-                {visibleFieldState.includes(fieldset.studies) ? (
+                {VisibleFieldState.includes(fieldset.studies) ? (
                   <Controller
                     name="studies"
                     control={control}
@@ -474,7 +472,7 @@ const ProfileView: FC<Props> = ({ _id, viewType }: Props) => {
               </StyledField>
               <StyledField>
                 <StyledLabel id="userStatusLabel">Account Status</StyledLabel>
-                {visibleFieldState.includes(fieldset.userStatus) ? (
+                {VisibleFieldState.includes(fieldset.userStatus) ? (
                   <Controller
                     name="userStatus"
                     control={control}
@@ -497,7 +495,7 @@ const ProfileView: FC<Props> = ({ _id, viewType }: Props) => {
               </StyledField>
               <StyledField visible={fieldset.dataCommons !== "HIDDEN"}>
                 <StyledLabel id="userDataCommons">Data Commons</StyledLabel>
-                {visibleFieldState.includes(fieldset.dataCommons) ? (
+                {VisibleFieldState.includes(fieldset.dataCommons) ? (
                   <Controller
                     name="dataCommons"
                     control={control}

--- a/src/content/users/ProfileView.tsx
+++ b/src/content/users/ProfileView.tsx
@@ -360,7 +360,8 @@ const ProfileView: FC<Props> = ({ _id, viewType }: Props) => {
 
     sortStudyOptions();
 
-    if (roleField === "Federal Lead") {
+    // If the user is a Federal Lead with no studies assigned, default to selecting "All" studies
+    if (!studiesField?.length && roleField === "Federal Lead") {
       setValue("studies", [ALL_STUDIES_OPTION]);
     }
   }, [formattedStudyMap, roleField]);

--- a/src/content/users/ProfileView.tsx
+++ b/src/content/users/ProfileView.tsx
@@ -160,6 +160,7 @@ const ProfileView: FC<Props> = ({ _id, viewType }: Props) => {
   const { lastSearchParams } = useSearchParamsContext();
   const { handleSubmit, register, reset, watch, control } = useForm<FormInput>();
 
+  const manageUsersPageUrl = `/users${lastSearchParams?.["/users"] ?? ""}`;
   const isSelf = _id === currentUser._id;
   const [user, setUser] = useState<User | null>(
     isSelf && viewType === "profile" ? { ...currentUser } : null
@@ -168,8 +169,8 @@ const ProfileView: FC<Props> = ({ _id, viewType }: Props) => {
   const [studyOptions, setStudyOptions] = useState<string[]>([]);
 
   const roleField = watch("role");
+  const studiesField = watch("studies");
   const fieldset = useProfileFields({ _id: user?._id, role: roleField }, viewType);
-  const manageUsersPageUrl = `/users${lastSearchParams?.["/users"] ?? ""}`;
 
   const canRequestRole: boolean = useMemo<boolean>(() => {
     if (viewType !== "profile" || _id !== currentUser._id) {
@@ -198,14 +199,7 @@ const ProfileView: FC<Props> = ({ _id, viewType }: Props) => {
     ListApprovedStudiesResp,
     ListApprovedStudiesInput
   >(LIST_APPROVED_STUDIES, {
-    variables: {
-      // show all access types
-      controlledAccess: "All",
-      first: -1,
-      offset: 0,
-      orderBy: "studyName",
-      sortDirection: "asc",
-    },
+    variables: { first: -1, orderBy: "studyName", sortDirection: "asc" },
     context: { clientName: "backend" },
     fetchPolicy: "cache-and-network",
     skip: fieldset.studies !== "UNLOCKED",
@@ -279,10 +273,9 @@ const ProfileView: FC<Props> = ({ _id, viewType }: Props) => {
   };
 
   const sortStudyOptions = () => {
-    const val = watch("studies");
     const options = Object.keys(formattedStudyMap);
 
-    const selectedOptions = val
+    const selectedOptions = studiesField
       .filter((v) => options.includes(v))
       .sort((a, b) => formattedStudyMap[a]?.localeCompare(formattedStudyMap?.[b]));
     const unselectedOptions = options
@@ -440,9 +433,7 @@ const ProfileView: FC<Props> = ({ _id, viewType }: Props) => {
                         renderInput={({ inputProps, ...params }) => (
                           <TextField
                             {...params}
-                            placeholder={
-                              watch("studies")?.length > 0 ? undefined : "Select studies"
-                            }
+                            placeholder={studiesField?.length > 0 ? undefined : "Select studies"}
                             inputProps={{ "aria-labelledby": "userStudies", ...inputProps }}
                             onBlur={sortStudyOptions}
                           />

--- a/src/content/users/ProfileView.tsx
+++ b/src/content/users/ProfileView.tsx
@@ -300,18 +300,15 @@ const ProfileView: FC<Props> = ({ _id, viewType }: Props) => {
     field: ControllerRenderProps<FormInput, "studies">,
     data: string[]
   ) => {
-    let updatedData = [...data];
-
     // Previous studies included "All", but the user selected something different
     if (prevStudiesRef.current?.includes(ALL_STUDIES_OPTION)) {
-      updatedData = updatedData.filter((v) => v !== ALL_STUDIES_OPTION);
+      data = data.filter((v) => v !== ALL_STUDIES_OPTION);
       // User selected "All" studies, remove any other studies
     } else if (data.includes(ALL_STUDIES_OPTION)) {
-      updatedData = [ALL_STUDIES_OPTION];
+      data = [ALL_STUDIES_OPTION];
     }
 
-    field.onChange(updatedData);
-    prevStudiesRef.current = updatedData;
+    field.onChange(data);
   };
 
   const handleRoleChange = (field: ControllerRenderProps<FormInput, "role">, value: UserRole) => {
@@ -371,6 +368,10 @@ const ProfileView: FC<Props> = ({ _id, viewType }: Props) => {
   useEffect(() => {
     prevRoleRef.current = roleField;
   }, [roleField]);
+
+  useEffect(() => {
+    prevStudiesRef.current = studiesField;
+  }, [studiesField]);
 
   if (!user || authStatus === AuthStatus.LOADING) {
     return <SuspenseLoader />;

--- a/src/content/users/ProfileView.tsx
+++ b/src/content/users/ProfileView.tsx
@@ -321,7 +321,7 @@ const ProfileView: FC<Props> = ({ _id, viewType }: Props) => {
         studiesField.filter((v) => v !== ALL_STUDIES_OPTION)
       );
     } else if (value === "Federal Lead") {
-      setValue("studies", [ALL_STUDIES_OPTION]);
+      setValue("studies", []);
     }
 
     field.onChange(value);
@@ -357,10 +357,16 @@ const ProfileView: FC<Props> = ({ _id, viewType }: Props) => {
   }, [_id]);
 
   useEffect(() => {
-    if (fieldset.studies === "UNLOCKED") {
-      sortStudyOptions();
+    if (fieldset.studies !== "UNLOCKED") {
+      return;
     }
-  }, [formattedStudyMap]);
+
+    sortStudyOptions();
+
+    if (roleField === "Federal Lead") {
+      setValue("studies", [ALL_STUDIES_OPTION]);
+    }
+  }, [formattedStudyMap, roleField]);
 
   useEffect(() => {
     prevRoleRef.current = roleField;
@@ -496,12 +502,7 @@ const ProfileView: FC<Props> = ({ _id, viewType }: Props) => {
                             </StyledTag>
                           );
                         }}
-                        options={
-                          roleField === "Federal Lead" &&
-                          !studyOptions?.includes(ALL_STUDIES_OPTION)
-                            ? [ALL_STUDIES_OPTION, ...studyOptions]
-                            : studyOptions
-                        }
+                        options={studyOptions}
                         getOptionLabel={(option: string) => formattedStudyMap[option]}
                         onChange={(_, data: string[]) => handleStudyChange(field, data)}
                         disabled={fieldset.studies === "DISABLED"}

--- a/src/hooks/useProfileFields.ts
+++ b/src/hooks/useProfileFields.ts
@@ -24,6 +24,11 @@ export type ProfileFields = Record<EditableFields, FieldState>;
 export type FieldState = "HIDDEN" | "DISABLED" | "UNLOCKED" | "READ_ONLY";
 
 /**
+ * An array of fields that are visible to the viewer, regardless of their state
+ */
+export const VisibleFieldState: FieldState[] = ["UNLOCKED", "DISABLED"];
+
+/**
  * Determines which profile fields are visible, editable, and disabled for the current user
  *
  * @param profileOf the user whose profile is being viewed


### PR DESCRIPTION
### Overview

This PR adds the "All" studies option for Federal Leads on the Edit User tool.

> [!Warning]
> When switching roles from anything (e.g. `Submitter`) to `Federal Lead`, MUI throws a warning because the "All" option is programmatically selected, but not available in the study options during the first render. The only solution I could find that worked is [not very clean](https://github.com/CBIIT/crdc-datahub-ui/pull/566/commits/f6e0da767afaddc2178114a8545b510b2ddcb373). I'm open to any alternatives.

### Change Details (Specifics)

- Add `All` option to the Studies list for Federal Leads, selected by default
- Migrate `VisibleFieldState` out of ProfileView into the useProfileFields hook

### Related Ticket(s)

CRDCDH-2123 (Task)
