### PR TITLE
HOTFIX: Create a Data Submission List View Error

### DIFF
--- a/src/content/dataSubmissions/DataSubmissionsListView.tsx
+++ b/src/content/dataSubmissions/DataSubmissionsListView.tsx
@@ -302,7 +302,7 @@ const ListingView: FC = () => {
       setOrganizations(
         d.listSubmissions.organizations
           ?.filter((org) => !!org?.name?.trim())
-          ?.sort((a, b) => a.name?.localeCompare(b.name))
+          ?.sort((a, b) => a.name?.localeCompare(b?.name))
       );
       setSubmitterNames(d.listSubmissions.submitterNames?.filter((sn) => !!sn.trim()));
       setDataCommons(d.listSubmissions.dataCommons?.filter((dc) => !!dc.trim()));
@@ -330,13 +330,14 @@ const ListingView: FC = () => {
       setData(d.listSubmissions.submissions);
       setOrganizations(
         d.listSubmissions.organizations
-          ?.filter((org) => !!org.name.trim())
-          ?.sort((a, b) => a.name?.localeCompare(b.name))
+          ?.filter((org) => !!org?.name?.trim())
+          ?.sort((a, b) => a.name?.localeCompare(b?.name))
       );
       setSubmitterNames(d.listSubmissions.submitterNames?.filter((sn) => !!sn.trim()));
       setDataCommons(d.listSubmissions.dataCommons?.filter((dc) => !!dc.trim()));
       setTotalData(d.listSubmissions.total);
     } catch (err) {
+      Logger.error("Error updating the Data Submission list", err);
       setError(true);
     } finally {
       setLoading(false);


### PR DESCRIPTION
### Overview

This is a minor fix for the generic error `"An error occurred while loading the data."` that appears when creating data submissions using a study that isn't associated with any organization (program).

It can't be replicated all the time, but it seems to do it with the study `1901-2`

### Change Details (Specifics)

- Add null-safe chaining when sorting the Program List for the dropdown filter
- Add the logging util to the try-catch

### Related Ticket(s)

N/A
