### PR TITLE
CRDCDH-2139 Additional Program Rebranding Changes

### DIFF
--- a/src/components/DataSubmissions/DataSubmissionListFilters.test.tsx
+++ b/src/components/DataSubmissions/DataSubmissionListFilters.test.tsx
@@ -81,6 +81,10 @@ describe("DataSubmissionListFilters Component", () => {
 
   const submitterNames = ["Submitter1", "Submitter2"];
   const dataCommons = ["DataCommon1", "DataCommon2"];
+  const organizations: Organization[] = [
+    { _id: "Org1", name: "Organization 1" } as Organization,
+    { _id: "Org2", name: "Organization 2" } as Organization,
+  ];
   const columnVisibilityModel = { name: true, status: true };
 
   const mockOnChange = jest.fn();
@@ -96,6 +100,7 @@ describe("DataSubmissionListFilters Component", () => {
       <TestParent>
         <DataSubmissionListFilters
           columns={columns}
+          organizations={organizations}
           submitterNames={submitterNames}
           dataCommons={dataCommons}
           columnVisibilityModel={columnVisibilityModel}
@@ -115,6 +120,7 @@ describe("DataSubmissionListFilters Component", () => {
       <TestParent userRole="Admin">
         <DataSubmissionListFilters
           columns={columns}
+          organizations={organizations}
           submitterNames={submitterNames}
           dataCommons={dataCommons}
           columnVisibilityModel={columnVisibilityModel}
@@ -125,6 +131,7 @@ describe("DataSubmissionListFilters Component", () => {
     );
 
     await waitFor(() => {
+      expect(getByTestId("organization-select")).toBeInTheDocument();
       expect(getByTestId("status-select")).toBeInTheDocument();
       expect(getByTestId("data-commons-select")).toBeInTheDocument();
       expect(getByTestId("submission-name-input")).toBeInTheDocument();
@@ -143,6 +150,7 @@ describe("DataSubmissionListFilters Component", () => {
       <TestParent>
         <DataSubmissionListFilters
           columns={columns}
+          organizations={organizations}
           submitterNames={submitterNames}
           dataCommons={dataCommons}
           columnVisibilityModel={columnVisibilityModel}
@@ -153,9 +161,10 @@ describe("DataSubmissionListFilters Component", () => {
     );
 
     await waitFor(() => {
-      expect(getByTestId("status-select")).toBeInTheDocument();
+      expect(getByTestId("organization-select")).toBeInTheDocument();
     });
 
+    expect(getByTestId("status-select")).toBeInTheDocument();
     expect(getByTestId("data-commons-select")).toBeInTheDocument();
     expect(getByTestId("submission-name-input")).toBeInTheDocument();
     expect(getByTestId("dbGaPID-input")).toBeInTheDocument();
@@ -164,11 +173,12 @@ describe("DataSubmissionListFilters Component", () => {
     expect(getByTestId("column-visibility-button")).toBeInTheDocument();
   });
 
-  it("resets all filters and clears URL searchParams when reset button is clicked", async () => {
-    const { getByTestId } = render(
+  it("allows users to select an organization when user is Admin", async () => {
+    const { getByTestId, getByRole } = render(
       <TestParent userRole="Admin">
         <DataSubmissionListFilters
           columns={columns}
+          organizations={organizations}
           submitterNames={submitterNames}
           dataCommons={dataCommons}
           columnVisibilityModel={columnVisibilityModel}
@@ -177,6 +187,83 @@ describe("DataSubmissionListFilters Component", () => {
         />
       </TestParent>
     );
+
+    const organizationSelect = within(getByTestId("organization-select")).getByRole("button");
+
+    userEvent.click(organizationSelect);
+
+    const muiSelectList = within(getByRole("listbox", { hidden: true }));
+
+    await waitFor(() => {
+      expect(muiSelectList.getByTestId("organization-option-All")).toBeInTheDocument();
+      expect(muiSelectList.getByTestId("organization-option-Org1")).toBeInTheDocument();
+      expect(muiSelectList.getByTestId("organization-option-Org2")).toBeInTheDocument();
+    });
+
+    userEvent.click(getByTestId("organization-option-Org2"));
+
+    await waitFor(() => {
+      expect(mockOnChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          organization: "Org2",
+        })
+      );
+    });
+  });
+
+  it("allows non-admin users to select an organization", async () => {
+    const { getByTestId } = render(
+      <TestParent userRole="Submitter">
+        <DataSubmissionListFilters
+          columns={columns}
+          organizations={organizations}
+          submitterNames={submitterNames}
+          dataCommons={dataCommons}
+          columnVisibilityModel={columnVisibilityModel}
+          onColumnVisibilityModelChange={mockOnColumnVisibilityModelChange}
+          onChange={mockOnChange}
+        />
+      </TestParent>
+    );
+
+    await waitFor(() => {
+      expect(getByTestId("organization-select")).toBeInTheDocument();
+    });
+
+    const organizationSelectInput = getByTestId("organization-select");
+
+    const button = within(organizationSelectInput).getByRole("button");
+    expect(button).not.toHaveClass("Mui-readOnly");
+  });
+
+  it("resets all filters and clears URL searchParams when reset button is clicked", async () => {
+    const { getByTestId, getByRole } = render(
+      <TestParent userRole="Admin">
+        <DataSubmissionListFilters
+          columns={columns}
+          organizations={organizations}
+          submitterNames={submitterNames}
+          dataCommons={dataCommons}
+          columnVisibilityModel={columnVisibilityModel}
+          onColumnVisibilityModelChange={mockOnColumnVisibilityModelChange}
+          onChange={mockOnChange}
+        />
+      </TestParent>
+    );
+
+    const organizationSelect = within(getByTestId("organization-select")).getByRole("button");
+
+    userEvent.click(organizationSelect);
+
+    const orgSelectList = within(getByRole("listbox", { hidden: true }));
+
+    await waitFor(() => {
+      expect(orgSelectList.getByTestId("organization-option-All")).toBeInTheDocument();
+      expect(orgSelectList.getByTestId("organization-option-Org1")).toBeInTheDocument();
+      expect(orgSelectList.getByTestId("organization-option-Org2")).toBeInTheDocument();
+    });
+
+    userEvent.click(orgSelectList.getByTestId("organization-option-Org2"));
 
     const statusSelect = within(getByTestId("status-select")).getByRole("button");
 
@@ -244,6 +331,7 @@ describe("DataSubmissionListFilters Component", () => {
     await waitFor(() => {
       expect(mockOnChange).toHaveBeenCalledWith(
         expect.objectContaining({
+          organization: "Org2",
           status: "Submitted",
           name: "Test Submission",
           dbGaPID: "12345",
@@ -256,6 +344,7 @@ describe("DataSubmissionListFilters Component", () => {
     userEvent.click(getByTestId("reset-filters-button"));
 
     await waitFor(() => {
+      expect(getByTestId("organization-select-input")).toHaveValue("All");
       expect(getByTestId("status-select-input")).toHaveValue("All");
       expect(getByTestId("data-commons-select-input")).toHaveValue("All");
       expect(getByTestId("submission-name-input")).toHaveValue("");
@@ -265,6 +354,7 @@ describe("DataSubmissionListFilters Component", () => {
 
     expect(mockOnChange).toHaveBeenCalledWith(
       expect.objectContaining({
+        organization: "All",
         status: "All",
         dataCommons: "All",
         name: "",
@@ -279,6 +369,7 @@ describe("DataSubmissionListFilters Component", () => {
       <TestParent userRole="Admin">
         <DataSubmissionListFilters
           columns={columns}
+          organizations={organizations}
           submitterNames={submitterNames}
           dataCommons={dataCommons}
           columnVisibilityModel={columnVisibilityModel}
@@ -306,6 +397,7 @@ describe("DataSubmissionListFilters Component", () => {
       <TestParent userRole="Admin">
         <DataSubmissionListFilters
           columns={columns}
+          organizations={organizations}
           submitterNames={submitterNames}
           dataCommons={dataCommons}
           columnVisibilityModel={columnVisibilityModel}
@@ -341,6 +433,7 @@ describe("DataSubmissionListFilters Component", () => {
       <TestParent userRole="Admin">
         <DataSubmissionListFilters
           columns={columns}
+          organizations={organizations}
           submitterNames={submitterNames}
           dataCommons={dataCommons}
           columnVisibilityModel={columnVisibilityModel}
@@ -370,6 +463,7 @@ describe("DataSubmissionListFilters Component", () => {
       <TestParent userRole="Admin">
         <DataSubmissionListFilters
           columns={columns}
+          organizations={organizations}
           submitterNames={submitterNames}
           dataCommons={dataCommons}
           columnVisibilityModel={columnVisibilityModel}
@@ -405,6 +499,7 @@ describe("DataSubmissionListFilters Component", () => {
       <TestParent userRole="Admin">
         <DataSubmissionListFilters
           columns={columns}
+          organizations={organizations}
           submitterNames={submitterNames}
           dataCommons={dataCommons}
           columnVisibilityModel={columnVisibilityModel}
@@ -442,6 +537,7 @@ describe("DataSubmissionListFilters Component", () => {
       <TestParent userRole="Admin">
         <DataSubmissionListFilters
           columns={columns}
+          organizations={organizations}
           submitterNames={submitterNames}
           dataCommons={dataCommons}
           columnVisibilityModel={columnVisibilityModel}
@@ -483,6 +579,7 @@ describe("DataSubmissionListFilters Component", () => {
       <TestParent userRole="Admin">
         <DataSubmissionListFilters
           columns={columns}
+          organizations={organizations}
           submitterNames={submitterNames}
           dataCommons={dataCommons}
           columnVisibilityModel={columnVisibilityModel}
@@ -516,7 +613,7 @@ describe("DataSubmissionListFilters Component", () => {
 
   it("initializes form fields based on searchParams", async () => {
     const initialEntries = [
-      "/?status=Submitted&dataCommons=DataCommon1&name=Test&dbGaPID=123&submitterName=Submitter1",
+      "/?organization=Org1&status=Submitted&dataCommons=DataCommon1&name=Test&dbGaPID=123&submitterName=Submitter1",
     ];
 
     const mockOnChange = jest.fn();
@@ -526,6 +623,7 @@ describe("DataSubmissionListFilters Component", () => {
       <TestParent initialEntries={initialEntries} userRole="Admin">
         <DataSubmissionListFilters
           columns={columns}
+          organizations={organizations}
           submitterNames={submitterNames}
           dataCommons={dataCommons}
           columnVisibilityModel={columnVisibilityModel}
@@ -536,6 +634,7 @@ describe("DataSubmissionListFilters Component", () => {
     );
 
     await waitFor(() => {
+      expect(getByTestId("organization-select-input")).toHaveValue("Org1");
       expect(getByTestId("status-select-input")).toHaveValue("Submitted");
       expect(getByTestId("data-commons-select-input")).toHaveValue("DataCommon1");
       expect(getByTestId("submission-name-input")).toHaveValue("Test");
@@ -545,6 +644,7 @@ describe("DataSubmissionListFilters Component", () => {
 
     expect(mockOnChange).toHaveBeenCalledWith(
       expect.objectContaining({
+        organization: "Org1",
         status: "Submitted",
         dataCommons: "DataCommon1",
         name: "Test",
@@ -567,6 +667,7 @@ describe("DataSubmissionListFilters Component", () => {
       <TestParent initialEntries={initialEntries} userRole="Admin">
         <DataSubmissionListFilters
           columns={columns}
+          organizations={organizations}
           submitterNames={submitterNames}
           dataCommons={dataCommons}
           columnVisibilityModel={columnVisibilityModel}
@@ -577,6 +678,7 @@ describe("DataSubmissionListFilters Component", () => {
     );
 
     await waitFor(() => {
+      expect(getByTestId("organization-select-input")).toHaveValue("All");
       expect(getByTestId("status-select-input")).toHaveValue("All");
       expect(getByTestId("data-commons-select-input")).toHaveValue("All");
       expect(getByTestId("submission-name-input")).toHaveValue("");
@@ -586,6 +688,7 @@ describe("DataSubmissionListFilters Component", () => {
 
     expect(mockOnChange).toHaveBeenCalledWith(
       expect.objectContaining({
+        organization: "All",
         status: "All",
         dataCommons: "All",
         name: "",
@@ -605,6 +708,7 @@ describe("DataSubmissionListFilters Component", () => {
       <TestParent initialEntries={initialEntries} userRole="Admin">
         <DataSubmissionListFilters
           columns={columns}
+          organizations={organizations}
           submitterNames={submitterNames}
           dataCommons={dataCommons}
           columnVisibilityModel={columnVisibilityModel}
@@ -617,6 +721,7 @@ describe("DataSubmissionListFilters Component", () => {
     await waitFor(() => {
       expect(mockOnChange).toHaveBeenCalledWith(
         expect.objectContaining({
+          organization: "All",
           status: "All",
           dataCommons: "All",
           name: "",
@@ -636,6 +741,7 @@ describe("DataSubmissionListFilters Component", () => {
       <TestParent initialEntries={initialEntries} userRole="Admin">
         <DataSubmissionListFilters
           columns={columns}
+          organizations={organizations}
           submitterNames={submitterNames}
           dataCommons={[]} // Empty dataCommons
           columnVisibilityModel={columnVisibilityModel}
@@ -679,6 +785,7 @@ describe("DataSubmissionListFilters Component", () => {
       <TestParent>
         <DataSubmissionListFilters
           columns={columns}
+          organizations={organizations}
           submitterNames={submitterNames}
           dataCommons={["DataCommon1", "DataCommon2"]} // Non-empty dataCommons
           columnVisibilityModel={columnVisibilityModel}
@@ -722,6 +829,7 @@ describe("DataSubmissionListFilters Component", () => {
       <TestParent>
         <DataSubmissionListFilters
           columns={columns}
+          organizations={organizations}
           submitterNames={[]} // Empty submitterNames
           dataCommons={dataCommons}
           columnVisibilityModel={columnVisibilityModel}
@@ -759,6 +867,7 @@ describe("DataSubmissionListFilters Component", () => {
       <TestParent>
         <DataSubmissionListFilters
           columns={columns}
+          organizations={organizations}
           submitterNames={["Submitter1", "Submitter2"]} // Non-empty submitterNames
           dataCommons={dataCommons}
           columnVisibilityModel={columnVisibilityModel}
@@ -789,6 +898,84 @@ describe("DataSubmissionListFilters Component", () => {
       expect(mockOnChange).toHaveBeenCalledWith(
         expect.objectContaining({
           submitterName: "Submitter1",
+        })
+      );
+    });
+  });
+
+  it("sets organization select to 'All' when organizations prop is empty", async () => {
+    const mockOnChange = jest.fn();
+    const mockOnColumnVisibilityModelChange = jest.fn();
+
+    const { getByTestId, getByRole } = render(
+      <TestParent>
+        <DataSubmissionListFilters
+          columns={columns}
+          organizations={[]}
+          submitterNames={submitterNames}
+          dataCommons={dataCommons}
+          columnVisibilityModel={columnVisibilityModel}
+          onColumnVisibilityModelChange={mockOnColumnVisibilityModelChange}
+          onChange={mockOnChange}
+        />
+      </TestParent>
+    );
+
+    await waitFor(() => {
+      expect(getByTestId("organization-select-input")).toHaveValue("All");
+    });
+
+    const organizationSelect = within(getByTestId("organization-select")).getByRole("button");
+    userEvent.click(organizationSelect);
+
+    const organizationList = within(getByRole("listbox", { hidden: true }));
+
+    await waitFor(() => {
+      expect(organizationList.getByTestId("organization-option-All")).toBeInTheDocument();
+      expect(organizationList.queryByTestId("organization-option-Org1")).not.toBeInTheDocument();
+      expect(organizationList.queryByTestId("organization-option-Org2")).not.toBeInTheDocument();
+    });
+  });
+
+  it("sets organization select to field.value when organizations prop is non-empty", async () => {
+    const mockOnChange = jest.fn();
+    const mockOnColumnVisibilityModelChange = jest.fn();
+
+    const { getByTestId, getByRole } = render(
+      <TestParent>
+        <DataSubmissionListFilters
+          columns={columns}
+          organizations={organizations}
+          submitterNames={submitterNames}
+          dataCommons={dataCommons}
+          columnVisibilityModel={columnVisibilityModel}
+          onColumnVisibilityModelChange={mockOnColumnVisibilityModelChange}
+          onChange={mockOnChange}
+        />
+      </TestParent>
+    );
+
+    await waitFor(() => {
+      expect(getByTestId("organization-select-input")).toHaveValue("All");
+    });
+
+    const organizationSelect = within(getByTestId("organization-select")).getByRole("button");
+    userEvent.click(organizationSelect);
+
+    const organizationList = within(getByRole("listbox", { hidden: true }));
+
+    await waitFor(() => {
+      expect(organizationList.getByTestId("organization-option-Org1")).toBeInTheDocument();
+      expect(organizationList.getByTestId("organization-option-Org2")).toBeInTheDocument();
+    });
+
+    userEvent.click(getByTestId("organization-option-Org1"));
+
+    await waitFor(() => {
+      expect(getByTestId("organization-select-input")).toHaveValue("Org1");
+      expect(mockOnChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          organization: "Org1",
         })
       );
     });

--- a/src/components/DataSubmissions/DataSubmissionListFilters.test.tsx
+++ b/src/components/DataSubmissions/DataSubmissionListFilters.test.tsx
@@ -613,7 +613,7 @@ describe("DataSubmissionListFilters Component", () => {
 
   it("initializes form fields based on searchParams", async () => {
     const initialEntries = [
-      "/?organization=Org1&status=Submitted&dataCommons=DataCommon1&name=Test&dbGaPID=123&submitterName=Submitter1",
+      "/?program=Org1&status=Submitted&dataCommons=DataCommon1&name=Test&dbGaPID=123&submitterName=Submitter1",
     ];
 
     const mockOnChange = jest.fn();

--- a/src/components/DataSubmissions/DataSubmissionListFilters.tsx
+++ b/src/components/DataSubmissions/DataSubmissionListFilters.tsx
@@ -355,7 +355,7 @@ const DataSubmissionListFilters = ({
         <Grid container spacing={2} rowSpacing="9px">
           <Grid item xs={4}>
             <StyledFormControl>
-              <StyledInlineLabel htmlFor="organization-filter">Organization</StyledInlineLabel>
+              <StyledInlineLabel htmlFor="organization-filter">Program</StyledInlineLabel>
               <Controller
                 name="organization"
                 control={control}

--- a/src/components/DataSubmissions/DataSubmissionListFilters.tsx
+++ b/src/components/DataSubmissions/DataSubmissionListFilters.tsx
@@ -180,14 +180,14 @@ const DataSubmissionListFilters = ({
       !organizationIds?.includes(orgFilter)
     ) {
       const newSearchParams = new URLSearchParams(searchParams);
-      newSearchParams.delete("organization");
+      newSearchParams.delete("program");
       setSearchParams(newSearchParams);
       setValue("organization", "All");
     }
   }, [organizations, orgFilter, touchedFilters]);
 
   useEffect(() => {
-    const organizationId = searchParams.get("organization");
+    const organizationId = searchParams.get("program");
     const status = searchParams.get("status");
     const dataCommon = searchParams.get("dataCommons");
     const name = searchParams.get("name");
@@ -225,9 +225,9 @@ const DataSubmissionListFilters = ({
     const newSearchParams = new URLSearchParams(searchParams);
 
     if (orgFilter && orgFilter !== "All") {
-      newSearchParams.set("organization", orgFilter);
+      newSearchParams.set("program", orgFilter);
     } else if (orgFilter === "All") {
-      newSearchParams.delete("organization");
+      newSearchParams.delete("program");
     }
     if (statusFilter && statusFilter !== "All") {
       newSearchParams.set("status", statusFilter);
@@ -339,7 +339,7 @@ const DataSubmissionListFilters = ({
 
   const handleResetFilters = () => {
     const newSearchParams = new URLSearchParams(searchParams);
-    searchParams.delete("organization");
+    searchParams.delete("program");
     searchParams.delete("status");
     searchParams.delete("dataCommons");
     searchParams.delete("name");

--- a/src/components/DataSubmissions/DataSubmissionSummary.test.tsx
+++ b/src/components/DataSubmissions/DataSubmissionSummary.test.tsx
@@ -264,6 +264,21 @@ describe("Basic Functionality", () => {
     const emailLink = queryByLabelText("Email Primary Contact");
     expect(emailLink).toBeNull();
   });
+
+  it("renders the Program as NA when no program is assigned", () => {
+    const dataSubmission: RecursivePartial<Submission> = {
+      organization: null,
+    };
+
+    const { getByText } = render(
+      <BaseComponent>
+        <DataSubmissionSummary dataSubmission={dataSubmission as Submission} />
+      </BaseComponent>
+    );
+
+    expect(getByText("Program")).toBeVisible();
+    expect(getByText("NA")).toBeVisible();
+  });
 });
 
 describe("DataSubmissionSummary Memoization Tests", () => {

--- a/src/components/DataSubmissions/DataSubmissionSummary.tsx
+++ b/src/components/DataSubmissions/DataSubmissionSummary.tsx
@@ -251,7 +251,10 @@ const DataSubmissionSummary: FC<Props> = ({ dataSubmission }) => {
             value={dataSubmission?.dataCommons}
             truncateAfter={false}
           />
-          <SubmissionHeaderProperty label="Program" value={dataSubmission?.organization?.name} />
+          <SubmissionHeaderProperty
+            label="Program"
+            value={dataSubmission?.organization?.name ?? "NA"}
+          />
           <SubmissionHeaderProperty
             label="Primary Contact"
             value={

--- a/src/content/dataSubmissions/DataSubmissionsListView.tsx
+++ b/src/content/dataSubmissions/DataSubmissionsListView.tsx
@@ -6,7 +6,7 @@ import { useSnackbar } from "notistack";
 import { useLazyQuery } from "@apollo/client";
 import bannerSvg from "../../assets/banner/submission_banner.png";
 import PageBanner from "../../components/PageBanner";
-import { FormatDate } from "../../utils";
+import { FormatDate, Logger } from "../../utils";
 import { useAuthContext, Status as AuthStatus } from "../../components/Contexts/AuthContext";
 import usePageTitle from "../../hooks/usePageTitle";
 import CreateDataSubmissionDialog from "../../components/DataSubmissions/CreateDataSubmissionDialog";
@@ -296,13 +296,14 @@ const ListingView: FC = () => {
       setData(d.listSubmissions.submissions);
       setOrganizations(
         d.listSubmissions.organizations
-          ?.filter((org) => !!org.name.trim())
+          ?.filter((org) => !!org?.name?.trim())
           ?.sort((a, b) => a.name?.localeCompare(b.name))
       );
       setSubmitterNames(d.listSubmissions.submitterNames?.filter((sn) => !!sn.trim()));
       setDataCommons(d.listSubmissions.dataCommons?.filter((dc) => !!dc.trim()));
       setTotalData(d.listSubmissions.total);
     } catch (err) {
+      Logger.error("Error while fetching Data Submission list", err);
       setError(true);
     } finally {
       setLoading(false);

--- a/src/content/dataSubmissions/DataSubmissionsListView.tsx
+++ b/src/content/dataSubmissions/DataSubmissionsListView.tsx
@@ -233,11 +233,13 @@ const ListingView: FC = () => {
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<boolean>(false);
   const [data, setData] = useState<T[]>([]);
+  const [organizations, setOrganizations] = useState<Pick<Organization, "_id" | "name">[]>([]);
   const [submitterNames, setSubmitterNames] = useState<string[]>([]);
   const [dataCommons, setDataCommons] = useState<string[]>([]);
   const [totalData, setTotalData] = useState<number>(0);
   const tableRef = useRef<TableMethods>(null);
   const filtersRef = useRef<FilterForm>({
+    organization: "All",
     status: "All",
     dataCommons: "All",
     name: "",
@@ -262,10 +264,18 @@ const ListingView: FC = () => {
         return;
       }
 
-      const { status, submitterName, name, dbGaPID, dataCommons: dc } = filtersRef.current;
+      const {
+        organization,
+        status,
+        submitterName,
+        name,
+        dbGaPID,
+        dataCommons: dc,
+      } = filtersRef.current;
 
       const { data: d, error } = await listSubmissions({
         variables: {
+          organization: organization ?? "All",
           status: status ?? "All",
           dataCommons: dc ?? "All",
           submitterName: submitterName ?? "All",
@@ -284,6 +294,11 @@ const ListingView: FC = () => {
       }
 
       setData(d.listSubmissions.submissions);
+      setOrganizations(
+        d.listSubmissions.organizations
+          ?.filter((org) => !!org.name.trim())
+          ?.sort((a, b) => a.name?.localeCompare(b.name))
+      );
       setSubmitterNames(d.listSubmissions.submitterNames?.filter((sn) => !!sn.trim()));
       setDataCommons(d.listSubmissions.dataCommons?.filter((dc) => !!dc.trim()));
       setTotalData(d.listSubmissions.total);
@@ -307,6 +322,11 @@ const ListingView: FC = () => {
         throw new Error("Unable to retrieve Data Submission List results.");
       }
       setData(d.listSubmissions.submissions);
+      setOrganizations(
+        d.listSubmissions.organizations
+          ?.filter((org) => !!org.name.trim())
+          ?.sort((a, b) => a.name?.localeCompare(b.name))
+      );
       setSubmitterNames(d.listSubmissions.submitterNames?.filter((sn) => !!sn.trim()));
       setDataCommons(d.listSubmissions.dataCommons?.filter((dc) => !!dc.trim()));
       setTotalData(d.listSubmissions.total);
@@ -354,6 +374,7 @@ const ListingView: FC = () => {
         <StyledFilterTableWrapper>
           <DataSubmissionListFilters
             columns={columns}
+            organizations={organizations}
             submitterNames={submitterNames}
             dataCommons={dataCommons}
             columnVisibilityModel={columnVisibilityModel}

--- a/src/content/dataSubmissions/DataSubmissionsListView.tsx
+++ b/src/content/dataSubmissions/DataSubmissionsListView.tsx
@@ -140,6 +140,11 @@ const columns: Column<T>[] = [
     },
   },
   {
+    label: "Program",
+    renderValue: (a) => <TruncatedText text={a.organization?.name ?? "NA"} />,
+    fieldKey: "organization.name",
+  },
+  {
     label: "Study",
     renderValue: (a) => <TruncatedText text={a.studyAbbreviation} />,
     field: "studyAbbreviation",

--- a/src/content/organizations/OrganizationView.tsx
+++ b/src/content/organizations/OrganizationView.tsx
@@ -395,9 +395,7 @@ const OrganizationView: FC<Props> = ({ _id }: Props) => {
               )}
 
               <StyledField>
-                <StyledLabel id="organizationName">
-                  {_id !== "new" ? "Program" : "Name"}
-                </StyledLabel>
+                <StyledLabel id="organizationName">Program</StyledLabel>
                 <StyledTextField
                   {...register("name", { required: true })}
                   inputProps={{ "aria-labelledby": "organizationName" }}

--- a/src/graphql/listSubmissions.ts
+++ b/src/graphql/listSubmissions.ts
@@ -2,6 +2,7 @@ import gql from "graphql-tag";
 
 export const query = gql`
   query listSubmissions(
+    $organization: String
     $status: String
     $dataCommons: String
     $name: String
@@ -13,6 +14,7 @@ export const query = gql`
     $sortDirection: String
   ) {
     listSubmissions(
+      organization: $organization
       status: $status
       dataCommons: $dataCommons
       name: $name
@@ -40,6 +42,10 @@ export const query = gql`
         updatedAt
         intention
       }
+      organizations {
+        _id
+        name
+      }
       submitterNames
       dataCommons
     }
@@ -47,6 +53,7 @@ export const query = gql`
 `;
 
 export type Input = {
+  organization?: string;
   status?: SubmissionStatus | "All";
   dataCommons?: string;
   name?: string;
@@ -65,6 +72,7 @@ export type Response = {
       Submission,
       "submitterID" | "bucketName" | "rootPath" | "history" | "organization"
     >[];
+    organizations: Pick<Organization, "_id" | "name">[];
     submitterNames: string[];
     dataCommons: string[];
   };

--- a/src/graphql/listSubmissions.ts
+++ b/src/graphql/listSubmissions.ts
@@ -31,6 +31,9 @@ export const query = gql`
         name
         submitterName
         dataCommons
+        organization {
+          name
+        }
         studyAbbreviation
         dbGaPID
         modelVersion
@@ -68,9 +71,23 @@ export type Input = {
 export type Response = {
   listSubmissions: {
     total: number;
-    submissions: Omit<
+    submissions: Pick<
       Submission,
-      "submitterID" | "bucketName" | "rootPath" | "history" | "organization"
+      | "_id"
+      | "name"
+      | "submitterName"
+      | "dataCommons"
+      | "organization"
+      | "studyAbbreviation"
+      | "dbGaPID"
+      | "modelVersion"
+      | "status"
+      | "archived"
+      | "conciergeName"
+      | "nodeCount"
+      | "createdAt"
+      | "updatedAt"
+      | "intention"
     >[];
     organizations: Pick<Organization, "_id" | "name">[];
     submitterNames: string[];


### PR DESCRIPTION
### Overview

Additional changes for the Program rebranding.

> [!NOTE]
> For testing, the Data Submission `8dea1607-fac8-44d5-a44e-976444fe840a` (No Program DS) was manually updated to remove the Org name and _id.

### Change Details (Specifics)

- Revert the removal of the Organization filter and column on the Data Submission List page and rename it to Program
- Fallback to "NA" when the Program is not assigned on the DS List column and DS Overview
- Add error logging when an error occurs fetching the list of Data Submissions
- Change the Program Name field to be consistently called "Program"
  - Previous requirements said to call it "Name" when adding, but "Program" (Organization) when editing

### Related Ticket(s)

CRDCDH-2139 (Task)
CRDCDH-1900 (US)
