### PR TITLE
CRDCDH-1674 Fix Orphaned Files error being moved from submission to QC Results

### DIFF
--- a/src/components/Contexts/SubmissionContext.test.tsx
+++ b/src/components/Contexts/SubmissionContext.test.tsx
@@ -3,7 +3,13 @@ import { act, render, renderHook, waitFor } from "@testing-library/react";
 import { MockedProvider, MockedResponse } from "@apollo/client/testing";
 import { GraphQLError } from "graphql";
 import { SubmissionCtxStatus, SubmissionProvider, useSubmissionContext } from "./SubmissionContext";
-import { GET_SUBMISSION, GetSubmissionInput, GetSubmissionResp } from "../../graphql";
+import {
+  GET_SUBMISSION,
+  GetSubmissionInput,
+  GetSubmissionResp,
+  SUBMISSION_QC_RESULTS,
+  SubmissionQCResultsResp,
+} from "../../graphql";
 
 const mockStartPolling = jest.fn();
 const mockStopPolling = jest.fn();
@@ -100,7 +106,23 @@ describe("useSubmissionContext", () => {
       },
     ];
 
-    expect(() => render(<TestParent mocks={mocks} _id="test-nominal-id" />)).not.toThrow();
+    const qcMocks: MockedResponse<SubmissionQCResultsResp<true>>[] = [
+      {
+        request: {
+          query: SUBMISSION_QC_RESULTS,
+        },
+        variableMatcher: () => true,
+        result: {
+          data: {
+            submissionQCResults: null,
+          },
+        },
+      },
+    ];
+
+    expect(() =>
+      render(<TestParent mocks={[...mocks, ...qcMocks]} _id="test-nominal-id" />)
+    ).not.toThrow();
   });
 });
 
@@ -119,8 +141,23 @@ describe("SubmissionProvider", () => {
         error: new Error("Network error"),
       },
     ];
+    const qcMocks: MockedResponse<SubmissionQCResultsResp<true>>[] = [
+      {
+        request: {
+          query: SUBMISSION_QC_RESULTS,
+        },
+        variableMatcher: () => true,
+        result: {
+          data: {
+            submissionQCResults: null,
+          },
+        },
+      },
+    ];
 
-    const { getByTestId } = render(<TestParent mocks={mocks} _id="test-network-error-id" />);
+    const { getByTestId } = render(
+      <TestParent mocks={[...mocks, ...qcMocks]} _id="test-network-error-id" />
+    );
 
     await waitFor(() => expect(getByTestId("ctx-status")).toHaveTextContent("ERROR"));
   });
@@ -137,8 +174,23 @@ describe("SubmissionProvider", () => {
         },
       },
     ];
+    const qcMocks: MockedResponse<SubmissionQCResultsResp<true>>[] = [
+      {
+        request: {
+          query: SUBMISSION_QC_RESULTS,
+        },
+        variableMatcher: () => true,
+        result: {
+          data: {
+            submissionQCResults: null,
+          },
+        },
+      },
+    ];
 
-    const { getByTestId } = render(<TestParent mocks={mocks} _id="test-graphql-error-id" />);
+    const { getByTestId } = render(
+      <TestParent mocks={[...mocks, ...qcMocks]} _id="test-graphql-error-id" />
+    );
 
     await waitFor(() => expect(getByTestId("ctx-status")).toHaveTextContent("ERROR"));
   });
@@ -159,8 +211,23 @@ describe("SubmissionProvider", () => {
         },
       },
     ];
+    const qcMocks: MockedResponse<SubmissionQCResultsResp<true>>[] = [
+      {
+        request: {
+          query: SUBMISSION_QC_RESULTS,
+        },
+        variableMatcher: () => true,
+        result: {
+          data: {
+            submissionQCResults: null,
+          },
+        },
+      },
+    ];
 
-    const { getByTestId } = render(<TestParent mocks={mocks} _id="test-null-id" />);
+    const { getByTestId } = render(
+      <TestParent mocks={[...mocks, ...qcMocks]} _id="test-null-id" />
+    );
 
     await waitFor(() => expect(getByTestId("ctx-status")).toHaveTextContent("ERROR"));
   });
@@ -188,8 +255,26 @@ describe("SubmissionProvider", () => {
         },
       },
     ];
+    const qcMocks: MockedResponse<SubmissionQCResultsResp<true>>[] = [
+      {
+        request: {
+          query: SUBMISSION_QC_RESULTS,
+        },
+        variableMatcher: () => true,
+        result: {
+          data: {
+            submissionQCResults: {
+              total: 0,
+              results: [],
+            },
+          },
+        },
+      },
+    ];
 
-    const { getByTestId } = render(<TestParent mocks={mocks} _id="test-valid-id" />);
+    const { getByTestId } = render(
+      <TestParent mocks={[...mocks, ...qcMocks]} _id="test-valid-id" />
+    );
 
     await waitFor(() => expect(getByTestId("ctx-status")).toHaveTextContent("LOADED"));
   });
@@ -223,10 +308,27 @@ describe("SubmissionProvider", () => {
         },
       },
     ];
+    const qcMocks: MockedResponse<SubmissionQCResultsResp<true>>[] = [
+      {
+        request: {
+          query: SUBMISSION_QC_RESULTS,
+        },
+        variableMatcher: () => true,
+        result: {
+          data: {
+            submissionQCResults: {
+              total: 0,
+              results: [],
+            },
+          },
+        },
+      },
+    ];
 
-    render(<TestParent mocks={mocks} _id="test-validating-id" />);
+    render(<TestParent mocks={[...mocks, ...qcMocks]} _id="test-validating-id" />);
 
-    await waitFor(() => expect(mockStartPolling).toHaveBeenCalledTimes(1));
+    // Should poll getSubmission + submissionQCResults
+    await waitFor(() => expect(mockStartPolling).toHaveBeenCalledTimes(2));
     expect(mockStopPolling).not.toHaveBeenCalled();
   });
 
@@ -259,10 +361,27 @@ describe("SubmissionProvider", () => {
         },
       },
     ];
+    const qcMocks: MockedResponse<SubmissionQCResultsResp<true>>[] = [
+      {
+        request: {
+          query: SUBMISSION_QC_RESULTS,
+        },
+        variableMatcher: () => true,
+        result: {
+          data: {
+            submissionQCResults: {
+              total: 0,
+              results: [],
+            },
+          },
+        },
+      },
+    ];
 
-    render(<TestParent mocks={mocks} _id="test-validating-id" />);
+    render(<TestParent mocks={[...mocks, ...qcMocks]} _id="test-validating-id" />);
 
-    await waitFor(() => expect(mockStopPolling).toHaveBeenCalledTimes(1));
+    // Should stop polling getSubmission + submissionQCResults
+    await waitFor(() => expect(mockStopPolling).toHaveBeenCalledTimes(2));
     expect(mockStartPolling).not.toHaveBeenCalled();
   });
 
@@ -295,10 +414,27 @@ describe("SubmissionProvider", () => {
         },
       },
     ];
+    const qcMocks: MockedResponse<SubmissionQCResultsResp<true>>[] = [
+      {
+        request: {
+          query: SUBMISSION_QC_RESULTS,
+        },
+        variableMatcher: () => true,
+        result: {
+          data: {
+            submissionQCResults: {
+              total: 0,
+              results: [],
+            },
+          },
+        },
+      },
+    ];
 
-    render(<TestParent mocks={mocks} _id="test-uploading-id" />);
+    render(<TestParent mocks={[...mocks, ...qcMocks]} _id="test-uploading-id" />);
 
-    await waitFor(() => expect(mockStartPolling).toHaveBeenCalledTimes(1));
+    // Should poll getSubmission + submissionQCResults
+    await waitFor(() => expect(mockStartPolling).toHaveBeenCalledTimes(2));
     expect(mockStopPolling).not.toHaveBeenCalled();
   });
 
@@ -331,10 +467,27 @@ describe("SubmissionProvider", () => {
         },
       },
     ];
+    const qcMocks: MockedResponse<SubmissionQCResultsResp<true>>[] = [
+      {
+        request: {
+          query: SUBMISSION_QC_RESULTS,
+        },
+        variableMatcher: () => true,
+        result: {
+          data: {
+            submissionQCResults: {
+              total: 0,
+              results: [],
+            },
+          },
+        },
+      },
+    ];
 
-    render(<TestParent mocks={mocks} _id="test-uploading-id" />);
+    // Should stop polling getSubmission + submissionQCResults
+    render(<TestParent mocks={[...mocks, ...qcMocks]} _id="test-uploading-id" />);
 
-    await waitFor(() => expect(mockStopPolling).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(mockStopPolling).toHaveBeenCalledTimes(2));
     expect(mockStartPolling).not.toHaveBeenCalled();
   });
 
@@ -363,10 +516,27 @@ describe("SubmissionProvider", () => {
         },
       },
     ];
+    const qcMocks: MockedResponse<SubmissionQCResultsResp<true>>[] = [
+      {
+        request: {
+          query: SUBMISSION_QC_RESULTS,
+        },
+        variableMatcher: () => true,
+        result: {
+          data: {
+            submissionQCResults: {
+              total: 0,
+              results: [],
+            },
+          },
+        },
+      },
+    ];
 
-    render(<TestParent mocks={mocks} _id="test-deleting-id" />);
+    render(<TestParent mocks={[...mocks, ...qcMocks]} _id="test-deleting-id" />);
 
-    await waitFor(() => expect(mockStartPolling).toHaveBeenCalledTimes(1));
+    // Should poll getSubmission + submissionQCResults
+    await waitFor(() => expect(mockStartPolling).toHaveBeenCalledTimes(2));
     expect(mockStopPolling).not.toHaveBeenCalled();
   });
 
@@ -395,10 +565,27 @@ describe("SubmissionProvider", () => {
         },
       },
     ];
+    const qcMocks: MockedResponse<SubmissionQCResultsResp<true>>[] = [
+      {
+        request: {
+          query: SUBMISSION_QC_RESULTS,
+        },
+        variableMatcher: () => true,
+        result: {
+          data: {
+            submissionQCResults: {
+              total: 0,
+              results: [],
+            },
+          },
+        },
+      },
+    ];
 
-    render(<TestParent mocks={mocks} _id="test-deleting-id" />);
+    render(<TestParent mocks={[...mocks, ...qcMocks]} _id="test-deleting-id" />);
 
-    await waitFor(() => expect(mockStopPolling).toHaveBeenCalledTimes(1));
+    // Should stop polling getSubmission + submissionQCResults
+    await waitFor(() => expect(mockStopPolling).toHaveBeenCalledTimes(2));
     expect(mockStartPolling).not.toHaveBeenCalled();
   });
 
@@ -430,10 +617,26 @@ describe("SubmissionProvider", () => {
         },
       },
     ];
+    const qcMocks: MockedResponse<SubmissionQCResultsResp<true>>[] = [
+      {
+        request: {
+          query: SUBMISSION_QC_RESULTS,
+        },
+        variableMatcher: () => true,
+        result: {
+          data: {
+            submissionQCResults: {
+              total: 0,
+              results: [],
+            },
+          },
+        },
+      },
+    ];
 
     const { result } = renderHook(() => useSubmissionContext(), {
       wrapper: ({ children }) => (
-        <TestParent mocks={mocks} _id="test-wrapper-id">
+        <TestParent mocks={[...mocks, ...qcMocks]} _id="test-wrapper-id">
           {children}
         </TestParent>
       ),
@@ -447,6 +650,7 @@ describe("SubmissionProvider", () => {
       startPolling(1000);
     });
 
+    await waitFor(() => expect(mockStartPolling).toHaveBeenCalledTimes(2));
     expect(mockStartPolling).toHaveBeenCalledWith(1000);
 
     act(() => {
@@ -479,10 +683,26 @@ describe("SubmissionProvider", () => {
         },
       },
     ];
+    const qcMocks: MockedResponse<SubmissionQCResultsResp<true>>[] = [
+      {
+        request: {
+          query: SUBMISSION_QC_RESULTS,
+        },
+        variableMatcher: () => true,
+        result: {
+          data: {
+            submissionQCResults: {
+              total: 0,
+              results: [],
+            },
+          },
+        },
+      },
+    ];
 
     const { result } = renderHook(() => useSubmissionContext(), {
       wrapper: ({ children }) => (
-        <TestParent mocks={mocks} _id="test-polling-id">
+        <TestParent mocks={[...mocks, ...qcMocks]} _id="test-polling-id">
           {children}
         </TestParent>
       ),

--- a/src/components/Contexts/SubmissionContext.tsx
+++ b/src/components/Contexts/SubmissionContext.tsx
@@ -128,6 +128,9 @@ export const SubmissionProvider: FC<ProviderProps> = ({ _id, children }: Provide
     updateQuery,
   } = useQuery<GetSubmissionResp, GetSubmissionInput>(GET_SUBMISSION, {
     notifyOnNetworkStatusChange: true,
+    variables: { id: _id },
+    context: { clientName: "backend" },
+    fetchPolicy: "cache-and-network",
     onCompleted: (d) => {
       const isValidating =
         d?.getSubmission?.fileValidationStatus === "Validating" ||

--- a/src/components/Contexts/SubmissionContext.tsx
+++ b/src/components/Contexts/SubmissionContext.tsx
@@ -1,7 +1,13 @@
 import React, { FC, createContext, useCallback, useContext, useMemo, useState } from "react";
 import { ApolloError, ApolloQueryResult, useQuery } from "@apollo/client";
 import { cloneDeep, isEqual } from "lodash";
-import { GetSubmissionResp, GET_SUBMISSION, GetSubmissionInput } from "../../graphql";
+import {
+  GetSubmissionResp,
+  GET_SUBMISSION,
+  GetSubmissionInput,
+  SubmissionQCResultsResp,
+  SUBMISSION_QC_RESULTS,
+} from "../../graphql";
 import { compareNodeStats, Logger } from "../../utils";
 
 export type SubmissionCtxState = {
@@ -17,6 +23,14 @@ export type SubmissionCtxState = {
    * The error returned by the query
    */
   error: ApolloError | null;
+  /**
+   * The partial Validation Results data
+   */
+  qcData?: SubmissionQCResultsResp<true> | null;
+  /**
+   * The error returned by the Validation Results query
+   */
+  qcError?: ApolloError | null;
   /**
    * Initiates polling for the query at the specified interval
    */
@@ -126,18 +140,32 @@ export const SubmissionProvider: FC<ProviderProps> = ({ _id, children }: Provide
 
       if (!isValidating && !hasUploadingBatches && !isDeleting) {
         stopApolloPolling();
+        stopQCPolling();
         setIsPolling(false);
       } else {
         startApolloPolling(1000);
+        startQCPolling(1000);
         setIsPolling(true);
       }
     },
     onError: (e) => {
       Logger.error("Error fetching submission data", e);
     },
-    variables: { id: _id },
+  });
+
+  const {
+    data: qcData,
+    error: qcError,
+    startPolling: startQCPolling,
+    stopPolling: stopQCPolling,
+  } = useQuery<SubmissionQCResultsResp<true>>(SUBMISSION_QC_RESULTS, {
+    variables: { id: _id, partial: true },
     context: { clientName: "backend" },
     fetchPolicy: "cache-and-network",
+    notifyOnNetworkStatusChange: true,
+    onError: (err) => {
+      Logger.error("Error fetching submission validation results data", err);
+    },
   });
 
   const status: SubmissionCtxStatus = useMemo<SubmissionCtxStatus>(() => {
@@ -174,30 +202,34 @@ export const SubmissionProvider: FC<ProviderProps> = ({ _id, children }: Provide
   const startPolling = useCallback(
     (interval: number) => {
       startApolloPolling(interval);
+      startQCPolling(interval);
       setIsPolling(true);
     },
-    [startApolloPolling]
+    [startApolloPolling, startQCPolling]
   );
 
   /**
-   * Wrapper function to stop polling for the submission
+   * Wrapper function to stop polling for the submission and QC results
    */
   const stopPolling = useCallback(() => {
     stopApolloPolling();
+    stopQCPolling();
     setIsPolling(false);
-  }, [stopApolloPolling]);
+  }, [stopApolloPolling, stopQCPolling]);
 
   const value: SubmissionCtxState = useMemo<SubmissionCtxState>(
     () => ({
       status,
       data: memoedData,
       error,
+      qcData,
+      qcError,
       startPolling,
       stopPolling,
       refetch,
       updateQuery,
     }),
-    [status, memoedData, error, startPolling, stopPolling, refetch, updateQuery]
+    [status, memoedData, error, startPolling, stopPolling, refetch, updateQuery, qcData, qcError]
   );
 
   return <MemoedProvider value={value}>{children}</MemoedProvider>;

--- a/src/components/DataSubmissions/ExportValidationButton.test.tsx
+++ b/src/components/DataSubmissions/ExportValidationButton.test.tsx
@@ -119,6 +119,7 @@ describe("ExportValidationButton cases", () => {
         request: {
           query: SUBMISSION_QC_RESULTS,
           variables: {
+            partial: false,
             id: submissionID,
             sortDirection: "asc",
             orderBy: "displayID",
@@ -175,6 +176,7 @@ describe("ExportValidationButton cases", () => {
           request: {
             query: SUBMISSION_QC_RESULTS,
             variables: {
+              partial: false,
               id: "example-dynamic-filename-id",
               sortDirection: "asc",
               orderBy: "displayID",
@@ -245,6 +247,7 @@ describe("ExportValidationButton cases", () => {
         request: {
           query: SUBMISSION_QC_RESULTS,
           variables: {
+            partial: false,
             id: submissionID,
             sortDirection: "asc",
             orderBy: "displayID",
@@ -298,6 +301,7 @@ describe("ExportValidationButton cases", () => {
         request: {
           query: SUBMISSION_QC_RESULTS,
           variables: {
+            partial: false,
             id: submissionID,
             sortDirection: "asc",
             orderBy: "displayID",
@@ -371,6 +375,7 @@ describe("ExportValidationButton cases", () => {
         request: {
           query: SUBMISSION_QC_RESULTS,
           variables: {
+            partial: false,
             id: submissionID,
             sortDirection: "asc",
             orderBy: "displayID",
@@ -408,6 +413,7 @@ describe("ExportValidationButton cases", () => {
         request: {
           query: SUBMISSION_QC_RESULTS,
           variables: {
+            partial: false,
             id: submissionID,
             sortDirection: "asc",
             orderBy: "displayID",
@@ -447,6 +453,7 @@ describe("ExportValidationButton cases", () => {
         request: {
           query: SUBMISSION_QC_RESULTS,
           variables: {
+            partial: false,
             id: submissionID,
             sortDirection: "asc",
             orderBy: "displayID",

--- a/src/config/SubmitButtonConfig.ts
+++ b/src/config/SubmitButtonConfig.ts
@@ -11,12 +11,12 @@ export type SubmitButtonCondition = {
    * If false, then submit button remains disabled. Otherwise, the current
    * condition is satisfied
    */
-  check: (submission: Submission) => boolean;
+  check: (submission: Submission, qcResults: Pick<QCResult, "errors">[]) => boolean;
   /**
    * Optionally checks the pre-condition to determine whether this condition
    * is applicable in the current submission state
    */
-  preConditionCheck?: (submission: Submission) => boolean;
+  preConditionCheck?: (submission: Submission, qcResults: Pick<QCResult, "errors">[]) => boolean;
   /**
    * The text that will display on the tooltip for the submit button
    */
@@ -28,6 +28,11 @@ export type SubmitButtonCondition = {
 };
 
 export type AdminOverrideCondition = Omit<SubmitButtonCondition, "required">;
+
+/**
+ * The title of the error message that represents an orphaned file
+ */
+const ORPHANED_FILE_ERROR_TITLE = "Orphaned file found";
 
 /**
  * Configuration of conditions used to determine whether the submit button
@@ -49,8 +54,9 @@ export const SUBMIT_BUTTON_CONDITIONS: SubmitButtonCondition[] = [
     required: true,
   },
   {
-    _identifier: "Submission should not have submission level errors, such as orphaned files",
-    check: (s) => !s.fileErrors?.length,
+    _identifier: "Submission should not have orphaned files",
+    check: (_, qcResults) =>
+      !qcResults?.some((qc) => qc.errors?.find((err) => err.title === ORPHANED_FILE_ERROR_TITLE)),
     tooltip: TOOLTIP_TEXT.SUBMISSION_ACTIONS.SUBMIT.DISABLED.NEW_DATA_OR_VALIDATION_ERRORS,
     required: true,
   },

--- a/src/content/dataSubmissions/DataSubmission.tsx
+++ b/src/content/dataSubmissions/DataSubmission.tsx
@@ -163,7 +163,7 @@ const DataSubmission: FC<Props> = ({ submissionId, tab = URLTabs.UPLOAD_ACTIVITY
   const { user } = useAuthContext();
   const { enqueueSnackbar } = useSnackbar();
   const { lastSearchParams } = useSearchParamsContext();
-  const { data, error, refetch: getSubmission } = useSubmissionContext();
+  const { data, error, refetch: getSubmission, qcData, qcError } = useSubmissionContext();
 
   const dataSubmissionListPageUrl = `/data-submissions${
     lastSearchParams?.["/data-submissions"] ?? ""
@@ -189,7 +189,7 @@ const DataSubmission: FC<Props> = ({ submissionId, tab = URLTabs.UPLOAD_ACTIVITY
       return { enabled: false };
     }
 
-    return shouldEnableSubmit(data.getSubmission, user?.role);
+    return shouldEnableSubmit(data.getSubmission, qcData?.submissionQCResults?.results, user?.role);
   }, [data?.getSubmission, user, hasUploadingBatches, SubmitDataSubmissionRoles]);
   const releaseInfo: ReleaseInfo = useMemo(
     () => shouldDisableRelease(data?.getSubmission),
@@ -251,8 +251,15 @@ const DataSubmission: FC<Props> = ({ submissionId, tab = URLTabs.UPLOAD_ACTIVITY
       navigate(dataSubmissionListPageUrl, {
         state: { error: "Oops! An error occurred while retrieving that Data Submission." },
       });
+    } else if (qcError) {
+      navigate(dataSubmissionListPageUrl, {
+        state: {
+          error:
+            "There was an issue while retrieving the validation results for that Data Submission.",
+        },
+      });
     }
-  }, [error]);
+  }, [error, qcError]);
 
   return (
     <StyledWrapper>

--- a/src/graphql/submissionQCResults.ts
+++ b/src/graphql/submissionQCResults.ts
@@ -1,5 +1,38 @@
 import gql from "graphql-tag";
 
+// The base QCResult model used for all submissionQCResults queries
+const BaseQCResultFragment = gql`
+  fragment BaseQCResultFragment on QCResult {
+    errors {
+      title
+      description
+    }
+  }
+`;
+
+// The extended QCResult model which includes all fields
+const FullQCResultFragment = gql`
+  fragment QCResultFragment on QCResult {
+    submissionID
+    type
+    validationType
+    batchID
+    displayID
+    submittedID
+    severity
+    uploadedDate
+    validatedDate
+    errors {
+      title
+      description
+    }
+    warnings {
+      title
+      description
+    }
+  }
+`;
+
 export const query = gql`
   query submissionQCResults(
     $id: ID!
@@ -10,6 +43,7 @@ export const query = gql`
     $offset: Int
     $orderBy: String
     $sortDirection: String
+    $partial: Boolean = false
   ) {
     submissionQCResults(
       _id: $id
@@ -23,28 +57,17 @@ export const query = gql`
     ) {
       total
       results {
-        submissionID
-        type
-        validationType
-        batchID
-        displayID
-        submittedID
-        severity
-        uploadedDate
-        validatedDate
-        errors {
-          title
-          description
-        }
-        warnings {
-          title
-          description
-        }
+        ...BaseQCResultFragment
+        ...QCResultFragment @skip(if: $partial)
       }
     }
   }
+  ${FullQCResultFragment}
+  ${BaseQCResultFragment}
 `;
 
-export type Response = {
-  submissionQCResults: ValidationResult<QCResult>;
+export type Response<IsPartial = false> = {
+  submissionQCResults: ValidationResult<
+    IsPartial extends true ? Pick<QCResult, "errors"> : QCResult
+  >;
 };

--- a/src/utils/dataSubmissionUtils.test.ts
+++ b/src/utils/dataSubmissionUtils.test.ts
@@ -38,6 +38,8 @@ const baseSubmission: Submission = {
   collaborators: [],
 };
 
+const baseQCResults: QCResult[] = [];
+
 describe("General Submit", () => {
   it("should disable submit without isAdminOverride when user role is not Admin but there are validation errors", () => {
     const submission: Submission = {
@@ -45,7 +47,7 @@ describe("General Submit", () => {
       metadataValidationStatus: "Error",
       fileValidationStatus: "Error",
     };
-    const result = utils.shouldEnableSubmit(submission, "Submitter");
+    const result = utils.shouldEnableSubmit(submission, baseQCResults, "Submitter");
     expect(result.enabled).toBe(false);
     expect(result.isAdminOverride).toBe(false);
   });
@@ -56,7 +58,7 @@ describe("General Submit", () => {
       metadataValidationStatus: "Passed",
       fileValidationStatus: "Error",
     };
-    const result = utils.shouldEnableSubmit(submission, "Submitter");
+    const result = utils.shouldEnableSubmit(submission, baseQCResults, "Submitter");
     expect(result.enabled).toBe(false);
     expect(result.isAdminOverride).toBe(false);
   });
@@ -67,7 +69,7 @@ describe("General Submit", () => {
       metadataValidationStatus: "Error",
       fileValidationStatus: "Passed",
     };
-    const result = utils.shouldEnableSubmit(submission, "Submitter");
+    const result = utils.shouldEnableSubmit(submission, baseQCResults, "Submitter");
     expect(result.enabled).toBe(false);
     expect(result.isAdminOverride).toBe(false);
   });
@@ -78,7 +80,7 @@ describe("General Submit", () => {
       metadataValidationStatus: "Warning",
       fileValidationStatus: "Error",
     };
-    const result = utils.shouldEnableSubmit(submission, "Submitter");
+    const result = utils.shouldEnableSubmit(submission, baseQCResults, "Submitter");
     expect(result.enabled).toBe(false);
     expect(result.isAdminOverride).toBe(false);
   });
@@ -89,7 +91,7 @@ describe("General Submit", () => {
       metadataValidationStatus: "Error",
       fileValidationStatus: "Warning",
     };
-    const result = utils.shouldEnableSubmit(submission, "Submitter");
+    const result = utils.shouldEnableSubmit(submission, baseQCResults, "Submitter");
     expect(result.enabled).toBe(false);
     expect(result.isAdminOverride).toBe(false);
   });
@@ -101,7 +103,7 @@ describe("General Submit", () => {
       metadataValidationStatus: "Passed",
       fileValidationStatus: null,
     };
-    const result = utils.shouldEnableSubmit(submission, "Submitter");
+    const result = utils.shouldEnableSubmit(submission, baseQCResults, "Submitter");
     expect(result.enabled).toBe(true);
     expect(result.isAdminOverride).toBe(false);
   });
@@ -112,7 +114,7 @@ describe("General Submit", () => {
       metadataValidationStatus: "Passed",
       fileValidationStatus: "Passed",
     };
-    const result = utils.shouldEnableSubmit(submission, "Submitter");
+    const result = utils.shouldEnableSubmit(submission, baseQCResults, "Submitter");
     expect(result.enabled).toBe(true);
     expect(result.isAdminOverride).toBe(false);
   });
@@ -123,7 +125,7 @@ describe("General Submit", () => {
       metadataValidationStatus: "Passed",
       fileValidationStatus: "Passed",
     };
-    const result = utils.shouldEnableSubmit(submission, undefined);
+    const result = utils.shouldEnableSubmit(submission, baseQCResults, undefined);
     expect(result.enabled).toBe(false);
     expect(result.isAdminOverride).toBe(false);
   });
@@ -134,7 +136,7 @@ describe("General Submit", () => {
       metadataValidationStatus: null,
       fileValidationStatus: "Passed",
     };
-    const result = utils.shouldEnableSubmit(submission, "Submitter");
+    const result = utils.shouldEnableSubmit(submission, baseQCResults, "Submitter");
     expect(result.enabled).toBe(false);
     expect(result.isAdminOverride).toBe(false);
   });
@@ -145,7 +147,7 @@ describe("General Submit", () => {
       metadataValidationStatus: "Passed",
       fileValidationStatus: null,
     };
-    const result = utils.shouldEnableSubmit(submission, "Submitter");
+    const result = utils.shouldEnableSubmit(submission, baseQCResults, "Submitter");
     expect(result.enabled).toBe(false);
     expect(result.isAdminOverride).toBe(false);
   });
@@ -158,7 +160,7 @@ describe("General Submit", () => {
       fileValidationStatus: null,
       intention: "Delete",
     };
-    const result = utils.shouldEnableSubmit(submission, "Submitter");
+    const result = utils.shouldEnableSubmit(submission, baseQCResults, "Submitter");
     expect(result.enabled).toBe(true);
     expect(result.isAdminOverride).toBe(false);
   });
@@ -170,7 +172,7 @@ describe("General Submit", () => {
       fileValidationStatus: null,
       intention: "New/Update",
     };
-    const result = utils.shouldEnableSubmit(submission, "Submitter");
+    const result = utils.shouldEnableSubmit(submission, baseQCResults, "Submitter");
     expect(result.enabled).toBe(false);
     expect(result.isAdminOverride).toBe(false);
   });
@@ -182,7 +184,7 @@ describe("General Submit", () => {
       fileValidationStatus: "Passed",
       intention: "Delete",
     };
-    const result = utils.shouldEnableSubmit(submission, "Submitter");
+    const result = utils.shouldEnableSubmit(submission, baseQCResults, "Submitter");
     expect(result.enabled).toBe(false);
     expect(result.isAdminOverride).toBe(false);
   });
@@ -194,7 +196,7 @@ describe("General Submit", () => {
       fileValidationStatus: "Error",
       intention: "Delete",
     };
-    const result = utils.shouldEnableSubmit(submission, "Submitter");
+    const result = utils.shouldEnableSubmit(submission, baseQCResults, "Submitter");
     expect(result.enabled).toBe(false);
     expect(result.isAdminOverride).toBe(false);
   });
@@ -205,7 +207,7 @@ describe("General Submit", () => {
       metadataValidationStatus: null,
       fileValidationStatus: null,
     };
-    const result = utils.shouldEnableSubmit(submission, "Submitter");
+    const result = utils.shouldEnableSubmit(submission, baseQCResults, "Submitter");
     expect(result.enabled).toBe(false);
     expect(result.isAdminOverride).toBe(false);
   });
@@ -216,7 +218,7 @@ describe("General Submit", () => {
       metadataValidationStatus: "Validating",
       fileValidationStatus: "Validating",
     };
-    const result = utils.shouldEnableSubmit(submission, "Submitter");
+    const result = utils.shouldEnableSubmit(submission, baseQCResults, "Submitter");
     expect(result.enabled).toBe(false);
     expect(result.isAdminOverride).toBe(false);
   });
@@ -227,7 +229,7 @@ describe("General Submit", () => {
       metadataValidationStatus: "Validating",
       fileValidationStatus: "Passed",
     };
-    const result = utils.shouldEnableSubmit(submission, "Submitter");
+    const result = utils.shouldEnableSubmit(submission, baseQCResults, "Submitter");
     expect(result.enabled).toBe(false);
     expect(result.isAdminOverride).toBe(false);
   });
@@ -238,7 +240,7 @@ describe("General Submit", () => {
       metadataValidationStatus: "Passed",
       fileValidationStatus: "Validating",
     };
-    const result = utils.shouldEnableSubmit(submission, "Submitter");
+    const result = utils.shouldEnableSubmit(submission, baseQCResults, "Submitter");
     expect(result.enabled).toBe(false);
     expect(result.isAdminOverride).toBe(false);
   });
@@ -249,7 +251,7 @@ describe("General Submit", () => {
       metadataValidationStatus: "New",
       fileValidationStatus: "New",
     };
-    const result = utils.shouldEnableSubmit(submission, "Submitter");
+    const result = utils.shouldEnableSubmit(submission, baseQCResults, "Submitter");
     expect(result.enabled).toBe(false);
     expect(result.isAdminOverride).toBe(false);
   });
@@ -260,7 +262,7 @@ describe("General Submit", () => {
       metadataValidationStatus: "New",
       fileValidationStatus: "Passed",
     };
-    const result = utils.shouldEnableSubmit(submission, "Submitter");
+    const result = utils.shouldEnableSubmit(submission, baseQCResults, "Submitter");
     expect(result.enabled).toBe(false);
     expect(result.isAdminOverride).toBe(false);
   });
@@ -271,7 +273,7 @@ describe("General Submit", () => {
       metadataValidationStatus: "Passed",
       fileValidationStatus: "New",
     };
-    const result = utils.shouldEnableSubmit(submission, "Submitter");
+    const result = utils.shouldEnableSubmit(submission, baseQCResults, "Submitter");
     expect(result.enabled).toBe(false);
     expect(result.isAdminOverride).toBe(false);
   });
@@ -282,7 +284,7 @@ describe("General Submit", () => {
       metadataValidationStatus: "Warning",
       fileValidationStatus: "Warning",
     };
-    const result = utils.shouldEnableSubmit(submission, "Submitter");
+    const result = utils.shouldEnableSubmit(submission, baseQCResults, "Submitter");
     expect(result.enabled).toBe(true);
     expect(result.isAdminOverride).toBe(false);
   });
@@ -293,7 +295,7 @@ describe("General Submit", () => {
       metadataValidationStatus: "Passed",
       fileValidationStatus: "Passed",
     };
-    const result = utils.shouldEnableSubmit(submission, "Submitter");
+    const result = utils.shouldEnableSubmit(submission, baseQCResults, "Submitter");
     expect(result.enabled).toBe(true);
     expect(result.isAdminOverride).toBe(false);
   });
@@ -304,7 +306,7 @@ describe("General Submit", () => {
       metadataValidationStatus: "Passed",
       fileValidationStatus: "Warning",
     };
-    const result = utils.shouldEnableSubmit(submission, "Submitter");
+    const result = utils.shouldEnableSubmit(submission, baseQCResults, "Submitter");
     expect(result.enabled).toBe(true);
     expect(result.isAdminOverride).toBe(false);
   });
@@ -315,13 +317,13 @@ describe("General Submit", () => {
       metadataValidationStatus: "Warning",
       fileValidationStatus: "Warning",
     };
-    const result = utils.shouldEnableSubmit(submission, "Submitter");
+    const result = utils.shouldEnableSubmit(submission, baseQCResults, "Submitter");
     expect(result.enabled).toBe(true);
     expect(result.isAdminOverride).toBe(false);
   });
 
   it("should disable submit when submission is null", () => {
-    const result = utils.shouldEnableSubmit(null, "Submitter");
+    const result = utils.shouldEnableSubmit(null, baseQCResults, "Submitter");
     expect(result.enabled).toBe(false);
     expect(result.isAdminOverride).toBe(false);
   });
@@ -334,7 +336,7 @@ describe("Admin Submit", () => {
       metadataValidationStatus: "Error",
       fileValidationStatus: "Error",
     };
-    const result = utils.shouldEnableSubmit(submission, "Admin");
+    const result = utils.shouldEnableSubmit(submission, baseQCResults, "Admin");
     expect(result.enabled).toBe(true);
     expect(result.isAdminOverride).toBe(true);
   });
@@ -345,7 +347,7 @@ describe("Admin Submit", () => {
       metadataValidationStatus: "Passed",
       fileValidationStatus: "Passed",
     };
-    const result = utils.shouldEnableSubmit(submission, "Admin");
+    const result = utils.shouldEnableSubmit(submission, baseQCResults, "Admin");
     expect(result.enabled).toBe(true);
     expect(result.isAdminOverride).toBe(false);
   });
@@ -356,7 +358,7 @@ describe("Admin Submit", () => {
       metadataValidationStatus: "Passed",
       fileValidationStatus: null,
     };
-    const result = utils.shouldEnableSubmit(submission, "Admin");
+    const result = utils.shouldEnableSubmit(submission, baseQCResults, "Admin");
     expect(result.enabled).toBe(false);
     expect(result.isAdminOverride).toBe(false);
   });
@@ -367,7 +369,7 @@ describe("Admin Submit", () => {
       metadataValidationStatus: null,
       fileValidationStatus: null,
     };
-    const result = utils.shouldEnableSubmit(submission, "Admin");
+    const result = utils.shouldEnableSubmit(submission, baseQCResults, "Admin");
     expect(result.enabled).toBe(false);
   });
 
@@ -379,7 +381,7 @@ describe("Admin Submit", () => {
       fileValidationStatus: null,
       intention: "Delete",
     };
-    const result = utils.shouldEnableSubmit(submission, "Admin");
+    const result = utils.shouldEnableSubmit(submission, baseQCResults, "Admin");
     expect(result.enabled).toBe(true);
     expect(result.isAdminOverride).toBe(true);
   });
@@ -405,7 +407,7 @@ describe("Admin Submit", () => {
         },
       ],
     };
-    const result = utils.shouldEnableSubmit(submission, "Admin");
+    const result = utils.shouldEnableSubmit(submission, baseQCResults, "Admin");
     expect(result.enabled).toBe(false);
     expect(result.isAdminOverride).toBe(false);
   });
@@ -431,7 +433,11 @@ describe("Admin Submit", () => {
         },
       ],
     };
-    const result = utils.shouldEnableSubmit(submission, "Submitter");
+    const qcResults: Pick<QCResult, "errors">[] = [
+      { errors: [{ title: "Orphaned file found", description: "" }] },
+    ];
+    const result = utils.shouldEnableSubmit(submission, qcResults, "Submitter");
+    expect(result._identifier).toBe("Submission should not have orphaned files");
     expect(result.enabled).toBe(false);
     expect(result.isAdminOverride).toBe(false);
   });
@@ -444,7 +450,7 @@ describe("Admin Submit", () => {
       fileValidationStatus: null,
       intention: "Delete",
     };
-    const result = utils.shouldEnableSubmit(submission, "Admin");
+    const result = utils.shouldEnableSubmit(submission, baseQCResults, "Admin");
     expect(result.enabled).toBe(true);
     expect(result.isAdminOverride).toBe(true);
   });
@@ -456,7 +462,7 @@ describe("Admin Submit", () => {
       metadataValidationStatus: "Passed",
       fileValidationStatus: "New",
     };
-    const result = utils.shouldEnableSubmit(submission, "Admin");
+    const result = utils.shouldEnableSubmit(submission, baseQCResults, "Admin");
     expect(result.enabled).toBe(false);
     expect(result.isAdminOverride).toBe(false);
   });
@@ -470,7 +476,7 @@ describe("Submit > Submission Type/Intention", () => {
       metadataValidationStatus: "Error",
       fileValidationStatus: "Error",
     };
-    const result = utils.shouldEnableSubmit(submission, "Submitter");
+    const result = utils.shouldEnableSubmit(submission, baseQCResults, "Submitter");
     expect(result.enabled).toBe(false);
     expect(result.isAdminOverride).toBe(false);
   });
@@ -503,13 +509,13 @@ describe("shouldAllowAdminOverride", () => {
   });
 
   it("should disable submit without isAdminOverride when submission is null", () => {
-    const result = utils.shouldAllowAdminOverride(null);
+    const result = utils.shouldAllowAdminOverride(null, baseQCResults);
     expect(result.enabled).toBe(false);
     expect(result.isAdminOverride).toBe(false);
   });
 
   it("should disable submit without isAdminOverride when submission is undefined", () => {
-    const result = utils.shouldAllowAdminOverride(undefined);
+    const result = utils.shouldAllowAdminOverride(undefined, baseQCResults);
     expect(result.enabled).toBe(false);
     expect(result.isAdminOverride).toBe(false);
   });
@@ -521,7 +527,7 @@ describe("shouldAllowAdminOverride", () => {
       metadataValidationStatus: "Error",
       fileValidationStatus: null,
     };
-    const result = utils.shouldAllowAdminOverride(submission);
+    const result = utils.shouldAllowAdminOverride(submission, baseQCResults);
     expect(result._identifier).toBe("Admin Override - Submission has validation errors");
     expect(result.enabled).toBe(true);
     expect(result.isAdminOverride).toBe(true);
@@ -534,7 +540,7 @@ describe("shouldAllowAdminOverride", () => {
       metadataValidationStatus: "Passed",
       fileValidationStatus: null,
     };
-    const result = utils.shouldAllowAdminOverride(submission);
+    const result = utils.shouldAllowAdminOverride(submission, baseQCResults);
     expect(result._identifier).toBe(undefined);
     expect(result.enabled).toBe(false);
     expect(result.isAdminOverride).toBe(false);
@@ -547,7 +553,7 @@ describe("shouldAllowAdminOverride", () => {
       metadataValidationStatus: "Passed",
       fileValidationStatus: "Validating",
     };
-    const result = utils.shouldAllowAdminOverride(submission);
+    const result = utils.shouldAllowAdminOverride(submission, baseQCResults);
     expect(result._identifier).toBe("Validation should not currently be running");
     expect(result.enabled).toBe(false);
     expect(result.isAdminOverride).toBe(false);
@@ -563,7 +569,7 @@ describe("shouldAllowAdminOverride", () => {
       fileValidationStatus: "Passed",
     };
 
-    const result = utils.shouldAllowAdminOverride(submission);
+    const result = utils.shouldAllowAdminOverride(submission, baseQCResults);
     expect(result._identifier).toBe("test-identifier-1");
     expect(result.enabled).toBe(false);
     expect(result.isAdminOverride).toBe(false);


### PR DESCRIPTION
### Overview

The BE moved the Orphaned Files error from `Submission.fileErrors` to within the QC Results API. Updated submit button config to accept QC Results as a param when checking logic to avoid submitting and admin submit when there's orphaned files.

### Change Details (Specifics)

- Added calling QC Results API in parallel to getSubmission API within SubmissionContext, including while polling
- Added the QC Results to the Submit button config to use for determining whether or not to enable the Submit button
- Updated the Orphaned Files logic to use QC Results instead of `Submission.fileErrors`

### Related Ticket(s)

[CRDCDH-1674](https://tracker.nci.nih.gov/browse/CRDCDH-1674) (Bug)

