### PR TITLE
CRDCDH-2138 Disable "Delete Node Data" button after submit

### DIFF
--- a/src/components/DataSubmissions/DeleteNodeDataButton.test.tsx
+++ b/src/components/DataSubmissions/DeleteNodeDataButton.test.tsx
@@ -743,4 +743,26 @@ describe("Implementation Requirements", () => {
       expect(queryByTestId("delete-node-data-button")).not.toBeInTheDocument();
     }
   );
+
+  it.each<SubmissionStatus>(["New", "In Progress", "Rejected", "Withdrawn"])(
+    "should (implicitly) be enabled for the Submission Status %s",
+    (status) => {
+      const { getByTestId } = render(<Button nodeType="test" selectedItems={["item-1"]} />, {
+        wrapper: (props) => <TestParent {...props} submission={{ status }} />,
+      });
+
+      expect(getByTestId("delete-node-data-button")).toBeEnabled();
+    }
+  );
+
+  it.each<SubmissionStatus>(["Submitted", "Released", "Completed", "Canceled", "Deleted"])(
+    "should be disabled for the Submission Status %s",
+    (status) => {
+      const { getByTestId } = render(<Button nodeType="test" selectedItems={["item-1"]} />, {
+        wrapper: (props) => <TestParent {...props} submission={{ status }} />,
+      });
+
+      expect(getByTestId("delete-node-data-button")).toBeDisabled();
+    }
+  );
 });

--- a/src/components/DataSubmissions/DeleteNodeDataButton.tsx
+++ b/src/components/DataSubmissions/DeleteNodeDataButton.tsx
@@ -22,6 +22,17 @@ const StyledTooltip = styled(StyledFormTooltip)({
   },
 });
 
+/**
+ * An array of submission statuses that should disable the delete button
+ */
+const DisabledStatuses: SubmissionStatus[] = [
+  "Submitted",
+  "Released",
+  "Completed",
+  "Canceled",
+  "Deleted",
+];
+
 type Props = {
   /**
    * The name of the node type currently selected
@@ -41,7 +52,7 @@ const DeleteNodeDataButton = ({ nodeType, selectedItems, disabled, onDelete, ...
   const { enqueueSnackbar } = useSnackbar();
   const { data } = useSubmissionContext();
   const { user } = useAuthContext();
-  const { _id, deletingData } = data?.getSubmission || {};
+  const { _id, status, deletingData } = data?.getSubmission || {};
 
   const collaborator = data?.getSubmission?.collaborators?.find(
     (c) => c.collaboratorID === user?._id
@@ -146,6 +157,7 @@ const DeleteNodeDataButton = ({ nodeType, selectedItems, disabled, onDelete, ...
               disabled ||
               deletingData === true ||
               selectedItems.length === 0 ||
+              DisabledStatuses.includes(status) ||
               (collaborator && collaborator.permission !== "Can Edit")
             }
             aria-label="Delete nodes icon"


### PR DESCRIPTION
### Overview

This PR updates the Delete Node Data button (Data View) to disable it in certain submission states. Per KC:

- Submitted
- Released
- Completed
- Canceled
- Deleted (I added this)

> [!NOTE]
> This bug also needs to go to the backend team so they can update the API.

### Change Details (Specifics)

N/A

### Related Ticket(s)

CRDCDH-2138
