### PR TITLE
CRDCDH-2099 PBAC - Display Submission Request Action buttons based on permissions

### DIFF
--- a/src/config/AuthPermissions.test.ts
+++ b/src/config/AuthPermissions.test.ts
@@ -1,13 +1,38 @@
 import { hasPermission } from "./AuthPermissions";
 
+const baseApplication: Application = {
+  _id: "",
+  status: "New",
+  createdAt: "",
+  updatedAt: "",
+  submittedDate: "",
+  history: [],
+  controlledAccess: false,
+  openAccess: false,
+  ORCID: "",
+  PI: "",
+  applicant: {
+    applicantID: "owner-123",
+    applicantName: "",
+    applicantEmail: "",
+  },
+  questionnaireData: null,
+  programName: "",
+  studyAbbreviation: "",
+  conditional: false,
+  pendingConditions: [],
+  programAbbreviation: "",
+  programDescription: "",
+};
+
 const createUser = (role: UserRole, permissions: AuthPermissions[] = []): User => ({
   role,
   permissions,
   notifications: [],
   _id: "user-1",
-  firstName: "",
-  lastName: "",
-  email: "",
+  firstName: "Alice",
+  lastName: "Smith",
+  email: "alice@example.com",
   dataCommons: [],
   studies: [],
   IDP: "nih",
@@ -40,7 +65,7 @@ describe("Basic Permissions", () => {
     "User",
     "Invalid-role" as UserRole,
   ])(
-    "should deny a user to view the dashboard if they have permission, regardless of '%s' role",
+    "should deny a user to view the dashboard if they do not have permission, regardless of '%s' role",
     (role) => {
       const user = createUser(role, []);
       expect(hasPermission(user, "dashboard", "view")).toBe(false);
@@ -67,5 +92,65 @@ describe("Edge Cases", () => {
   it("should deny permission if the resource is invalid", () => {
     const user = createUser("Admin");
     expect(hasPermission(user, "invalid_resource" as never, "view" as never)).toBe(false);
+  });
+});
+
+describe("submission_request:submit Permission", () => {
+  const validStatuses: ApplicationStatus[] = ["In Progress", "Inquired"];
+  const invalidStatuses: ApplicationStatus[] = [
+    "Approved",
+    "In Review",
+    "New",
+    "Rejected",
+    "Submitted",
+  ];
+
+  it.each(validStatuses)(
+    "should allow the form owner to submit if the status is '%s' without the permission",
+    (status) => {
+      const user = createUser("Submitter", []);
+
+      const application: Application = {
+        ...baseApplication,
+        status,
+        applicant: {
+          ...baseApplication.applicant,
+          applicantID: "user-1",
+        },
+      };
+
+      expect(hasPermission(user, "submission_request", "submit", application)).toBe(true);
+    }
+  );
+
+  it.each(validStatuses)(
+    "should allow a user with 'submission_request:submit' permission key if the status is '%s', even if not owner",
+    (status) => {
+      const user = createUser("Submitter", ["submission_request:submit"]);
+      const application: Application = { ...baseApplication, status };
+
+      expect(hasPermission(user, "submission_request", "submit", application)).toBe(true);
+    }
+  );
+
+  it("should deny submission if the user is not the owner AND lacks the 'submission_request:submit' permission key", () => {
+    const user = createUser("Submitter", []);
+    const application: Application = { ...baseApplication, status: "In Progress" };
+
+    expect(hasPermission(user, "submission_request", "submit", application)).toBe(false);
+  });
+
+  it.each(invalidStatuses)("should deny submission if the application status is '%s'", (status) => {
+    const user = createUser("Submitter", ["submission_request:submit"]);
+    const application: Application = { ...baseApplication, status };
+
+    expect(hasPermission(user, "submission_request", "submit", application)).toBe(false);
+  });
+
+  it("should return false if application is missing or undefined", () => {
+    const user = createUser("Submitter", ["submission_request:submit"]);
+
+    expect(hasPermission(user, "submission_request", "submit", undefined)).toBe(false);
+    expect(hasPermission(user, "submission_request", "submit", null)).toBe(false);
   });
 });

--- a/src/config/AuthPermissions.ts
+++ b/src/config/AuthPermissions.ts
@@ -45,7 +45,21 @@ export const PERMISSION_MAP = {
   submission_request: {
     view: NO_CONDITIONS,
     create: NO_CONDITIONS,
-    submit: NO_CONDITIONS,
+    submit: (user, application) => {
+      const isFormOwner = application?.applicant?.applicantID === user?._id;
+      const hasPermissionKey = user?.permissions?.includes("submission_request:submit");
+      const submitStatuses: ApplicationStatus[] = ["In Progress", "Inquired"];
+
+      // Check for implicit permission as well as for the permission key
+      if (!isFormOwner && !hasPermissionKey) {
+        return false;
+      }
+      if (!submitStatuses?.includes(application?.status)) {
+        return false;
+      }
+
+      return true;
+    },
     review: NO_CONDITIONS,
   },
   dashboard: {

--- a/src/config/AuthPermissions.ts
+++ b/src/config/AuthPermissions.ts
@@ -46,7 +46,8 @@ export const ROLES = {
     submission_request: {
       view: true,
       create: true,
-      submit: true,
+      submit: (_, submission) =>
+        (["In Progress", "Inquired"] as ApplicationStatus[]).includes(submission?.status),
       review: true,
     },
     dashboard: {
@@ -136,7 +137,7 @@ export const ROLES = {
     submission_request: {
       view: false,
       create: true,
-      submit: false,
+      submit: false, // Associated with Submission owner, but permission is never granted
       review: false,
     },
     dashboard: {

--- a/src/content/questionnaire/FormView.tsx
+++ b/src/content/questionnaire/FormView.tsx
@@ -626,15 +626,6 @@ const FormView: FC<Props> = ({ section }: Props) => {
   });
 
   useEffect(() => {
-    const formLoaded = status === FormStatus.LOADED && authStatus === AuthStatus.LOADED && data;
-    const invalidFormAuth = formMode === "Unauthorized" || authStatus === AuthStatus.ERROR || !user;
-
-    if (formLoaded && invalidFormAuth) {
-      navigate("/");
-    }
-  }, [formMode, navigate, status, authStatus, user, data]);
-
-  useEffect(() => {
     const isComplete = isAllSectionsComplete();
     setAllSectionsComplete(isComplete);
   }, [status, data]);

--- a/src/content/questionnaire/FormView.tsx
+++ b/src/content/questionnaire/FormView.tsx
@@ -170,7 +170,6 @@ const FormView: FC<Props> = ({ section }: Props) => {
     ? `/submission/${data?.["_id"]}/${sectionKeys[sectionIndex + 1]}`
     : null;
   const isSectionD = activeSection === "D";
-  const isFormOwner = data?.applicant?.applicantID === user?._id;
   const formContentRef = useRef(null);
   const lastSectionRef = useRef(null);
   const hasReopenedFormRef = useRef(false);
@@ -540,11 +539,7 @@ const FormView: FC<Props> = ({ section }: Props) => {
 
   const handleSubmitForm = () => {
     if (!hasPermission(user, "submission_request", "submit", data)) {
-      Logger.error("Invalid request to submit Submission Request form.", {
-        isFormOwner,
-        hasPermission,
-        submissionStatus: data?.status,
-      });
+      Logger.error("Invalid request to submit Submission Request form.");
       return;
     }
     setOpenSubmitDialog(true);

--- a/src/content/questionnaire/FormView.tsx
+++ b/src/content/questionnaire/FormView.tsx
@@ -170,6 +170,7 @@ const FormView: FC<Props> = ({ section }: Props) => {
     ? `/submission/${data?.["_id"]}/${sectionKeys[sectionIndex + 1]}`
     : null;
   const isSectionD = activeSection === "D";
+  const isFormOwner = data?.applicant?.applicantID === user?._id;
   const formContentRef = useRef(null);
   const lastSectionRef = useRef(null);
   const hasReopenedFormRef = useRef(false);
@@ -539,12 +540,12 @@ const FormView: FC<Props> = ({ section }: Props) => {
 
   const handleSubmitForm = () => {
     if (
-      !hasPermission(user, "submission_request", "submit", data) ||
-      (data?.status !== "In Progress" &&
-        (data?.status !== "Inquired" || user?.role !== "Federal Lead"))
+      (!isFormOwner && !hasPermission(user, "submission_request", "submit", data)) ||
+      !["In Progress", "Inquired"].includes(data?.status)
     ) {
       Logger.error("Invalid request to submit Submission Request form.", {
-        userRole: user?.role,
+        isFormOwner,
+        hasPermission,
         submissionStatus: data?.status,
       });
       return;
@@ -730,7 +731,9 @@ const FormView: FC<Props> = ({ section }: Props) => {
               )}
 
               {activeSection === "REVIEW" &&
-                hasPermission(user, "submission_request", "submit") &&
+                // Submission Request owners aren't granted the permission,
+                // but should be allowed to submit
+                (isFormOwner || hasPermission(user, "submission_request", "submit", data)) &&
                 ["In Progress", "Inquired"].includes(data?.status) && (
                   <StyledExtendedLoadingButton
                     id="submission-form-submit-button"

--- a/src/content/questionnaire/FormView.tsx
+++ b/src/content/questionnaire/FormView.tsx
@@ -539,10 +539,7 @@ const FormView: FC<Props> = ({ section }: Props) => {
   };
 
   const handleSubmitForm = () => {
-    if (
-      (!isFormOwner && !hasPermission(user, "submission_request", "submit", data)) ||
-      !["In Progress", "Inquired"].includes(data?.status)
-    ) {
+    if (!hasPermission(user, "submission_request", "submit", data)) {
       Logger.error("Invalid request to submit Submission Request form.", {
         isFormOwner,
         hasPermission,
@@ -731,10 +728,7 @@ const FormView: FC<Props> = ({ section }: Props) => {
               )}
 
               {activeSection === "REVIEW" &&
-                // Submission Request owners aren't granted the permission,
-                // but should be allowed to submit
-                (isFormOwner || hasPermission(user, "submission_request", "submit", data)) &&
-                ["In Progress", "Inquired"].includes(data?.status) && (
+                hasPermission(user, "submission_request", "submit", data) && (
                   <StyledExtendedLoadingButton
                     id="submission-form-submit-button"
                     variant="contained"

--- a/src/hooks/useFormMode.ts
+++ b/src/hooks/useFormMode.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { Status as AuthStatus, useAuthContext } from "../components/Contexts/AuthContext";
 import { Status as FormStatus, useFormContext } from "../components/Contexts/FormContext";
-import { FormMode, FormModes, getFormMode } from "../utils";
+import { FormMode, FormModes, getFormMode, Logger } from "../utils";
 
 const useFormMode = () => {
   const { user, status: authStatus } = useAuthContext();
@@ -15,10 +15,15 @@ const useFormMode = () => {
     }
 
     const updatedFormMode: FormMode = getFormMode(user, data);
+    if (updatedFormMode === FormModes.UNAUTHORIZED) {
+      Logger.error("useFormMode: User is unauthorized to view this Submission Request.", {
+        user,
+        data,
+      });
+    }
+
     setFormMode(updatedFormMode);
-    setReadOnlyInputs(
-      updatedFormMode === FormModes.VIEW_ONLY || updatedFormMode === FormModes.REVIEW
-    );
+    setReadOnlyInputs(updatedFormMode !== FormModes.EDIT);
   }, [user, data]);
 
   return { formMode, readOnlyInputs };

--- a/src/utils/formModeUtils.test.ts
+++ b/src/utils/formModeUtils.test.ts
@@ -297,10 +297,14 @@ describe("getFormMode tests based on provided requirements", () => {
         expect(utils.getFormMode(null, null)).toBe(utils.FormModes.UNAUTHORIZED);
       });
 
-      it("should set Unauthorized form if user does not have the required permissions", () => {
+      it("should set Unauthorized form if user does not have the required permissions and is not submission owner", () => {
         const user: User = { ...baseUser, role: undefined, permissions: [] };
+        const submission: Application = {
+          ...baseSubmission,
+          applicant: { ...baseSubmission.applicant, applicantID: "some-other-user" },
+        };
 
-        expect(utils.getFormMode(user, baseSubmission)).toBe(utils.FormModes.UNAUTHORIZED);
+        expect(utils.getFormMode(user, submission)).toBe(utils.FormModes.UNAUTHORIZED);
       });
 
       it("should set 'View Only' if form status is unknown or not defined", () => {

--- a/src/utils/formModeUtils.ts
+++ b/src/utils/formModeUtils.ts
@@ -29,6 +29,7 @@ export const getFormMode = (user: User, data: Application): FormMode => {
   }
 
   if (
+    !isFormOwner &&
     !hasPermission(user, "submission_request", "view") &&
     !hasPermission(user, "submission_request", "create") &&
     !hasPermission(user, "submission_request", "review")

--- a/src/utils/formModeUtils.ts
+++ b/src/utils/formModeUtils.ts
@@ -44,7 +44,12 @@ export const getFormMode = (user: User, data: Application): FormMode => {
     return FormModes.REVIEW;
   }
 
-  if (hasPermission(user, "submission_request", "create") && EditStatuses.includes(data?.status)) {
+  // User is only allowed to edit their own Submission Request
+  if (
+    isFormOwner &&
+    hasPermission(user, "submission_request", "create") &&
+    EditStatuses.includes(data?.status)
+  ) {
     return FormModes.EDIT;
   }
 

--- a/src/utils/formModeUtils.ts
+++ b/src/utils/formModeUtils.ts
@@ -23,10 +23,8 @@ export const getFormMode = (user: User, data: Application): FormMode => {
   if (!data) {
     return FormModes.UNAUTHORIZED;
   }
-  if (
-    !hasPermission(user, "submission_request", "view") &&
-    user?._id !== data.applicant?.applicantID
-  ) {
+  const isFormOwner = user?._id === data.applicant?.applicantID;
+  if (!hasPermission(user, "submission_request", "view") && !isFormOwner) {
     return FormModes.UNAUTHORIZED;
   }
 


### PR DESCRIPTION
### Overview

Update to support PBAC for Submission Request list view as well as the form. 

### Change Details (Specifics)

- Fixed the Submit button logic as the US mentions that Submission Request form owners are associated with the "create" permission, but aren't actually granted it. Therefore, logic has been updated to support having either the permission or being the form owner
- Verified changes in parent branch (no code changes required) for:
  - "Start a Submission Request" button only visible if user has "create" permissions
  - "Resume" button only visible if user has "create" permissions and submission is in "New", "In Progress", or "Inquired" status. (Otherwise "View")
  - "Review" button only visible if user has "review" permissions and submission is in "Submitted" or "In Review" status. (Otherwise "View")
  - The review related buttons within the form such as "Approve", "Reject" and "Request Additional Changes" are only visible if user has "review" permissions and submission is in "In Review" status.
- Removed redirect when user is unauthorized to view Submission Request, instead it will just log it and put them in "View Only". This should be handled by BE instead.

> [!Note]
> For testing, you will have to manually add the permissions array property to your user in the DB.

### Related Ticket(s)

[CRDCDH-2099](https://tracker.nci.nih.gov/browse/CRDCDH-2099) (Task)
[CRDCDH-2013](https://tracker.nci.nih.gov/browse/CRDCDH-2013) (User Story)
