### PR TITLE
fix: CLI Tool should not be bound by `data_submission:create`

### DIFF
--- a/src/components/Header/components/HeaderTabletAndMobile.tsx
+++ b/src/components/Header/components/HeaderTabletAndMobile.tsx
@@ -154,6 +154,19 @@ const Header = () => {
       className: "navMobileSubItem",
     },
     {
+      name: "Uploader CLI Tool",
+      onClick: () => setUploaderToolOpen(true),
+      id: "navbar-dropdown-item-uploader-tool",
+      className: "navMobileSubItem action",
+    },
+    {
+      name: "API Token",
+      onClick: () => setOpenAPITokenDialog(true),
+      id: "navbar-dropdown-item-api-token",
+      className: "navMobileSubItem action",
+      permissions: ["data_submission:create"],
+    },
+    {
       name: "Manage Studies",
       link: "/studies",
       id: "navbar-dropdown-item-studies-manage",
@@ -173,20 +186,6 @@ const Header = () => {
       id: "navbar-dropdown-item-user-manage",
       className: "navMobileSubItem",
       permissions: ["user:manage"],
-    },
-    {
-      name: "Uploader CLI Tool",
-      onClick: () => setUploaderToolOpen(true),
-      id: "navbar-dropdown-item-uploader-tool",
-      className: "navMobileSubItem action",
-      permissions: ["data_submission:create"],
-    },
-    {
-      name: "API Token",
-      onClick: () => setOpenAPITokenDialog(true),
-      id: "navbar-dropdown-item-api-token",
-      className: "navMobileSubItem action",
-      permissions: ["data_submission:create"],
     },
     {
       name: "Logout",

--- a/src/components/Header/components/NavbarDesktop.tsx
+++ b/src/components/Header/components/NavbarDesktop.tsx
@@ -312,6 +312,19 @@ const NavBar = () => {
       className: "navMobileSubItem",
     },
     {
+      name: "Uploader CLI Tool",
+      onClick: () => setUploaderToolOpen(true),
+      id: "navbar-dropdown-item-uploader-tool",
+      className: "navMobileSubItem action",
+    },
+    {
+      name: "API Token",
+      onClick: () => setOpenAPITokenDialog(true),
+      id: "navbar-dropdown-item-api-token",
+      className: "navMobileSubItem action",
+      permissions: ["data_submission:create"],
+    },
+    {
       name: "Manage Studies",
       link: "/studies",
       id: "navbar-dropdown-item-studies-manage",
@@ -331,20 +344,6 @@ const NavBar = () => {
       id: "navbar-dropdown-item-user-manage",
       className: "navMobileSubItem",
       permissions: ["user:manage"],
-    },
-    {
-      name: "Uploader CLI Tool",
-      onClick: () => setUploaderToolOpen(true),
-      id: "navbar-dropdown-item-uploader-tool",
-      className: "navMobileSubItem action",
-      permissions: ["data_submission:create"],
-    },
-    {
-      name: "API Token",
-      onClick: () => setOpenAPITokenDialog(true),
-      id: "navbar-dropdown-item-api-token",
-      className: "navMobileSubItem action",
-      permissions: ["data_submission:create"],
     },
     {
       name: "Logout",


### PR DESCRIPTION
### Overview

PR to restore the original visibility of the Uploader CLI Tool, which should always be visible and not hidden based on PBAC. Also, moves the CLI Tool to right after User Profile.

### Change Details (Specifics)

N/A

### Related Ticket(s)

N/A – PBAC Stories
