### PR TITLE
CRDCDH-2105 PBAC – Individual Permissions Control of User Accounts

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -31,6 +31,15 @@ const cache = new InMemoryCache({
     Collaborator: {
       keyFields: ["collaboratorID"],
     },
+    PBACDefaults: {
+      keyFields: ["role"],
+    },
+    Permission: {
+      keyFields: false,
+    },
+    Notification: {
+      keyFields: false,
+    },
   },
 });
 

--- a/src/components/PermissionPanel/index.test.tsx
+++ b/src/components/PermissionPanel/index.test.tsx
@@ -1,5 +1,5 @@
 import { MockedProvider, MockedResponse } from "@apollo/client/testing";
-import { act, render, within } from "@testing-library/react";
+import { act, render, waitFor, within } from "@testing-library/react";
 import { FormProvider, FormProviderProps } from "react-hook-form";
 import { axe } from "jest-axe";
 import { FC } from "react";
@@ -193,7 +193,7 @@ describe("Basic Functionality", () => {
                   _id: "submission_request:create",
                   group: "Submission Request",
                   name: "Create",
-                  checked: false,
+                  checked: true,
                   disabled: false,
                 },
                 {
@@ -234,7 +234,12 @@ describe("Basic Functionality", () => {
     };
 
     const mockWatcher = jest.fn().mockImplementation((field) => {
-      if (field === "role") return "Admin";
+      // Return the selected role (e.g. watch("role"))
+      if (field === "role") {
+        return "Submitter";
+      }
+
+      // Return the selected permissions (e.g. watch("permissions"))
       return [];
     });
 
@@ -246,11 +251,14 @@ describe("Basic Functionality", () => {
       ),
     });
 
-    const srGroup = getByTestId("permissions-group-Submission Request");
-    expect(srGroup).toBeInTheDocument();
-    expect(within(srGroup).getByTestId("permission-submission_request:create")).toBeInTheDocument();
-    const dsGroup = getByTestId("permissions-group-Data Submission");
+    await waitFor(() => {
+      expect(getByTestId("permissions-group-Submission Request")).toBeInTheDocument();
+    });
 
+    const srGroup = getByTestId("permissions-group-Submission Request");
+    expect(within(srGroup).getByTestId("permission-submission_request:create")).toBeInTheDocument();
+
+    const dsGroup = getByTestId("permissions-group-Data Submission");
     expect(dsGroup).toBeInTheDocument();
     expect(within(dsGroup).getByTestId("permission-data_submission:view")).toBeInTheDocument();
 
@@ -258,10 +266,10 @@ describe("Basic Functionality", () => {
     expect(adminGroup).toBeInTheDocument();
     expect(within(adminGroup).getByTestId("permission-program:manage")).toBeInTheDocument();
 
-    const dsNotifGroup = getByTestId("notifications-group-Data Submissions");
-    expect(dsNotifGroup).toBeInTheDocument();
+    const dsEmailGroup = getByTestId("notifications-group-Data Submissions");
+    expect(dsEmailGroup).toBeInTheDocument();
     expect(
-      within(dsNotifGroup).getByTestId("notification-data_submission:cancelled")
+      within(dsEmailGroup).getByTestId("notification-data_submission:cancelled")
     ).toBeInTheDocument();
 
     const accountGroup = getByTestId("notifications-group-Account");
@@ -296,6 +304,10 @@ describe("Implementation Requirements", () => {
   it.todo("should allow disabled permissions to be checked by default");
 
   it.todo("should be rendered as collapsed by default");
+
+  it.todo(
+    "should sort the permission groups in the following order: Submission Request, Data Submission, Admin, Miscellaneous"
+  );
 
   it.todo("should propagate the permissions selections to the parent form");
 

--- a/src/components/PermissionPanel/index.test.tsx
+++ b/src/components/PermissionPanel/index.test.tsx
@@ -1,0 +1,303 @@
+import { MockedProvider, MockedResponse } from "@apollo/client/testing";
+import { act, render, within } from "@testing-library/react";
+import { FormProvider, FormProviderProps } from "react-hook-form";
+import { axe } from "jest-axe";
+import { FC } from "react";
+import PermissionPanel from "./index";
+import {
+  RETRIEVE_PBAC_DEFAULTS,
+  RetrievePBACDefaultsInput,
+  RetrievePBACDefaultsResp,
+} from "../../graphql";
+
+type MockParentProps = {
+  children: React.ReactNode;
+  methods?: FormProviderProps<unknown>;
+  mocks?: MockedResponse[];
+};
+
+const MockParent: FC<MockParentProps> = ({ children, methods, mocks = [] }) => (
+  <MockedProvider mocks={mocks}>
+    <FormProvider
+      watch={jest.fn().mockImplementation(() => []) as FormProviderProps["watch"]}
+      setValue={jest.fn()}
+      {...methods}
+    >
+      {children}
+    </FormProvider>
+  </MockedProvider>
+);
+
+describe("Accessibility", () => {
+  it("should not have any accessibility violations (empty)", async () => {
+    const mock: MockedResponse<RetrievePBACDefaultsResp, RetrievePBACDefaultsInput> = {
+      request: {
+        query: RETRIEVE_PBAC_DEFAULTS,
+        variables: { roles: ["All"] },
+      },
+      result: {
+        data: {
+          retrievePBACDefaults: [
+            {
+              role: "Submitter",
+              permissions: [],
+              notifications: [],
+            },
+          ],
+        },
+      },
+    };
+
+    const { container } = render(<PermissionPanel role="Submitter" />, {
+      wrapper: ({ children }) => <MockParent mocks={[mock]}>{children}</MockParent>,
+    });
+
+    let result;
+    await act(async () => {
+      result = await axe(container);
+    });
+    expect(result).toHaveNoViolations();
+  });
+
+  it("should not have any accessibility violations (populated)", async () => {
+    const mock: MockedResponse<RetrievePBACDefaultsResp, RetrievePBACDefaultsInput> = {
+      request: {
+        query: RETRIEVE_PBAC_DEFAULTS,
+        variables: { roles: ["All"] },
+      },
+      result: {
+        data: {
+          retrievePBACDefaults: [
+            {
+              role: "Submitter",
+              permissions: [
+                {
+                  _id: "submission_request:create",
+                  group: "Submission Request",
+                  name: "Create",
+                  checked: false,
+                  disabled: false,
+                },
+                {
+                  _id: "data_submission:view",
+                  group: "Data Submission",
+                  name: "View",
+                  checked: true,
+                  disabled: true,
+                },
+              ],
+              notifications: [
+                {
+                  _id: "data_submission:cancelled",
+                  group: "Data Submissions",
+                  name: "Cancelled",
+                  checked: false,
+                  disabled: false,
+                },
+                {
+                  _id: "account:disabled",
+                  group: "Account",
+                  name: "Disabled",
+                  checked: false,
+                  disabled: false,
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const { container } = render(<PermissionPanel role="Submitter" />, {
+      wrapper: ({ children }) => <MockParent mocks={[mock]}>{children}</MockParent>,
+    });
+
+    let result;
+    await act(async () => {
+      result = await axe(container);
+    });
+    expect(result).toHaveNoViolations();
+  });
+});
+
+describe("Basic Functionality", () => {
+  it("should not crash when rendered", async () => {
+    const mock: MockedResponse<RetrievePBACDefaultsResp, RetrievePBACDefaultsInput> = {
+      request: {
+        query: RETRIEVE_PBAC_DEFAULTS,
+        variables: { roles: ["All"] },
+      },
+      result: {
+        data: {
+          retrievePBACDefaults: [
+            {
+              role: "Submitter",
+              permissions: [],
+              notifications: [],
+            },
+          ],
+        },
+      },
+    };
+
+    render(<PermissionPanel role="Submitter" />, {
+      wrapper: ({ children }) => <MockParent mocks={[mock]}>{children}</MockParent>,
+    });
+  });
+
+  it("should cache the default PBAC data by default", async () => {
+    const mockMatcher = jest.fn().mockImplementation(() => true);
+    const mock: MockedResponse<RetrievePBACDefaultsResp, RetrievePBACDefaultsInput> = {
+      request: {
+        query: RETRIEVE_PBAC_DEFAULTS,
+      },
+      variableMatcher: mockMatcher,
+      result: {
+        data: {
+          retrievePBACDefaults: [
+            {
+              role: "Submitter",
+              permissions: [],
+              notifications: [],
+            },
+          ],
+        },
+      },
+      maxUsageCount: 999,
+    };
+
+    const { rerender } = render(<PermissionPanel role="Submitter" />, {
+      wrapper: ({ children }) => <MockParent mocks={[mock]}>{children}</MockParent>,
+    });
+
+    expect(mockMatcher).toHaveBeenCalledTimes(1);
+
+    rerender(<PermissionPanel role="Admin" />);
+
+    expect(mockMatcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("should group the permissions by their pre-defined groups", async () => {
+    const mock: MockedResponse<RetrievePBACDefaultsResp, RetrievePBACDefaultsInput> = {
+      request: {
+        query: RETRIEVE_PBAC_DEFAULTS,
+        variables: { roles: ["All"] },
+      },
+      result: {
+        data: {
+          retrievePBACDefaults: [
+            {
+              role: "Submitter",
+              permissions: [
+                {
+                  _id: "submission_request:create",
+                  group: "Submission Request",
+                  name: "Create",
+                  checked: false,
+                  disabled: false,
+                },
+                {
+                  _id: "data_submission:view",
+                  group: "Data Submission",
+                  name: "View",
+                  checked: true,
+                  disabled: true,
+                },
+                {
+                  _id: "program:manage",
+                  group: "Admin",
+                  name: "Manage Programs",
+                  checked: false,
+                  disabled: false,
+                },
+              ],
+              notifications: [
+                {
+                  _id: "data_submission:cancelled",
+                  group: "Data Submissions",
+                  name: "Cancelled",
+                  checked: false,
+                  disabled: false,
+                },
+                {
+                  _id: "account:disabled",
+                  group: "Account",
+                  name: "Disabled",
+                  checked: false,
+                  disabled: false,
+                },
+              ],
+            },
+          ],
+        },
+      },
+    };
+
+    const mockWatcher = jest.fn().mockImplementation((field) => {
+      if (field === "role") return "Admin";
+      return [];
+    });
+
+    const { getByTestId } = render(<PermissionPanel role="Submitter" />, {
+      wrapper: ({ children }) => (
+        <MockParent mocks={[mock]} methods={{ watch: mockWatcher } as unknown as FormProviderProps}>
+          {children}
+        </MockParent>
+      ),
+    });
+
+    const srGroup = getByTestId("permissions-group-Submission Request");
+    expect(srGroup).toBeInTheDocument();
+    expect(within(srGroup).getByTestId("permission-submission_request:create")).toBeInTheDocument();
+    const dsGroup = getByTestId("permissions-group-Data Submission");
+
+    expect(dsGroup).toBeInTheDocument();
+    expect(within(dsGroup).getByTestId("permission-data_submission:view")).toBeInTheDocument();
+
+    const adminGroup = getByTestId("permissions-group-Admin");
+    expect(adminGroup).toBeInTheDocument();
+    expect(within(adminGroup).getByTestId("permission-program:manage")).toBeInTheDocument();
+
+    const dsNotifGroup = getByTestId("notifications-group-Data Submissions");
+    expect(dsNotifGroup).toBeInTheDocument();
+    expect(
+      within(dsNotifGroup).getByTestId("notification-data_submission:cancelled")
+    ).toBeInTheDocument();
+
+    const accountGroup = getByTestId("notifications-group-Account");
+    expect(accountGroup).toBeInTheDocument();
+    expect(within(accountGroup).getByTestId("notification-account:disabled")).toBeInTheDocument();
+  });
+
+  it.todo("should utilize a maximum of 3 columns for the permissions");
+
+  it.todo("should utilize a maximum of 3 columns for the notifications");
+
+  it.todo(
+    "should utilize the current permissions to determine the checked state of each permission"
+  );
+
+  it.todo("should log an error when unable to retrieve the default PBAC details (GraphQL)");
+
+  it.todo("should log an error when unable to retrieve the default PBAC details (Network)");
+
+  it.todo("should log an error when unable to retrieve the default PBAC details (API)");
+
+  it.todo("should log an error when a permission is assigned but not provided in the defaults");
+
+  it.todo("should log an error when a notification is assigned but not provided in the defaults");
+
+  it.todo("should render a loading state when fetching the default PBAC details");
+});
+
+describe("Implementation Requirements", () => {
+  it.todo("should reset the permissions to their default values when the role changes");
+
+  it.todo("should allow disabled permissions to be checked by default");
+
+  it.todo("should be rendered as collapsed by default");
+
+  it.todo("should propagate the permissions selections to the parent form");
+
+  it.todo("should propagate the notification selections to the parent form");
+});

--- a/src/components/PermissionPanel/index.test.tsx
+++ b/src/components/PermissionPanel/index.test.tsx
@@ -986,10 +986,6 @@ describe("Implementation Requirements", () => {
     );
   });
 
-  it.todo(
-    "should sort the permission groups in the following order: Submission Request, Data Submission, Admin, Miscellaneous"
-  );
-
   it("should propagate the permission and notification selections to the parent form", async () => {
     const mock: MockedResponse<RetrievePBACDefaultsResp, RetrievePBACDefaultsInput> = {
       request: {

--- a/src/components/PermissionPanel/index.test.tsx
+++ b/src/components/PermissionPanel/index.test.tsx
@@ -299,6 +299,13 @@ describe("Basic Functionality", () => {
                   disabled: false,
                 },
                 {
+                  _id: "submission_request:submit",
+                  group: "Group1",
+                  name: "Create",
+                  checked: true,
+                  disabled: false,
+                },
+                {
                   _id: "submission_request:review",
                   group: "Group2",
                   name: "Create",
@@ -406,6 +413,13 @@ describe("Basic Functionality", () => {
                   _id: "access:requested",
                   group: "Group1",
                   name: "Notification 1",
+                  checked: true,
+                  disabled: false,
+                },
+                {
+                  _id: "data_submission:deleted",
+                  group: "Group1",
+                  name: "Notification 1-2",
                   checked: true,
                   disabled: false,
                 },
@@ -852,7 +866,7 @@ describe("Implementation Requirements", () => {
                   group: "Submission Request",
                   name: "Create",
                   checked: true,
-                  disabled: false,
+                  disabled: true,
                 },
                 {
                   _id: "data_submission:view",
@@ -882,6 +896,7 @@ describe("Implementation Requirements", () => {
           ],
         },
       },
+      maxUsageCount: 999,
     };
 
     const formValues = {
@@ -911,7 +926,6 @@ describe("Implementation Requirements", () => {
     formValues.role = "Submitter";
 
     rerender(<PermissionPanel />);
-    rerender(<PermissionPanel />);
 
     await waitFor(() => {
       expect(getByTestId("permission-submission_request:create")).toBeInTheDocument();
@@ -921,9 +935,10 @@ describe("Implementation Requirements", () => {
       within(getByTestId("permission-submission_request:create")).getByRole("checkbox", {
         hidden: true,
       })
-    ).toBeChecked();
+    ).toBeDisabled();
+
     expect(
-      within(getByTestId("permission-submission_request:create")).getByRole("checkbox", {
+      within(getByTestId("notification-data_submission:cancelled")).getByRole("checkbox", {
         hidden: true,
       })
     ).toBeDisabled();
@@ -1022,7 +1037,7 @@ describe("Implementation Requirements", () => {
       formValues[field] = value;
     });
 
-    const { getByTestId } = render(<PermissionPanel />, {
+    const { getByTestId, rerender } = render(<PermissionPanel />, {
       wrapper: ({ children }) => (
         <MockParent
           mocks={[mock]}
@@ -1045,6 +1060,16 @@ describe("Implementation Requirements", () => {
 
     expect(mockSetValue).toHaveBeenCalledWith("permissions", ["submission_request:create"]);
 
+    rerender(<PermissionPanel />); // Force the watch() to be called again and update the form values
+
+    userEvent.click(
+      within(getByTestId("permission-submission_request:create")).getByRole("checkbox", {
+        hidden: true,
+      })
+    );
+
+    expect(mockSetValue).toHaveBeenCalledWith("permissions", []);
+
     userEvent.click(
       within(getByTestId("notification-data_submission:cancelled")).getByRole("checkbox", {
         hidden: true,
@@ -1052,6 +1077,16 @@ describe("Implementation Requirements", () => {
     );
 
     expect(mockSetValue).toHaveBeenCalledWith("notifications", ["data_submission:cancelled"]);
+
+    rerender(<PermissionPanel />); // Force the watch() to be called again and update the form values
+
+    userEvent.click(
+      within(getByTestId("notification-data_submission:cancelled")).getByRole("checkbox", {
+        hidden: true,
+      })
+    );
+
+    expect(mockSetValue).toHaveBeenCalledWith("notifications", []);
   });
 
   it("should render a notice when there are no default PBAC details for a role", async () => {

--- a/src/components/PermissionPanel/index.test.tsx
+++ b/src/components/PermissionPanel/index.test.tsx
@@ -300,4 +300,32 @@ describe("Implementation Requirements", () => {
   it.todo("should propagate the permissions selections to the parent form");
 
   it.todo("should propagate the notification selections to the parent form");
+
+  it("should render a notice when there are no default PBAC details for a role", async () => {
+    const mock: MockedResponse<RetrievePBACDefaultsResp, RetrievePBACDefaultsInput> = {
+      request: {
+        query: RETRIEVE_PBAC_DEFAULTS,
+        variables: { roles: ["All"] },
+      },
+      result: {
+        data: {
+          retrievePBACDefaults: [],
+        },
+      },
+    };
+
+    const { getByTestId } = render(<PermissionPanel role="Submitter" />, {
+      wrapper: ({ children }) => <MockParent mocks={[mock]}>{children}</MockParent>,
+    });
+
+    expect(getByTestId("no-permissions-notice")).toBeInTheDocument();
+    expect(getByTestId("no-permissions-notice")).toHaveTextContent(
+      /No permission options found for this role./i
+    );
+
+    expect(getByTestId("no-notifications-notice")).toBeInTheDocument();
+    expect(getByTestId("no-notifications-notice")).toHaveTextContent(
+      /No notification options found for this role./i
+    );
+  });
 });

--- a/src/components/PermissionPanel/index.test.tsx
+++ b/src/components/PermissionPanel/index.test.tsx
@@ -50,7 +50,7 @@ describe("Accessibility", () => {
       },
     };
 
-    const { container } = render(<PermissionPanel role="Submitter" />, {
+    const { container } = render(<PermissionPanel />, {
       wrapper: ({ children }) => <MockParent mocks={[mock]}>{children}</MockParent>,
     });
 
@@ -110,7 +110,7 @@ describe("Accessibility", () => {
       },
     };
 
-    const { container } = render(<PermissionPanel role="Submitter" />, {
+    const { container } = render(<PermissionPanel />, {
       wrapper: ({ children }) => <MockParent mocks={[mock]}>{children}</MockParent>,
     });
 
@@ -142,7 +142,7 @@ describe("Basic Functionality", () => {
       },
     };
 
-    render(<PermissionPanel role="Submitter" />, {
+    render(<PermissionPanel />, {
       wrapper: ({ children }) => <MockParent mocks={[mock]}>{children}</MockParent>,
     });
   });
@@ -168,13 +168,13 @@ describe("Basic Functionality", () => {
       maxUsageCount: 999,
     };
 
-    const { rerender } = render(<PermissionPanel role="Submitter" />, {
+    const { rerender } = render(<PermissionPanel />, {
       wrapper: ({ children }) => <MockParent mocks={[mock]}>{children}</MockParent>,
     });
 
     expect(mockMatcher).toHaveBeenCalledTimes(1);
 
-    rerender(<PermissionPanel role="Admin" />);
+    rerender(<PermissionPanel />);
 
     expect(mockMatcher).toHaveBeenCalledTimes(1);
   });
@@ -245,7 +245,7 @@ describe("Basic Functionality", () => {
       return [];
     });
 
-    const { getByTestId } = render(<PermissionPanel role="Submitter" />, {
+    const { getByTestId } = render(<PermissionPanel />, {
       wrapper: ({ children }) => (
         <MockParent mocks={[mock]} methods={{ watch: mockWatcher } as unknown as FormProviderProps}>
           {children}
@@ -349,7 +349,7 @@ describe("Basic Functionality", () => {
       return [];
     });
 
-    const { getByTestId, queryByTestId } = render(<PermissionPanel role="Submitter" />, {
+    const { getByTestId, queryByTestId } = render(<PermissionPanel />, {
       wrapper: ({ children }) => (
         <MockParent mocks={[mock]} methods={{ watch: mockWatcher } as unknown as FormProviderProps}>
           {children}
@@ -459,7 +459,7 @@ describe("Basic Functionality", () => {
       return [];
     });
 
-    const { getByTestId, queryByTestId } = render(<PermissionPanel role="Submitter" />, {
+    const { getByTestId, queryByTestId } = render(<PermissionPanel />, {
       wrapper: ({ children }) => (
         <MockParent mocks={[mock]} methods={{ watch: mockWatcher } as unknown as FormProviderProps}>
           {children}
@@ -510,7 +510,7 @@ describe("Basic Functionality", () => {
       },
     };
 
-    render(<PermissionPanel role="Submitter" />, {
+    render(<PermissionPanel />, {
       wrapper: ({ children }) => <MockParent mocks={[mock]}>{children}</MockParent>,
     });
 
@@ -530,7 +530,7 @@ describe("Basic Functionality", () => {
       error: new Error("Network error"),
     };
 
-    render(<PermissionPanel role="Submitter" />, {
+    render(<PermissionPanel />, {
       wrapper: ({ children }) => <MockParent mocks={[mock]}>{children}</MockParent>,
     });
 
@@ -615,7 +615,7 @@ describe("Implementation Requirements", () => {
       return [];
     });
 
-    const { getByTestId } = render(<PermissionPanel role="Submitter" />, {
+    const { getByTestId } = render(<PermissionPanel />, {
       wrapper: ({ children }) => (
         <MockParent mocks={[mock]} methods={{ watch: mockWatcher } as unknown as FormProviderProps}>
           {children}
@@ -757,7 +757,7 @@ describe("Implementation Requirements", () => {
       formValues[field] = value;
     });
 
-    const { getByTestId, rerender } = render(<PermissionPanel role="Submitter" />, {
+    const { getByTestId, rerender } = render(<PermissionPanel />, {
       wrapper: ({ children }) => (
         <MockParent
           mocks={[mock]}
@@ -803,8 +803,8 @@ describe("Implementation Requirements", () => {
     // Change the role
     formValues.role = "Federal Lead";
 
-    rerender(<PermissionPanel role="Submitter" />); // The original role is "Submitter", nothing should change
-    rerender(<PermissionPanel role="Submitter" />); // This is a work-around to trigger the UI update
+    rerender(<PermissionPanel />); // The original role is "Submitter", nothing should change
+    rerender(<PermissionPanel />); // This is a work-around to trigger the UI update
 
     // Checked permissions by default based on the NEW role
     expect(
@@ -896,7 +896,7 @@ describe("Implementation Requirements", () => {
       formValues[field] = value;
     });
 
-    const { getByTestId, rerender } = render(<PermissionPanel role="Federal Lead" />, {
+    const { getByTestId, rerender } = render(<PermissionPanel />, {
       wrapper: ({ children }) => (
         <MockParent
           mocks={[mock]}
@@ -910,8 +910,8 @@ describe("Implementation Requirements", () => {
     // Trigger role change
     formValues.role = "Submitter";
 
-    rerender(<PermissionPanel role="Federal Lead" />);
-    rerender(<PermissionPanel role="Federal Lead" />);
+    rerender(<PermissionPanel />);
+    rerender(<PermissionPanel />);
 
     await waitFor(() => {
       expect(getByTestId("permission-submission_request:create")).toBeInTheDocument();
@@ -942,7 +942,7 @@ describe("Implementation Requirements", () => {
       },
     };
 
-    const { getByTestId } = render(<PermissionPanel role="Submitter" />, {
+    const { getByTestId } = render(<PermissionPanel />, {
       wrapper: ({ children }) => <MockParent mocks={[mock]}>{children}</MockParent>,
     });
 
@@ -1022,7 +1022,7 @@ describe("Implementation Requirements", () => {
       formValues[field] = value;
     });
 
-    const { getByTestId } = render(<PermissionPanel role="Submitter" />, {
+    const { getByTestId } = render(<PermissionPanel />, {
       wrapper: ({ children }) => (
         <MockParent
           mocks={[mock]}
@@ -1067,7 +1067,7 @@ describe("Implementation Requirements", () => {
       },
     };
 
-    const { getByTestId } = render(<PermissionPanel role="Submitter" />, {
+    const { getByTestId } = render(<PermissionPanel />, {
       wrapper: ({ children }) => <MockParent mocks={[mock]}>{children}</MockParent>,
     });
 

--- a/src/components/PermissionPanel/index.tsx
+++ b/src/components/PermissionPanel/index.tsx
@@ -86,23 +86,12 @@ const StyledNotice = styled(Typography)({
   userSelect: "none",
 });
 
-type PermissionPanelProps = {
-  /**
-   * The original/stored role of the user.
-   *
-   * This is used to determine if the role has changed and to update the default permissions.
-   *
-   * @deprecated This prop is no longer used. Remove it.
-   */
-  role: UserRole;
-};
-
 /**
  * Provides a panel for managing permissions and notifications for a user role.
  *
  * @returns The PermissionPanel component.
  */
-const PermissionPanel: FC<PermissionPanelProps> = ({ role }) => {
+const PermissionPanel: FC = () => {
   const { enqueueSnackbar } = useSnackbar();
   const { setValue, watch } = useFormContext<EditUserInput>();
 

--- a/src/components/PermissionPanel/index.tsx
+++ b/src/components/PermissionPanel/index.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@apollo/client";
-import { ArrowDropDown } from "@mui/icons-material";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import {
   Accordion,
   AccordionDetails,
@@ -10,10 +10,10 @@ import {
   FormGroup,
   styled,
   Typography,
+  Unstable_Grid2 as Grid2,
 } from "@mui/material";
 import { FC, memo, useEffect, useMemo, useRef } from "react";
 import { useFormContext } from "react-hook-form";
-import Grid2 from "@mui/material/Unstable_Grid2";
 import { useSnackbar } from "notistack";
 import { cloneDeep } from "lodash";
 import {
@@ -44,7 +44,7 @@ const StyledAccordionSummary = styled(AccordionSummary)({
   "& .MuiAccordionSummary-content.Mui-expanded": {
     margin: "9px 0",
   },
-  "& .MuiAccordionSummary-expandIcon": {
+  "& .MuiAccordionSummary-expandIconWrapper": {
     color: "#356AAD",
   },
 });
@@ -197,7 +197,7 @@ const PermissionPanel: FC = () => {
   return (
     <StyledBox>
       <StyledAccordion elevation={0} data-testid="permissions-accordion">
-        <StyledAccordionSummary expandIcon={<ArrowDropDown />}>
+        <StyledAccordionSummary expandIcon={<ExpandMoreIcon />}>
           <StyledAccordionHeader component="span">Permissions</StyledAccordionHeader>
         </StyledAccordionSummary>
         <AccordionDetails>
@@ -232,7 +232,7 @@ const PermissionPanel: FC = () => {
         </AccordionDetails>
       </StyledAccordion>
       <StyledAccordion elevation={0} data-testid="notifications-accordion">
-        <StyledAccordionSummary expandIcon={<ArrowDropDown />}>
+        <StyledAccordionSummary expandIcon={<ExpandMoreIcon />}>
           <StyledAccordionHeader component="span">Email Notifications</StyledAccordionHeader>
         </StyledAccordionSummary>
         <AccordionDetails>

--- a/src/components/PermissionPanel/index.tsx
+++ b/src/components/PermissionPanel/index.tsx
@@ -177,7 +177,7 @@ const PermissionPanel: FC<PermissionPanelProps> = ({ role }) => {
     });
 
     return columns;
-  }, []);
+  }, [data, notificationsValue]);
 
   const handlePermissionChange = (_id: AuthPermissions) => {
     if (permissionsValue.includes(_id)) {

--- a/src/components/PermissionPanel/index.tsx
+++ b/src/components/PermissionPanel/index.tsx
@@ -13,6 +13,7 @@ import {
 import { FC, memo, useEffect, useMemo } from "react";
 import { useFormContext } from "react-hook-form";
 import Grid2 from "@mui/material/Unstable_Grid2";
+import { useSnackbar } from "notistack";
 import {
   EditUserInput,
   RetrievePBACDefaultsResp,
@@ -99,6 +100,7 @@ type PermissionPanelProps = {
  * @returns The PermissionPanel component.
  */
 const PermissionPanel: FC<PermissionPanelProps> = ({ role }) => {
+  const { enqueueSnackbar } = useSnackbar();
   const { setValue, watch } = useFormContext<EditUserInput>();
 
   const { data, loading } = useQuery<RetrievePBACDefaultsResp, RetrievePBACDefaultsInput>(
@@ -107,6 +109,10 @@ const PermissionPanel: FC<PermissionPanelProps> = ({ role }) => {
       variables: { roles: ["All"] },
       context: { clientName: "backend" },
       fetchPolicy: "cache-first",
+      onError: (error) => {
+        Logger.error("Failed to retrieve PBAC defaults", { error });
+        enqueueSnackbar("Failed to retrieve PBAC defaults", { variant: "error" });
+      },
     }
   );
 

--- a/src/components/PermissionPanel/index.tsx
+++ b/src/components/PermissionPanel/index.tsx
@@ -1,0 +1,310 @@
+import { useQuery } from "@apollo/client";
+import { ArrowDropDown } from "@mui/icons-material";
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Checkbox,
+  FormControlLabel,
+  FormGroup,
+  styled,
+  Typography,
+} from "@mui/material";
+import { FC, memo, useEffect, useMemo } from "react";
+import { useFormContext } from "react-hook-form";
+import Grid2 from "@mui/material/Unstable_Grid2";
+import {
+  EditUserInput,
+  RetrievePBACDefaultsResp,
+  RetrievePBACDefaultsInput,
+  RETRIEVE_PBAC_DEFAULTS,
+} from "../../graphql";
+
+const StyledAccordion = styled(Accordion)({
+  width: "957px", // TODO: Need to fix the page layout
+});
+
+const StyledAccordionSummary = styled(AccordionSummary)({
+  borderBottom: "1px solid #6B7294",
+  minHeight: "unset !important",
+  "& .MuiAccordionSummary-content": {
+    margin: "9px 0",
+  },
+  "& .MuiAccordionSummary-content.Mui-expanded": {
+    margin: "9px 0",
+  },
+  "& .MuiAccordionSummary-expandIcon": {
+    color: "#356AAD",
+  },
+});
+
+const StyledAccordionHeader = styled(Typography)<{ component: React.ElementType }>({
+  fontWeight: 700,
+  fontSize: "16px",
+  lineHeight: "19px",
+  color: "#356AAD",
+});
+
+const StyledGroupTitle = styled(Typography)({
+  fontWeight: 600,
+  fontSize: "13px",
+  lineHeight: "20px",
+  color: "#187A90",
+  textTransform: "uppercase",
+  marginBottom: "7.5px",
+  marginTop: "13.5px",
+  userSelect: "none",
+});
+
+const StyledFormControlLabel = styled(FormControlLabel)({
+  whiteSpace: "nowrap",
+  userSelect: "none",
+  "& .MuiTypography-root": {
+    fontWeight: 400,
+    fontSize: "16px",
+    color: "#083A50 !important",
+  },
+  "& .MuiCheckbox-root": {
+    paddingTop: "5.5px",
+    paddingBottom: "5.5px",
+    color: "#005EA2 !important",
+  },
+  "& .MuiTypography-root.Mui-disabled, & .MuiCheckbox-root.Mui-disabled": {
+    opacity: 0.6,
+    cursor: "not-allowed !important",
+  },
+});
+
+type PermissionPanelProps = {
+  /**
+   * The original/stored role of the user.
+   *
+   * This is used to determine if the role has changed and to update the default permissions.
+   */
+  role: UserRole;
+};
+
+const mockPerms: PBACDefault<AuthPermissions>[] = [
+  {
+    _id: "submission_request:view",
+    group: "Submission Request",
+    name: "View",
+    checked: false,
+    disabled: false,
+  },
+  {
+    _id: "submission_request:create",
+    group: "Submission Request",
+    name: "Create",
+    checked: false,
+    disabled: false,
+  },
+  {
+    _id: "data_submission:view",
+    group: "Data Submission",
+    name: "View",
+    checked: true,
+    disabled: true,
+  },
+  {
+    _id: "data_submission:create",
+    group: "Data Submission",
+    name: "Create",
+    checked: false,
+    disabled: false,
+  },
+  {
+    _id: "data_submission:confirm",
+    group: "Data Submission",
+    name: "Confirm",
+    checked: false,
+    disabled: false,
+  },
+  {
+    _id: "program:manage",
+    group: "Admin",
+    name: "Manage Programs",
+    checked: false,
+    disabled: false,
+  },
+  {
+    _id: "study:manage",
+    group: "Admin",
+    name: "Manage Studies",
+    checked: false,
+    disabled: false,
+  },
+  {
+    _id: "access:request",
+    group: "Miscellaneous",
+    name: "Request Access",
+    checked: false,
+    disabled: true,
+  },
+];
+
+/**
+ * Provides a panel for managing permissions and notifications for a user role.
+ *
+ * @returns The PermissionPanel component.
+ */
+const PermissionPanel: FC<PermissionPanelProps> = ({ role }) => {
+  const { setValue, watch } = useFormContext<EditUserInput>();
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { data: pbacData, loading } = useQuery<RetrievePBACDefaultsResp, RetrievePBACDefaultsInput>(
+    RETRIEVE_PBAC_DEFAULTS,
+    {
+      variables: { roles: ["All"] },
+      context: { clientName: "backend" },
+      fetchPolicy: "cache-first",
+    }
+  );
+
+  const data = mockPerms; // TODO: remove this
+
+  const selectedRole = watch("role");
+  const permissionsValue = watch("permissions");
+  const notificationsValue = watch("notifications");
+
+  const permissionColumns = useMemo<
+    Array<Array<{ name: string; permissions: PBACDefault<AuthPermissions>[] }>>
+  >(() => {
+    const updatedPermissions: PBACDefault<AuthPermissions>[] = data.map((perm) => ({
+      ...perm,
+      checked: permissionsValue.includes(perm._id),
+    }));
+
+    const groupedPermissions: Record<string, PBACDefault<AuthPermissions>[]> =
+      updatedPermissions.reduce((acc, perm) => {
+        if (!acc[perm.group]) {
+          acc[perm.group] = [];
+        }
+        acc[perm.group].push(perm);
+        return acc;
+      }, {});
+
+    const columns: Array<Array<{ name: string; permissions: PBACDefault<AuthPermissions>[] }>> = [
+      [],
+      [],
+      [],
+    ];
+
+    Object.entries(groupedPermissions).forEach(([name, permissions], index) => {
+      const placement = index > 1 ? 2 : index;
+      columns[placement].push({ name, permissions });
+    });
+
+    return columns;
+  }, [data, permissionsValue]);
+
+  const notificationColumns = useMemo<
+    Array<Array<{ name: string; notifications: PBACDefault<AuthNotifications>[] }>>
+  >(() => [], []);
+
+  const handlePermissionChange = (_id: AuthPermissions) => {
+    if (permissionsValue.includes(_id)) {
+      setValue(
+        "permissions",
+        permissionsValue.filter((p) => p !== _id)
+      );
+    } else {
+      setValue("permissions", [...permissionsValue, _id]);
+    }
+  };
+
+  const handleNotificationChange = (_id: AuthNotifications) => {
+    if (notificationsValue.includes(_id)) {
+      setValue(
+        "notifications",
+        notificationsValue.filter((n) => n !== _id)
+      );
+    } else {
+      setValue("notifications", [...notificationsValue, _id]);
+    }
+  };
+
+  const handleRoleChange = (selectedRole: UserRole) => {
+    if (selectedRole === role) {
+      return;
+    }
+
+    // TODO: This is a mock implementation. Refactor it to use the actual data based on the role.
+    setValue(
+      "permissions",
+      data.filter((perm) => perm.checked).map((perm) => perm._id)
+    );
+    setValue("notifications", []); // TODO: Need default notifications
+  };
+
+  useEffect(() => {
+    handleRoleChange(selectedRole);
+  }, [selectedRole]);
+
+  return (
+    <>
+      <StyledAccordion elevation={0} data-testid="permissions-accordion">
+        <StyledAccordionSummary expandIcon={<ArrowDropDown />}>
+          <StyledAccordionHeader component="span">Permissions</StyledAccordionHeader>
+        </StyledAccordionSummary>
+        <AccordionDetails>
+          <Grid2 container spacing={2}>
+            {permissionColumns.map((column, index) => (
+              // eslint-disable-next-line react/no-array-index-key
+              <Grid2 xs={4} key={index} data-testid={`permissions-column-${index}`}>
+                {column.map(({ name, permissions }) => (
+                  <div key={name} data-testid={`permissions-group-${name}`}>
+                    <StyledGroupTitle>{name}</StyledGroupTitle>
+                    <FormGroup>
+                      {permissions.map(({ _id, checked, disabled, name }) => (
+                        <StyledFormControlLabel
+                          key={_id}
+                          label={name}
+                          onChange={() => handlePermissionChange(_id)}
+                          control={<Checkbox name={_id} checked={checked} disabled={disabled} />}
+                          data-testid={`permission-${_id}`}
+                        />
+                      ))}
+                    </FormGroup>
+                  </div>
+                ))}
+              </Grid2>
+            ))}
+          </Grid2>
+        </AccordionDetails>
+      </StyledAccordion>
+      <StyledAccordion elevation={0} data-testid="notifications-accordion">
+        <StyledAccordionSummary expandIcon={<ArrowDropDown />}>
+          <StyledAccordionHeader component="span">Email Notifications</StyledAccordionHeader>
+        </StyledAccordionSummary>
+        <AccordionDetails>
+          <Grid2 container spacing={2}>
+            {notificationColumns.map((column, index) => (
+              // eslint-disable-next-line react/no-array-index-key
+              <Grid2 xs={4} key={index} data-testid={`notifications-column-${index}`}>
+                {column.map(({ name, notifications }) => (
+                  <div key={name} data-testid={`notifications-group-${name}`}>
+                    <StyledGroupTitle>{name}</StyledGroupTitle>
+                    <FormGroup>
+                      {notifications.map(({ _id, checked, disabled, name }) => (
+                        <StyledFormControlLabel
+                          key={_id}
+                          label={name}
+                          onChange={() => handleNotificationChange(_id)}
+                          control={<Checkbox name={_id} checked={checked} disabled={disabled} />}
+                          data-testid={`notification-${_id}`}
+                        />
+                      ))}
+                    </FormGroup>
+                  </div>
+                ))}
+              </Grid2>
+            ))}
+          </Grid2>
+        </AccordionDetails>
+      </StyledAccordion>
+    </>
+  );
+};
+
+export default memo(PermissionPanel);

--- a/src/components/PermissionPanel/index.tsx
+++ b/src/components/PermissionPanel/index.tsx
@@ -76,6 +76,14 @@ const StyledFormControlLabel = styled(FormControlLabel)({
   },
 });
 
+const StyledNotice = styled(Typography)({
+  marginTop: "29.5px",
+  textAlign: "center",
+  width: "100%",
+  color: "#6B7294",
+  userSelect: "none",
+});
+
 type PermissionPanelProps = {
   /**
    * The original/stored role of the user.
@@ -111,7 +119,7 @@ const PermissionPanel: FC<PermissionPanelProps> = ({ role }) => {
   >(() => {
     const defaults = data?.retrievePBACDefaults?.find((pbac) => pbac.role === selectedRole);
     if (!defaults || !defaults?.permissions) {
-      Logger.error("Role not found in PBAC defaults", { role: selectedRole });
+      Logger.error("Role not found in PBAC defaults", { role: selectedRole, data });
       return [];
     }
 
@@ -148,7 +156,7 @@ const PermissionPanel: FC<PermissionPanelProps> = ({ role }) => {
   >(() => {
     const defaults = data?.retrievePBACDefaults?.find((pbac) => pbac.role === selectedRole);
     if (!defaults || !defaults?.notifications) {
-      Logger.error("Role not found in PBAC defaults", { role: selectedRole });
+      Logger.error("Role not found in PBAC defaults", { role: selectedRole, data });
       return [];
     }
 
@@ -244,6 +252,11 @@ const PermissionPanel: FC<PermissionPanelProps> = ({ role }) => {
                 ))}
               </Grid2>
             ))}
+            {permissionColumns.length === 0 && (
+              <StyledNotice variant="body1" data-testid="no-permissions-notice">
+                No permission options found for this role.
+              </StyledNotice>
+            )}
           </Grid2>
         </AccordionDetails>
       </StyledAccordion>
@@ -274,6 +287,11 @@ const PermissionPanel: FC<PermissionPanelProps> = ({ role }) => {
                 ))}
               </Grid2>
             ))}
+            {notificationColumns.length === 0 && (
+              <StyledNotice variant="body1" data-testid="no-notifications-notice">
+                No notification options found for this role.
+              </StyledNotice>
+            )}
           </Grid2>
         </AccordionDetails>
       </StyledAccordion>

--- a/src/components/PermissionPanel/index.tsx
+++ b/src/components/PermissionPanel/index.tsx
@@ -4,6 +4,7 @@ import {
   Accordion,
   AccordionDetails,
   AccordionSummary,
+  Box,
   Checkbox,
   FormControlLabel,
   FormGroup,
@@ -23,8 +24,15 @@ import {
 } from "../../graphql";
 import { ColumnizedPBACGroups, columnizePBACGroups, Logger } from "../../utils";
 
+const StyledBox = styled(Box)({
+  width: "957px",
+  transform: "translateX(-50%)",
+  marginLeft: "50%",
+  marginTop: "63px",
+});
+
 const StyledAccordion = styled(Accordion)({
-  width: "957px", // TODO: Need to fix the page layout
+  width: "100%",
 });
 
 const StyledAccordionSummary = styled(AccordionSummary)({
@@ -187,7 +195,7 @@ const PermissionPanel: FC = () => {
   }, [selectedRole]);
 
   return (
-    <>
+    <StyledBox>
       <StyledAccordion elevation={0} data-testid="permissions-accordion">
         <StyledAccordionSummary expandIcon={<ArrowDropDown />}>
           <StyledAccordionHeader component="span">Permissions</StyledAccordionHeader>
@@ -258,7 +266,7 @@ const PermissionPanel: FC = () => {
           </Grid2>
         </AccordionDetails>
       </StyledAccordion>
-    </>
+    </StyledBox>
   );
 };
 

--- a/src/components/PermissionPanel/index.tsx
+++ b/src/components/PermissionPanel/index.tsx
@@ -21,7 +21,7 @@ import {
   RetrievePBACDefaultsInput,
   RETRIEVE_PBAC_DEFAULTS,
 } from "../../graphql";
-import { Logger } from "../../utils";
+import { ColumnizedPBACGroups, columnizePBACGroups, Logger } from "../../utils";
 
 const StyledAccordion = styled(Accordion)({
   width: "957px", // TODO: Need to fix the page layout
@@ -113,9 +113,7 @@ const PermissionPanel: FC = () => {
   const notificationsValue = watch("notifications");
   const roleRef = useRef<UserRole>(selectedRole);
 
-  const permissionColumns = useMemo<
-    { name: string; data: PBACDefault<AuthPermissions>[] }[][]
-  >(() => {
+  const permissionColumns = useMemo<ColumnizedPBACGroups<AuthPermissions>>(() => {
     if (!data?.retrievePBACDefaults && loading) {
       return [];
     }
@@ -126,31 +124,14 @@ const PermissionPanel: FC = () => {
       return [];
     }
 
-    const updatedPermissions: PBACDefault<AuthPermissions>[] = cloneDeep(defaults.permissions).map(
+    const remappedPermissions: PBACDefault<AuthPermissions>[] = cloneDeep(defaults.permissions).map(
       (p) => ({ ...p, checked: permissionsValue.includes(p._id) })
     );
 
-    const groupedPermissions: Record<string, PBACDefault<AuthPermissions>[]> =
-      updatedPermissions.reduce((acc, p) => {
-        if (!acc[p.group]) {
-          acc[p.group] = [];
-        }
-        acc[p.group].push(p);
-        return acc;
-      }, {});
-
-    const columns: { name: string; data: PBACDefault<AuthPermissions>[] }[][] = [[], [], []];
-    Object.entries(groupedPermissions).forEach(([name, permissions], index) => {
-      const placement = index > 1 ? 2 : index;
-      columns[placement].push({ name, data: permissions });
-    });
-
-    return columns;
+    return columnizePBACGroups(remappedPermissions, 3);
   }, [data, permissionsValue]);
 
-  const notificationColumns = useMemo<
-    { name: string; data: PBACDefault<AuthNotifications>[] }[][]
-  >(() => {
+  const notificationColumns = useMemo<ColumnizedPBACGroups<AuthNotifications>>(() => {
     if (!data?.retrievePBACDefaults && loading) {
       return [];
     }
@@ -161,26 +142,11 @@ const PermissionPanel: FC = () => {
       return [];
     }
 
-    const updatedNotifications: PBACDefault<AuthNotifications>[] = cloneDeep(
+    const remappedNotifications: PBACDefault<AuthNotifications>[] = cloneDeep(
       defaults.notifications
     ).map((n) => ({ ...n, checked: notificationsValue.includes(n._id) }));
 
-    const groupedNotifications: Record<string, PBACDefault<AuthNotifications>[]> =
-      updatedNotifications.reduce((acc, n) => {
-        if (!acc[n.group]) {
-          acc[n.group] = [];
-        }
-        acc[n.group].push(n);
-        return acc;
-      }, {});
-
-    const columns: { name: string; data: PBACDefault<AuthNotifications>[] }[][] = [[], [], []];
-    Object.entries(groupedNotifications).forEach(([name, notifications], index) => {
-      const placement = index > 1 ? 2 : index;
-      columns[placement].push({ name, data: notifications });
-    });
-
-    return columns;
+    return columnizePBACGroups(remappedNotifications, 3);
   }, [data, notificationsValue]);
 
   const handlePermissionChange = (_id: AuthPermissions) => {

--- a/src/components/PermissionPanel/index.tsx
+++ b/src/components/PermissionPanel/index.tsx
@@ -101,7 +101,7 @@ type PermissionPanelProps = {
 const PermissionPanel: FC<PermissionPanelProps> = ({ role }) => {
   const { setValue, watch } = useFormContext<EditUserInput>();
 
-  const { data } = useQuery<RetrievePBACDefaultsResp, RetrievePBACDefaultsInput>(
+  const { data, loading } = useQuery<RetrievePBACDefaultsResp, RetrievePBACDefaultsInput>(
     RETRIEVE_PBAC_DEFAULTS,
     {
       variables: { roles: ["All"] },
@@ -117,6 +117,10 @@ const PermissionPanel: FC<PermissionPanelProps> = ({ role }) => {
   const permissionColumns = useMemo<
     Array<Array<{ name: string; permissions: PBACDefault<AuthPermissions>[] }>>
   >(() => {
+    if (!data?.retrievePBACDefaults && loading) {
+      return [];
+    }
+
     const defaults = data?.retrievePBACDefaults?.find((pbac) => pbac.role === selectedRole);
     if (!defaults || !defaults?.permissions) {
       Logger.error("Role not found in PBAC defaults", { role: selectedRole, data });
@@ -154,6 +158,10 @@ const PermissionPanel: FC<PermissionPanelProps> = ({ role }) => {
   const notificationColumns = useMemo<
     Array<Array<{ name: string; notifications: PBACDefault<AuthNotifications>[] }>>
   >(() => {
+    if (!data?.retrievePBACDefaults && loading) {
+      return [];
+    }
+
     const defaults = data?.retrievePBACDefaults?.find((pbac) => pbac.role === selectedRole);
     if (!defaults || !defaults?.notifications) {
       Logger.error("Role not found in PBAC defaults", { role: selectedRole, data });

--- a/src/content/users/ProfileView.tsx
+++ b/src/content/users/ProfileView.tsx
@@ -125,17 +125,12 @@ const StyledButtonStack = styled(Stack)({
   marginTop: "50px",
 });
 
-const StyledButton = styled(LoadingButton)(({ txt, border }: { txt: string; border: string }) => ({
-  borderRadius: "8px",
-  border: `2px solid ${border}`,
-  color: `${txt} !important`,
-  width: "101px",
-  height: "51px",
-  textTransform: "none",
-  fontWeight: 700,
-  fontSize: "17px",
-  padding: "6px 8px",
-}));
+const StyledButton = styled(LoadingButton)({
+  minWidth: "120px",
+  fontSize: "16px",
+  padding: "10px",
+  lineHeight: "24px",
+});
 
 const StyledContentStack = styled(Stack)({
   marginLeft: "2px !important",
@@ -587,7 +582,12 @@ const ProfileView: FC<Props> = ({ _id, viewType }: Props) => {
                   spacing={1}
                 >
                   {Object.values(fieldset).some((fieldState) => fieldState === "UNLOCKED") && (
-                    <StyledButton type="submit" loading={saving} txt="#14634F" border="#26B893">
+                    <StyledButton
+                      type="submit"
+                      loading={saving}
+                      variant="contained"
+                      color="success"
+                    >
                       Save
                     </StyledButton>
                   )}
@@ -595,8 +595,8 @@ const ProfileView: FC<Props> = ({ _id, viewType }: Props) => {
                     <StyledButton
                       type="button"
                       onClick={() => navigate(manageUsersPageUrl)}
-                      txt="#666666"
-                      border="#828282"
+                      variant="contained"
+                      color="info"
                     >
                       Cancel
                     </StyledButton>

--- a/src/content/users/ProfileView.tsx
+++ b/src/content/users/ProfileView.tsx
@@ -579,9 +579,7 @@ const ProfileView: FC<Props> = ({ _id, viewType }: Props) => {
                   )}
                 </StyledField>
                 {VisibleFieldState.includes(fieldset.permissions) &&
-                  VisibleFieldState.includes(fieldset.notifications) && (
-                    <PermissionPanel role={user?.role} />
-                  )}
+                  VisibleFieldState.includes(fieldset.notifications) && <PermissionPanel />}
                 <StyledButtonStack
                   direction="row"
                   justifyContent="center"

--- a/src/content/users/ProfileView.tsx
+++ b/src/content/users/ProfileView.tsx
@@ -95,6 +95,10 @@ const StyledHeaderText = styled(Typography)({
   fontWeight: 700,
 });
 
+const StyledForm = styled("form")({
+  width: "532px",
+});
+
 const StyledField = styled("div", { shouldForwardProp: (p) => p !== "visible" })<{
   visible?: boolean;
 }>(({ visible = true }) => ({
@@ -407,7 +411,7 @@ const ProfileView: FC<Props> = ({ _id, viewType }: Props) => {
               <StyledHeaderText variant="h2">{user.email}</StyledHeaderText>
             </StyledHeader>
             <FormProvider {...methods}>
-              <form onSubmit={handleSubmit(onSubmit)}>
+              <StyledForm onSubmit={handleSubmit(onSubmit)}>
                 <StyledField>
                   <StyledLabel>Account Type</StyledLabel>
                   {formatIDP(user.IDP)}
@@ -602,7 +606,7 @@ const ProfileView: FC<Props> = ({ _id, viewType }: Props) => {
                     </StyledButton>
                   )}
                 </StyledButtonStack>
-              </form>
+              </StyledForm>
             </FormProvider>
           </StyledContentStack>
         </Stack>

--- a/src/content/users/ProfileView.tsx
+++ b/src/content/users/ProfileView.tsx
@@ -2,7 +2,13 @@ import { FC, useEffect, useMemo, useRef, useState } from "react";
 import { useLazyQuery, useMutation, useQuery } from "@apollo/client";
 import { LoadingButton } from "@mui/lab";
 import { Box, Container, MenuItem, Stack, TextField, Typography, styled } from "@mui/material";
-import { Controller, ControllerRenderProps, SubmitHandler, useForm } from "react-hook-form";
+import {
+  Controller,
+  ControllerRenderProps,
+  FormProvider,
+  SubmitHandler,
+  useForm,
+} from "react-hook-form";
 import { useNavigate } from "react-router-dom";
 import { useSnackbar } from "notistack";
 import bannerSvg from "../../assets/banner/profile_banner.png";
@@ -33,13 +39,14 @@ import BaseOutlinedInput from "../../components/StyledFormComponents/StyledOutli
 import BaseAutocomplete from "../../components/StyledFormComponents/StyledAutocomplete";
 import useProfileFields, { VisibleFieldState } from "../../hooks/useProfileFields";
 import AccessRequest from "../../components/AccessRequest";
+import PermissionPanel from "../../components/PermissionPanel";
 
 type Props = {
   _id: User["_id"];
   viewType: "users" | "profile";
 };
 
-type FormInput = UpdateMyUserInput["userInfo"] | EditUserInput;
+export type FormInput = UpdateMyUserInput["userInfo"] | EditUserInput;
 
 const StyledContainer = styled(Container)({
   marginBottom: "90px",
@@ -158,7 +165,7 @@ const ProfileView: FC<Props> = ({ _id, viewType }: Props) => {
   const { enqueueSnackbar } = useSnackbar();
   const { user: currentUser, setData, logout, status: authStatus } = useAuthContext();
   const { lastSearchParams } = useSearchParamsContext();
-  const { handleSubmit, register, reset, watch, setValue, control } = useForm<FormInput>();
+  const methods = useForm<FormInput>();
 
   const ALL_STUDIES_OPTION = "All";
   const manageUsersPageUrl = `/users${lastSearchParams?.["/users"] ?? ""}`;
@@ -169,6 +176,7 @@ const ProfileView: FC<Props> = ({ _id, viewType }: Props) => {
   const [saving, setSaving] = useState<boolean>(false);
   const [studyOptions, setStudyOptions] = useState<string[]>([]);
 
+  const { handleSubmit, register, reset, watch, setValue, control } = methods;
   const roleField = watch("role");
   const prevRoleRef = useRef<UserRole>(roleField);
   const studiesField = watch("studies");
@@ -258,6 +266,8 @@ const ProfileView: FC<Props> = ({ _id, viewType }: Props) => {
           userStatus: data.userStatus,
           studies: fieldset.studies !== "HIDDEN" ? data.studies : null,
           dataCommons: fieldset.dataCommons !== "HIDDEN" ? data.dataCommons : null,
+          permissions: data.permissions,
+          notifications: data.notifications,
         },
       }).catch((e) => ({ errors: e?.message, data: null }));
       setSaving(false);
@@ -401,197 +411,201 @@ const ProfileView: FC<Props> = ({ _id, viewType }: Props) => {
             <StyledHeader>
               <StyledHeaderText variant="h2">{user.email}</StyledHeaderText>
             </StyledHeader>
+            <FormProvider {...methods}>
+              <form onSubmit={handleSubmit(onSubmit)}>
+                <StyledField>
+                  <StyledLabel>Account Type</StyledLabel>
+                  {formatIDP(user.IDP)}
+                </StyledField>
+                <StyledField>
+                  <StyledLabel>Email</StyledLabel>
+                  {user.email}
+                </StyledField>
+                <StyledField>
+                  <StyledLabel id="firstNameLabel">First name</StyledLabel>
+                  {VisibleFieldState.includes(fieldset.firstName) ? (
+                    <StyledTextField
+                      {...register("firstName", {
+                        required: true,
+                        maxLength: 30,
+                        setValueAs: (v: string) => v?.trim(),
+                      })}
+                      inputProps={{ "aria-labelledby": "firstNameLabel", maxLength: 30 }}
+                      size="small"
+                      required
+                    />
+                  ) : (
+                    user.firstName
+                  )}
+                </StyledField>
+                <StyledField>
+                  <StyledLabel id="lastNameLabel">Last name</StyledLabel>
+                  {VisibleFieldState.includes(fieldset.lastName) ? (
+                    <StyledTextField
+                      {...register("lastName", {
+                        required: true,
+                        maxLength: 30,
+                        setValueAs: (v: string) => v?.trim(),
+                      })}
+                      inputProps={{ "aria-labelledby": "lastNameLabel", maxLength: 30 }}
+                      size="small"
+                      required
+                    />
+                  ) : (
+                    user.lastName
+                  )}
+                </StyledField>
+                <StyledField>
+                  <StyledLabel id="userRoleLabel">Role</StyledLabel>
+                  {VisibleFieldState.includes(fieldset.role) ? (
+                    <Controller
+                      name="role"
+                      control={control}
+                      rules={{ required: true }}
+                      render={({ field }) => (
+                        <StyledSelect
+                          {...field}
+                          size="small"
+                          onChange={(e) => handleRoleChange(field, e?.target?.value as UserRole)}
+                          MenuProps={{ disablePortal: true }}
+                          inputProps={{ "aria-labelledby": "userRoleLabel" }}
+                        >
+                          {Roles.map((role) => (
+                            <MenuItem key={role} value={role}>
+                              {role}
+                            </MenuItem>
+                          ))}
+                        </StyledSelect>
+                      )}
+                    />
+                  ) : (
+                    <>
+                      {user?.role}
+                      {canRequestRole && <AccessRequest />}
+                    </>
+                  )}
+                </StyledField>
+                <StyledField visible={fieldset.studies !== "HIDDEN"}>
+                  <StyledLabel id="userStudies">Studies</StyledLabel>
+                  {VisibleFieldState.includes(fieldset.studies) ? (
+                    <Controller
+                      name="studies"
+                      control={control}
+                      rules={{ required: true }}
+                      render={({ field }) => (
+                        <StyledAutocomplete
+                          {...field}
+                          renderInput={({ inputProps, ...params }) => (
+                            <TextField
+                              {...params}
+                              placeholder={studiesField?.length > 0 ? undefined : "Select studies"}
+                              inputProps={{ "aria-labelledby": "userStudies", ...inputProps }}
+                              onBlur={sortStudyOptions}
+                            />
+                          )}
+                          renderTags={(value: string[], _, state) => {
+                            if (value?.length === 0 || state.focused) {
+                              return null;
+                            }
 
-            <form onSubmit={handleSubmit(onSubmit)}>
-              <StyledField>
-                <StyledLabel>Account Type</StyledLabel>
-                {formatIDP(user.IDP)}
-              </StyledField>
-              <StyledField>
-                <StyledLabel>Email</StyledLabel>
-                {user.email}
-              </StyledField>
-              <StyledField>
-                <StyledLabel id="firstNameLabel">First name</StyledLabel>
-                {VisibleFieldState.includes(fieldset.firstName) ? (
-                  <StyledTextField
-                    {...register("firstName", {
-                      required: true,
-                      maxLength: 30,
-                      setValueAs: (v: string) => v?.trim(),
-                    })}
-                    inputProps={{ "aria-labelledby": "firstNameLabel", maxLength: 30 }}
-                    size="small"
-                    required
-                  />
-                ) : (
-                  user.firstName
-                )}
-              </StyledField>
-              <StyledField>
-                <StyledLabel id="lastNameLabel">Last name</StyledLabel>
-                {VisibleFieldState.includes(fieldset.lastName) ? (
-                  <StyledTextField
-                    {...register("lastName", {
-                      required: true,
-                      maxLength: 30,
-                      setValueAs: (v: string) => v?.trim(),
-                    })}
-                    inputProps={{ "aria-labelledby": "lastNameLabel", maxLength: 30 }}
-                    size="small"
-                    required
-                  />
-                ) : (
-                  user.lastName
-                )}
-              </StyledField>
-              <StyledField>
-                <StyledLabel id="userRoleLabel">Role</StyledLabel>
-                {VisibleFieldState.includes(fieldset.role) ? (
-                  <Controller
-                    name="role"
-                    control={control}
-                    rules={{ required: true }}
-                    render={({ field }) => (
-                      <StyledSelect
-                        {...field}
-                        size="small"
-                        onChange={(e) => handleRoleChange(field, e?.target?.value as UserRole)}
-                        MenuProps={{ disablePortal: true }}
-                        inputProps={{ "aria-labelledby": "userRoleLabel" }}
-                      >
-                        {Roles.map((role) => (
-                          <MenuItem key={role} value={role}>
-                            {role}
-                          </MenuItem>
-                        ))}
-                      </StyledSelect>
-                    )}
-                  />
-                ) : (
-                  <>
-                    {user?.role}
-                    {canRequestRole && <AccessRequest />}
-                  </>
-                )}
-              </StyledField>
-              <StyledField visible={fieldset.studies !== "HIDDEN"}>
-                <StyledLabel id="userStudies">Studies</StyledLabel>
-                {VisibleFieldState.includes(fieldset.studies) ? (
-                  <Controller
-                    name="studies"
-                    control={control}
-                    rules={{ required: true }}
-                    render={({ field }) => (
-                      <StyledAutocomplete
-                        {...field}
-                        renderInput={({ inputProps, ...params }) => (
-                          <TextField
-                            {...params}
-                            placeholder={studiesField?.length > 0 ? undefined : "Select studies"}
-                            inputProps={{ "aria-labelledby": "userStudies", ...inputProps }}
-                            onBlur={sortStudyOptions}
-                          />
-                        )}
-                        renderTags={(value: string[], _, state) => {
-                          if (value?.length === 0 || state.focused) {
-                            return null;
-                          }
-
-                          return (
-                            <StyledTag>
-                              {formatStudySelectionValue(value, formattedStudyMap)}
-                            </StyledTag>
-                          );
-                        }}
-                        options={studyOptions}
-                        getOptionLabel={(option: string) => formattedStudyMap[option]}
-                        onChange={(_, data: string[]) => handleStudyChange(field, data)}
-                        disabled={fieldset.studies === "DISABLED"}
-                        loading={approvedStudiesLoading}
-                        disableCloseOnSelect
-                        multiple
-                      />
-                    )}
-                  />
-                ) : null}
-              </StyledField>
-              <StyledField>
-                <StyledLabel id="userStatusLabel">Account Status</StyledLabel>
-                {VisibleFieldState.includes(fieldset.userStatus) ? (
-                  <Controller
-                    name="userStatus"
-                    control={control}
-                    rules={{ required: true }}
-                    render={({ field }) => (
-                      <StyledSelect
-                        {...field}
-                        size="small"
-                        MenuProps={{ disablePortal: true }}
-                        inputProps={{ "aria-labelledby": "userStatusLabel" }}
-                      >
-                        <MenuItem value="Active">Active</MenuItem>
-                        <MenuItem value="Inactive">Inactive</MenuItem>
-                      </StyledSelect>
-                    )}
-                  />
-                ) : (
-                  user.userStatus
-                )}
-              </StyledField>
-              <StyledField visible={fieldset.dataCommons !== "HIDDEN"}>
-                <StyledLabel id="userDataCommons">Data Commons</StyledLabel>
-                {VisibleFieldState.includes(fieldset.dataCommons) ? (
-                  <Controller
-                    name="dataCommons"
-                    control={control}
-                    rules={{ required: false }}
-                    render={({ field }) => (
-                      <StyledSelect
-                        {...field}
-                        size="small"
-                        value={field.value || []}
-                        disabled={fieldset.dataCommons === "DISABLED"}
-                        MenuProps={{ disablePortal: true }}
-                        inputProps={{ "aria-labelledby": "userDataCommons" }}
-                        multiple
-                      >
-                        {DataCommons.map((dc) => (
-                          <MenuItem key={dc.name} value={dc.name}>
-                            {dc.name}
-                          </MenuItem>
-                        ))}
-                      </StyledSelect>
-                    )}
-                  />
-                ) : (
-                  user.dataCommons?.join(", ")
-                )}
-              </StyledField>
-
-              <StyledButtonStack
-                direction="row"
-                justifyContent="center"
-                alignItems="center"
-                spacing={1}
-              >
-                {Object.values(fieldset).some((fieldState) => fieldState === "UNLOCKED") && (
-                  <StyledButton type="submit" loading={saving} txt="#14634F" border="#26B893">
-                    Save
-                  </StyledButton>
-                )}
-                {viewType === "users" && (
-                  <StyledButton
-                    type="button"
-                    onClick={() => navigate(manageUsersPageUrl)}
-                    txt="#666666"
-                    border="#828282"
-                  >
-                    Cancel
-                  </StyledButton>
-                )}
-              </StyledButtonStack>
-            </form>
+                            return (
+                              <StyledTag>
+                                {formatStudySelectionValue(value, formattedStudyMap)}
+                              </StyledTag>
+                            );
+                          }}
+                          options={studyOptions}
+                          getOptionLabel={(option: string) => formattedStudyMap[option]}
+                          onChange={(_, data: string[]) => handleStudyChange(field, data)}
+                          disabled={fieldset.studies === "DISABLED"}
+                          loading={approvedStudiesLoading}
+                          disableCloseOnSelect
+                          multiple
+                        />
+                      )}
+                    />
+                  ) : null}
+                </StyledField>
+                <StyledField>
+                  <StyledLabel id="userStatusLabel">Account Status</StyledLabel>
+                  {VisibleFieldState.includes(fieldset.userStatus) ? (
+                    <Controller
+                      name="userStatus"
+                      control={control}
+                      rules={{ required: true }}
+                      render={({ field }) => (
+                        <StyledSelect
+                          {...field}
+                          size="small"
+                          MenuProps={{ disablePortal: true }}
+                          inputProps={{ "aria-labelledby": "userStatusLabel" }}
+                        >
+                          <MenuItem value="Active">Active</MenuItem>
+                          <MenuItem value="Inactive">Inactive</MenuItem>
+                        </StyledSelect>
+                      )}
+                    />
+                  ) : (
+                    user.userStatus
+                  )}
+                </StyledField>
+                <StyledField visible={fieldset.dataCommons !== "HIDDEN"}>
+                  <StyledLabel id="userDataCommons">Data Commons</StyledLabel>
+                  {VisibleFieldState.includes(fieldset.dataCommons) ? (
+                    <Controller
+                      name="dataCommons"
+                      control={control}
+                      rules={{ required: false }}
+                      render={({ field }) => (
+                        <StyledSelect
+                          {...field}
+                          size="small"
+                          value={field.value || []}
+                          disabled={fieldset.dataCommons === "DISABLED"}
+                          MenuProps={{ disablePortal: true }}
+                          inputProps={{ "aria-labelledby": "userDataCommons" }}
+                          multiple
+                        >
+                          {DataCommons.map((dc) => (
+                            <MenuItem key={dc.name} value={dc.name}>
+                              {dc.name}
+                            </MenuItem>
+                          ))}
+                        </StyledSelect>
+                      )}
+                    />
+                  ) : (
+                    user.dataCommons?.join(", ")
+                  )}
+                </StyledField>
+                {VisibleFieldState.includes(fieldset.permissions) &&
+                  VisibleFieldState.includes(fieldset.notifications) && (
+                    <PermissionPanel role={user?.role} />
+                  )}
+                <StyledButtonStack
+                  direction="row"
+                  justifyContent="center"
+                  alignItems="center"
+                  spacing={1}
+                >
+                  {Object.values(fieldset).some((fieldState) => fieldState === "UNLOCKED") && (
+                    <StyledButton type="submit" loading={saving} txt="#14634F" border="#26B893">
+                      Save
+                    </StyledButton>
+                  )}
+                  {viewType === "users" && (
+                    <StyledButton
+                      type="button"
+                      onClick={() => navigate(manageUsersPageUrl)}
+                      txt="#666666"
+                      border="#828282"
+                    >
+                      Cancel
+                    </StyledButton>
+                  )}
+                </StyledButtonStack>
+              </form>
+            </FormProvider>
           </StyledContentStack>
         </Stack>
       </StyledContainer>

--- a/src/graphql/editUser.ts
+++ b/src/graphql/editUser.ts
@@ -7,6 +7,8 @@ export const mutation = gql`
     $role: String
     $studies: [String]
     $dataCommons: [String]
+    $permissions: [String]
+    $notifications: [String]
   ) {
     editUser(
       userID: $userID
@@ -14,6 +16,8 @@ export const mutation = gql`
       role: $role
       studies: $studies
       dataCommons: $dataCommons
+      permissions: $permissions
+      notifications: $notifications
     ) {
       userStatus
       role

--- a/src/graphql/editUser.ts
+++ b/src/graphql/editUser.ts
@@ -25,6 +25,8 @@ export const mutation = gql`
         dbGaPID
         controlledAccess
       }
+      permissions
+      notifications
     }
   }
 `;
@@ -38,10 +40,10 @@ export type Input = {
    * An array of studyIDs to assign to the user
    */
   studies: string[];
-} & Pick<User, "userStatus" | "role" | "dataCommons">;
+} & Pick<User, "userStatus" | "role" | "dataCommons" | "permissions" | "notifications">;
 
 export type Response = {
-  editUser: Pick<User, "userStatus" | "role" | "dataCommons"> & {
+  editUser: Pick<User, "userStatus" | "role" | "dataCommons" | "permissions" | "notifications"> & {
     studies: Pick<
       ApprovedStudy,
       "_id" | "studyName" | "studyAbbreviation" | "dbGaPID" | "controlledAccess"

--- a/src/graphql/getMyUser.ts
+++ b/src/graphql/getMyUser.ts
@@ -19,6 +19,7 @@ export const query = gql`
         controlledAccess
       }
       permissions
+      notifications
       createdAt
       updateAt
     }

--- a/src/graphql/getUser.ts
+++ b/src/graphql/getUser.ts
@@ -18,6 +18,8 @@ export const query = gql`
         studyName
         studyAbbreviation
       }
+      permissions
+      notifications
     }
   }
 `;

--- a/src/graphql/index.ts
+++ b/src/graphql/index.ts
@@ -149,6 +149,12 @@ export type { Input as EditUserInput, Response as EditUserResp } from "./editUse
 export { mutation as REQUEST_ACCESS } from "./requestAccess";
 export type { Input as RequestAccessInput, Response as RequestAccessResp } from "./requestAccess";
 
+export { query as RETRIEVE_PBAC_DEFAULTS } from "./retrievePBACDefaults";
+export type {
+  Input as RetrievePBACDefaultsInput,
+  Response as RetrievePBACDefaultsResp,
+} from "./retrievePBACDefaults";
+
 // Organizations
 export { query as LIST_ORGS } from "./listOrganizations";
 export type { Response as ListOrgsResp } from "./listOrganizations";

--- a/src/graphql/retrievePBACDefaults.ts
+++ b/src/graphql/retrievePBACDefaults.ts
@@ -1,0 +1,44 @@
+import gql from "graphql-tag";
+
+export const query = gql`
+  query retrievePBACDefaults($roles: [String!]!) {
+    retrievePBACDefaults(roles: $roles) {
+      role
+      permissions {
+        _id
+        group
+        name
+        checked
+        disabled
+      }
+      notifications {
+        _id
+        group
+        name
+        checked
+        disabled
+      }
+    }
+  }
+`;
+
+export type Input = {
+  roles: Array<UserRole | "All">;
+};
+
+export type Response = {
+  retrievePBACDefaults: Array<{
+    /**
+     * The role that the defaults apply to.
+     */
+    role: UserRole;
+    /**
+     * The default permissions for the role.
+     */
+    permissions: PBACDefault<AuthPermissions>[];
+    /**
+     * The default notifications for the role.
+     */
+    notifications: PBACDefault<AuthNotifications>[];
+  }>;
+};

--- a/src/hooks/useProfileFields.test.ts
+++ b/src/hooks/useProfileFields.test.ts
@@ -17,6 +17,8 @@ describe("Users View", () => {
 
     expect(result.current.role).toBe("UNLOCKED");
     expect(result.current.userStatus).toBe("UNLOCKED");
+    expect(result.current.permissions).toBe("UNLOCKED");
+    expect(result.current.notifications).toBe("UNLOCKED");
   });
 
   it("should return READ_ONLY for all standard fields when a Submitter views the page", () => {
@@ -130,6 +132,27 @@ describe("Profile View", () => {
     expect(result.current.studies).toBe("HIDDEN");
   });
 
+  it.each<UserRole>([
+    "User",
+    "Submitter",
+    "Federal Lead",
+    "Data Commons Personnel",
+    "fake role" as UserRole,
+  ])(
+    "should return HIDDEN for the permissions and notifications panel on the profile page for role %s",
+    (role) => {
+      const user = { _id: "User-A", role } as User;
+      const profileOf: Pick<User, "_id" | "role"> = { _id: "User-A", role };
+
+      jest.spyOn(Auth, "useAuthContext").mockReturnValue({ user } as Auth.ContextState);
+
+      const { result } = renderHook(() => useProfileFields(profileOf, "profile"));
+
+      expect(result.current.permissions).toBe("HIDDEN");
+      expect(result.current.notifications).toBe("HIDDEN");
+    }
+  );
+
   it.each<[state: FieldState, role: UserRole]>([
     ["HIDDEN", "User"],
     ["HIDDEN", "Submitter"],
@@ -172,6 +195,8 @@ describe("Profile View", () => {
       expect(result.current.userStatus).toBe("READ_ONLY");
       expect(result.current.dataCommons).toBe("HIDDEN");
       expect(result.current.studies).toBe("HIDDEN");
+      expect(result.current.permissions).toBe("HIDDEN");
+      expect(result.current.notifications).toBe("HIDDEN");
     }
   );
 

--- a/src/hooks/useProfileFields.ts
+++ b/src/hooks/useProfileFields.ts
@@ -5,7 +5,14 @@ import { RequiresStudiesAssigned } from "../config/AuthRoles";
  */
 type EditableFields = Extends<
   keyof User,
-  "firstName" | "lastName" | "role" | "userStatus" | "studies" | "dataCommons"
+  | "firstName"
+  | "lastName"
+  | "role"
+  | "userStatus"
+  | "studies"
+  | "dataCommons"
+  | "permissions"
+  | "notifications"
 >;
 
 /**
@@ -47,6 +54,8 @@ const useProfileFields = (
     userStatus: "READ_ONLY",
     dataCommons: "HIDDEN",
     studies: "HIDDEN",
+    permissions: "HIDDEN",
+    notifications: "HIDDEN",
   };
   const isSelf: boolean = user?._id === profileOf?._id;
 
@@ -60,6 +69,8 @@ const useProfileFields = (
   if (user?.role === "Admin" && viewType === "users") {
     fields.role = "UNLOCKED";
     fields.userStatus = "UNLOCKED";
+    fields.permissions = "UNLOCKED";
+    fields.notifications = "UNLOCKED";
 
     // Editable for Admin viewing certain roles, otherwise hidden (even for a user viewing their own profile)
     fields.studies = RequiresStudiesAssigned.includes(profileOf?.role) ? "UNLOCKED" : "HIDDEN";

--- a/src/types/Auth.d.ts
+++ b/src/types/Auth.d.ts
@@ -54,7 +54,7 @@ type User = {
   /**
    * The list of notifications the user will receive
    */
-  notifications: string[];
+  notifications: AuthNotifications[];
   /**
    * The last update date of the user object
    *
@@ -70,34 +70,6 @@ type User = {
 };
 
 type UserRole = "User" | "Admin" | "Data Commons Personnel" | "Federal Lead" | "Submitter";
-
-type SubmissionRequestPermissions =
-  | "submission_request:view"
-  | "submission_request:create"
-  | "submission_request:review"
-  | "submission_request:submit";
-
-type DataSubmissionPermissions =
-  | "data_submission:view"
-  | "data_submission:create"
-  | "data_submission:review"
-  | "data_submission:admin_submit"
-  | "data_submission:confirm";
-
-type DashboardPermissions = "dashboard:view";
-type AccessPermissions = "access:request";
-type UserPermissions = "user:manage";
-type ProgramPermissions = "program:manage";
-type StudyPermissions = "study:manage";
-
-type AuthPermissions =
-  | SubmissionRequestPermissions
-  | DataSubmissionPermissions
-  | DashboardPermissions
-  | AccessPermissions
-  | UserPermissions
-  | ProgramPermissions
-  | StudyPermissions;
 
 type OrgInfo = {
   orgID: string;

--- a/src/types/PBAC.d.ts
+++ b/src/types/PBAC.d.ts
@@ -58,7 +58,7 @@ type AuthNotifications =
  *
  * e.g. Permission or Notification
  */
-type PBACDefault<T> = {
+type PBACDefault<T = AuthNotifications | AuthPermissions> = {
   /**
    * The unique identifier of the PBAC object.
    *

--- a/src/types/PBAC.d.ts
+++ b/src/types/PBAC.d.ts
@@ -1,0 +1,88 @@
+type SubmissionRequestPermissions =
+  | "submission_request:view"
+  | "submission_request:create"
+  | "submission_request:review"
+  | "submission_request:submit";
+
+type DataSubmissionPermissions =
+  | "data_submission:view"
+  | "data_submission:create"
+  | "data_submission:review"
+  | "data_submission:admin_submit"
+  | "data_submission:confirm";
+
+type DashboardPermissions = "dashboard:view";
+type AccessPermissions = "access:request";
+type UserPermissions = "user:manage";
+type ProgramPermissions = "program:manage";
+type StudyPermissions = "study:manage";
+
+type AuthPermissions =
+  | SubmissionRequestPermissions
+  | DataSubmissionPermissions
+  | DashboardPermissions
+  | AccessPermissions
+  | UserPermissions
+  | ProgramPermissions
+  | StudyPermissions;
+
+type SubmissionRequestNotifications =
+  | "submission_request:submitted"
+  | "submission_request:to_be_reviewed"
+  | "submission_request:reviewed"
+  | "submission_request:deleted"
+  | "submission_request:expiring";
+
+type DataSubmissionNotifications =
+  | "data_submission:submitted"
+  | "data_submission:cancelled"
+  | "data_submission:withdrawn"
+  | "data_submission:released"
+  | "data_submission:completed"
+  | "data_submission:deleted"
+  | "data_submission:expiring";
+
+type MiscNotifications =
+  | "access:requested"
+  | "account:inactivated"
+  | "account:users_inactivated"
+  | "account:disabled";
+
+type AuthNotifications =
+  | SubmissionRequestNotifications
+  | DataSubmissionNotifications
+  | MiscNotifications;
+
+/**
+ * Defines the default structure of a PBAC object.
+ *
+ * e.g. Permission or Notification
+ */
+type PBACDefault<T> = {
+  /**
+   * The unique identifier of the PBAC object.
+   *
+   * @example "manage:users"
+   */
+  _id: T;
+  /**
+   * The group the PBAC object belongs to.
+   *
+   * @example "User Management"
+   */
+  group: string;
+  /**
+   * The name of the PBAC object.
+   *
+   * @example "Manage Users"
+   */
+  name: string;
+  /**
+   * Whether the PBAC object is checked for the role.
+   */
+  checked: boolean;
+  /**
+   * Whether the PBAC object is disabled for the role.
+   */
+  disabled: boolean;
+};

--- a/src/types/PBAC.d.ts
+++ b/src/types/PBAC.d.ts
@@ -72,7 +72,7 @@ type PBACDefault<T> = {
    */
   group: string;
   /**
-   * The name of the PBAC object.
+   * The name of the individual PBAC setting.
    *
    * @example "Manage Users"
    */

--- a/src/utils/profileUtils.test.ts
+++ b/src/utils/profileUtils.test.ts
@@ -382,4 +382,32 @@ describe("columnizePBACGroups cases", () => {
       pbacDefaults[4],
     ]);
   });
+
+  it("should sort the groups in the order: Submission Request, Data Submission, Admin, Miscellaneous", () => {
+    const pbacDefaults: PBACDefault[] = [
+      { ...baseDefault, name: "6", group: "Random Group 1" }, // 5
+      { ...baseDefault, name: "1", group: "Data Submission" }, // 2
+      { ...baseDefault, name: "3", group: "Miscellaneous" }, // 4
+      { ...baseDefault, name: "2", group: "Admin" }, // 3
+      { ...baseDefault, name: "4", group: "Submission Request" }, // 1
+    ];
+
+    const columnized = utils.columnizePBACGroups(pbacDefaults, 4);
+
+    expect(columnized).toHaveLength(4);
+    expect(columnized[0]).toHaveLength(1);
+    expect(columnized[1]).toHaveLength(1);
+    expect(columnized[2]).toHaveLength(1);
+    expect(columnized[3]).toHaveLength(2);
+
+    expect(columnized[0][0].data).toEqual([
+      { ...baseDefault, name: "4", group: "Submission Request" },
+    ]);
+    expect(columnized[1][0].data).toEqual([
+      { ...baseDefault, name: "1", group: "Data Submission" },
+    ]);
+    expect(columnized[2][0].data).toEqual([{ ...baseDefault, name: "2", group: "Admin" }]);
+    expect(columnized[3][0].data).toEqual([{ ...baseDefault, name: "3", group: "Miscellaneous" }]);
+    expect(columnized[3][1].data).toEqual([{ ...baseDefault, name: "6", group: "Random Group 1" }]);
+  });
 });

--- a/src/utils/profileUtils.ts
+++ b/src/utils/profileUtils.ts
@@ -89,8 +89,11 @@ export const columnizePBACGroups = <T = unknown>(
     groupedData[groupName].push(item);
   });
 
+  const sortedGroups = Object.entries(groupedData);
+  sortedGroups.sort(([a], [b]) => orderPBACGroups(a, b));
+
   const columns: ColumnizedPBACGroups<T> = [];
-  Object.entries(groupedData).forEach(([group, data], index) => {
+  sortedGroups.forEach(([group, data], index) => {
     const groupIndex = index > colCount - 1 ? colCount - 1 : index;
     if (!columns[groupIndex]) {
       columns[groupIndex] = [];
@@ -100,4 +103,40 @@ export const columnizePBACGroups = <T = unknown>(
   });
 
   return columns;
+};
+
+/**
+ * A utility function to order PBAC Groups by their partial group name in the following order:
+ *
+ * 1. Submission Request
+ * 2. Data Submission
+ * 3. Admin
+ * 4. Miscellaneous
+ * 5. All other groups
+ *
+ * If the name does not contain any of the above groups, it will be pushed to the end,
+ * but will not be sorted against other unlisted groups.
+ *
+ * @param groups The groups to order
+ * @returns The ordered groups in the format of Record<string, T[]>
+ */
+export const orderPBACGroups = (a: string, b: string): number => {
+  const SORT_PRIORITY = ["Submission Request", "Data Submission", "Admin", "Miscellaneous"];
+
+  const aIndex = SORT_PRIORITY.findIndex((group) => a.includes(group));
+  const bIndex = SORT_PRIORITY.findIndex((group) => b.includes(group));
+
+  if (aIndex === -1 && bIndex === -1) {
+    return 0;
+  }
+
+  if (aIndex === -1) {
+    return 1;
+  }
+
+  if (bIndex === -1) {
+    return -1;
+  }
+
+  return aIndex - bIndex;
 };

--- a/src/utils/profileUtils.ts
+++ b/src/utils/profileUtils.ts
@@ -61,8 +61,8 @@ export type ColumnizedPBACGroups<T = unknown> = {
  * A utility function to group an array of PBACDefaults into columns
  * based on the group name.
  *
- * If colCount is greater than the number of groups, the last column will
- * aggregate the remaining groups.
+ * If the number of unique groups exceeds `colCount`, the function will
+ * aggregate the remaining groups into the last column.
  *
  * Data Structure: Array of Columns -> Array of Groups -> PBAC Defaults for the group
  *

--- a/src/utils/profileUtils.ts
+++ b/src/utils/profileUtils.ts
@@ -40,3 +40,64 @@ export const userToCollaborator = (
     orgName: user?.organization?.orgName,
   },
 });
+
+/**
+ * The data structure for a columized PBAC group
+ */
+export type ColumnizedPBACGroups<T = unknown> = {
+  /**
+   * The name of the group of PBACDefaults
+   *
+   * All PBACDefaults in the group will have the same group name
+   */
+  name: string;
+  /**
+   * The PBACDefaults for the group
+   */
+  data: PBACDefault<T>[];
+}[][];
+
+/**
+ * A utility function to group an array of PBACDefaults into columns
+ * based on the group name.
+ *
+ * If colCount is greater than the number of groups, the last column will
+ * aggregate the remaining groups.
+ *
+ * Data Structure: Array of Columns -> Array of Groups -> PBAC Defaults for the group
+ *
+ * @see {@link ColumnizedPBACGroups}
+ * @param data The array of PBACDefaults to columnize
+ * @param colCount The number of columns to create
+ * @returns An array of columns containing an array of PBACDefaults
+ */
+export const columnizePBACGroups = <T = unknown>(
+  data: PBACDefault<T>[],
+  colCount = 3
+): ColumnizedPBACGroups<T> => {
+  if (!data || !Array.isArray(data) || data.length === 0) {
+    return [];
+  }
+
+  const groupedData: Record<string, PBACDefault<T>[]> = {};
+  data.forEach((item) => {
+    const groupName = typeof item?.group === "string" ? item.group : "";
+    if (!groupedData[groupName]) {
+      groupedData[groupName] = [];
+    }
+
+    groupedData[groupName].push(item);
+  });
+
+  const columns: ColumnizedPBACGroups<T> = [];
+  Object.entries(groupedData).forEach(([group, data], index) => {
+    const groupIndex = index > colCount - 1 ? colCount - 1 : index;
+    if (!columns[groupIndex]) {
+      columns[groupIndex] = [];
+    }
+
+    columns[groupIndex].push({ name: group, data });
+  });
+
+  return columns;
+};


### PR DESCRIPTION
### Overview

This PR introduces the ability to configure individual PBAC permissions for an account.

> [!Warning]
> Some known issues / expected things from the backend implementation:
> - You can adjust a Submitter or User's permissions, but no changes will actually be saved. This is expected, but BE should be locking all permissions, and they currently aren't
> - The backend seems to reject some permissions and/or notification selections and returns an error for it. Just uncheck them in the FE for now
> - The visual permission names don't really match the user stories anymore (they keep getting changed)
> - The order of actual permissions in the nested groups may not match the user stories (see below)

> [!NOTE]
> The frontend sorts the groups based on the User Story, but we don't sort the nested permissions themselves since that's somewhat impractical (way too many options). 

### Change Details (Specifics)

- Implement a PermissionsPanel component, which handles the PBAC checkboxes, defaults, and form management
- Update the useProfileFields hook to conditionally render permissions/notifications fields
- Update remaining queries to pull the notification/permission assignments
- Update the Apollo memory cache to stop it from normalizing the PBAC data
  - It was discarding the relationship between the roles and their specific defaults causing serious issues
- Move `AuthPermissions` to a separate file (`PBAC.d.ts`) and create `AuthNotifications` type for consistency
  - I'm also fine with just leaving it in `Auth.d.ts` if that's preferred, it was just getting cluttered
- Update the ProfileView action buttons to be consistent with design (matching DS and SR theme)

### Related Ticket(s)

CRDCDH-2105 (Task)
... A lot of stories
