### PR TITLE
CRDCDH-2212 Restrict Data Submission 'create' permission scope for specific roles

### DIFF
--- a/src/config/AuthPermissions.test.ts
+++ b/src/config/AuthPermissions.test.ts
@@ -226,16 +226,42 @@ describe("data_submission:create Permission", () => {
     expect(hasPermission(user, "data_submission", "create", createSubmission)).toBe(true);
   });
 
-  it("should allow a 'Federal Lead' with 'data_submission:create' key if they have the matching study", () => {
+  it("should allow a 'Federal Lead' who is the submission owner WITH 'data_submission:create' key if they have the matching study", () => {
     const user = createUser("Federal Lead", ["data_submission:create"]);
+    user._id = "owner-123";
     user.studies = [{ _id: "study-1" }];
     expect(hasPermission(user, "data_submission", "create", createSubmission)).toBe(true);
   });
 
-  it("should allow 'Data Commons Personnel' with 'data_submission:create' key if they have the matching dataCommons", () => {
+  it("should deny a 'Federal Lead' who is the submission owner WITH 'data_submission:create' key without a matching study", () => {
+    const user = createUser("Federal Lead", ["data_submission:create"]);
+    user._id = "owner-123";
+    expect(hasPermission(user, "data_submission", "create", createSubmission)).toBe(false);
+  });
+
+  it("should deny a 'Federal Lead' who is NOT the submission owner WITH 'data_submission:create' and matching study", () => {
+    const user = createUser("Federal Lead", ["data_submission:create"]);
+    user.studies = [{ _id: "study-1" }];
+    expect(hasPermission(user, "data_submission", "create", createSubmission)).toBe(false);
+  });
+
+  it("should allow a 'Data Commons Personnel' who is the submission owner WITH 'data_submission:create' key", () => {
     const user = createUser("Data Commons Personnel", ["data_submission:create"]);
+    user._id = "owner-123";
     user.dataCommons = ["commons-1"];
     expect(hasPermission(user, "data_submission", "create", createSubmission)).toBe(true);
+  });
+
+  it("should deny a 'Data Commons Personnel' who is the submission owner WITH 'data_submission:create' key without matching dataCommons", () => {
+    const user = createUser("Data Commons Personnel", ["data_submission:create"]);
+    user._id = "owner-123";
+    expect(hasPermission(user, "data_submission", "create", createSubmission)).toBe(false);
+  });
+
+  it("should deny a 'Data Commons Personnel' who is NOT the submission owner WITH 'data_submission:create' key and matching dataCommons", () => {
+    const user = createUser("Data Commons Personnel", ["data_submission:create"]);
+    user.dataCommons = ["commons-1"];
+    expect(hasPermission(user, "data_submission", "create", createSubmission)).toBe(false);
   });
 
   it("should allow 'Admin' with 'data_submission:create' key", () => {

--- a/src/config/AuthPermissions.test.ts
+++ b/src/config/AuthPermissions.test.ts
@@ -226,53 +226,21 @@ describe("data_submission:create Permission", () => {
     expect(hasPermission(user, "data_submission", "create", createSubmission)).toBe(true);
   });
 
-  it("should allow a 'Federal Lead' who is the submission owner WITH 'data_submission:create' key if they have the matching study", () => {
+  it("should allow a 'Federal Lead' who is the submission owner WITH 'data_submission:create' key", () => {
     const user = createUser("Federal Lead", ["data_submission:create"]);
     user._id = "owner-123";
-    user.studies = [{ _id: "study-1" }];
     expect(hasPermission(user, "data_submission", "create", createSubmission)).toBe(true);
-  });
-
-  it("should allow a 'Federal Lead' who is the submission owner WITH 'data_submission:create' key if they have the 'All' study", () => {
-    const user = createUser("Federal Lead", ["data_submission:create"]);
-    user._id = "owner-123";
-    user.studies = [{ _id: "All" }];
-    expect(hasPermission(user, "data_submission", "create", createSubmission)).toBe(true);
-  });
-
-  it("should deny a 'Federal Lead' who is the submission owner WITH 'data_submission:create' key without a matching study", () => {
-    const user = createUser("Federal Lead", ["data_submission:create"]);
-    user._id = "owner-123";
-    expect(hasPermission(user, "data_submission", "create", createSubmission)).toBe(false);
-  });
-
-  it("should deny a 'Federal Lead' who is NOT the submission owner WITH 'data_submission:create' and matching study", () => {
-    const user = createUser("Federal Lead", ["data_submission:create"]);
-    user.studies = [{ _id: "study-1" }];
-    expect(hasPermission(user, "data_submission", "create", createSubmission)).toBe(false);
   });
 
   it("should allow a 'Data Commons Personnel' who is the submission owner WITH 'data_submission:create' key", () => {
     const user = createUser("Data Commons Personnel", ["data_submission:create"]);
     user._id = "owner-123";
-    user.dataCommons = ["commons-1"];
     expect(hasPermission(user, "data_submission", "create", createSubmission)).toBe(true);
   });
 
-  it("should deny a 'Data Commons Personnel' who is the submission owner WITH 'data_submission:create' key without matching dataCommons", () => {
-    const user = createUser("Data Commons Personnel", ["data_submission:create"]);
-    user._id = "owner-123";
-    expect(hasPermission(user, "data_submission", "create", createSubmission)).toBe(false);
-  });
-
-  it("should deny a 'Data Commons Personnel' who is NOT the submission owner WITH 'data_submission:create' key and matching dataCommons", () => {
-    const user = createUser("Data Commons Personnel", ["data_submission:create"]);
-    user.dataCommons = ["commons-1"];
-    expect(hasPermission(user, "data_submission", "create", createSubmission)).toBe(false);
-  });
-
-  it("should allow 'Admin' with 'data_submission:create' key", () => {
+  it("should allow 'Admin' who is the submission owner WITH 'data_submission:create' key", () => {
     const user = createUser("Admin", ["data_submission:create"]);
+    user._id = "owner-123";
     expect(hasPermission(user, "data_submission", "create", createSubmission)).toBe(true);
   });
 

--- a/src/config/AuthPermissions.test.ts
+++ b/src/config/AuthPermissions.test.ts
@@ -233,6 +233,13 @@ describe("data_submission:create Permission", () => {
     expect(hasPermission(user, "data_submission", "create", createSubmission)).toBe(true);
   });
 
+  it("should allow a 'Federal Lead' who is the submission owner WITH 'data_submission:create' key if they have the 'All' study", () => {
+    const user = createUser("Federal Lead", ["data_submission:create"]);
+    user._id = "owner-123";
+    user.studies = [{ _id: "All" }];
+    expect(hasPermission(user, "data_submission", "create", createSubmission)).toBe(true);
+  });
+
   it("should deny a 'Federal Lead' who is the submission owner WITH 'data_submission:create' key without a matching study", () => {
     const user = createUser("Federal Lead", ["data_submission:create"]);
     user._id = "owner-123";
@@ -295,6 +302,12 @@ describe("data_submission:review Permission", () => {
     expect(hasPermission(user, "data_submission", "review", reviewSubmission)).toBe(true);
   });
 
+  it("should allow a 'Federal Lead' with 'data_submission:review' key if they have the 'All' study", () => {
+    const user = createUser("Federal Lead", ["data_submission:review"]);
+    user.studies = [{ _id: "All" }];
+    expect(hasPermission(user, "data_submission", "review", reviewSubmission)).toBe(true);
+  });
+
   it("should allow 'Data Commons Personnel' with 'data_submission:review' key if they have the matching dataCommons", () => {
     const user = createUser("Data Commons Personnel", ["data_submission:review"]);
     user.dataCommons = ["commons-3"];
@@ -329,6 +342,14 @@ describe("data_submission:admin_submit Permission", () => {
   it("should allow a 'Federal Lead' with 'data_submission:admin_submit' key if they have the matching study", () => {
     const user = createUser("Federal Lead", ["data_submission:admin_submit"]);
     user.studies = [{ _id: "study-4" }];
+    expect(hasPermission(user, "data_submission", "admin_submit", adminSubmitSubmission)).toBe(
+      true
+    );
+  });
+
+  it("should allow a 'Federal Lead' with 'data_submission:admin_submit' key if they have the 'All' study", () => {
+    const user = createUser("Federal Lead", ["data_submission:admin_submit"]);
+    user.studies = [{ _id: "All" }];
     expect(hasPermission(user, "data_submission", "admin_submit", adminSubmitSubmission)).toBe(
       true
     );
@@ -374,6 +395,12 @@ describe("data_submission:confirm Permission", () => {
   it("should allow a 'Federal Lead' with 'data_submission:confirm' key if they have the matching study", () => {
     const user = createUser("Federal Lead", ["data_submission:confirm"]);
     user.studies = [{ _id: "study-5" }];
+    expect(hasPermission(user, "data_submission", "confirm", confirmSubmission)).toBe(true);
+  });
+
+  it("should allow a 'Federal Lead' with 'data_submission:confirm' key if they have the 'All' study", () => {
+    const user = createUser("Federal Lead", ["data_submission:confirm"]);
+    user.studies = [{ _id: "All" }];
     expect(hasPermission(user, "data_submission", "confirm", confirmSubmission)).toBe(true);
   });
 

--- a/src/config/AuthPermissions.ts
+++ b/src/config/AuthPermissions.ts
@@ -81,10 +81,10 @@ export const PERMISSION_MAP = {
       if (role === "Submitter" && isSubmissionOwner && hasPermissionKey) {
         return true;
       }
-      if (role === "Federal Lead" && hasPermissionKey) {
+      if (role === "Federal Lead" && isSubmissionOwner && hasPermissionKey) {
         return studies?.some((s) => s._id === submission.studyID);
       }
-      if (role === "Data Commons Personnel" && hasPermissionKey) {
+      if (role === "Data Commons Personnel" && isSubmissionOwner && hasPermissionKey) {
         return dataCommons?.some((dc) => dc === submission?.dataCommons);
       }
       if (role === "Admin" && hasPermissionKey) {

--- a/src/config/AuthPermissions.ts
+++ b/src/config/AuthPermissions.ts
@@ -82,7 +82,7 @@ export const PERMISSION_MAP = {
         return true;
       }
       if (role === "Federal Lead" && isSubmissionOwner && hasPermissionKey) {
-        return studies?.some((s) => s._id === submission.studyID);
+        return studies?.some((s) => s._id === submission.studyID || s._id === "All");
       }
       if (role === "Data Commons Personnel" && isSubmissionOwner && hasPermissionKey) {
         return dataCommons?.some((dc) => dc === submission?.dataCommons);
@@ -98,7 +98,7 @@ export const PERMISSION_MAP = {
       const hasPermissionKey = user?.permissions?.includes("data_submission:review");
 
       if (role === "Federal Lead" && hasPermissionKey) {
-        return studies?.some((s) => s._id === submission.studyID);
+        return studies?.some((s) => s._id === submission.studyID || s._id === "All");
       }
       if (role === "Data Commons Personnel" && hasPermissionKey) {
         return dataCommons?.some((dc) => dc === submission?.dataCommons);
@@ -114,7 +114,7 @@ export const PERMISSION_MAP = {
       const hasPermissionKey = user?.permissions?.includes("data_submission:admin_submit");
 
       if (role === "Federal Lead" && hasPermissionKey) {
-        return studies?.some((s) => s._id === submission.studyID);
+        return studies?.some((s) => s._id === submission.studyID || s._id === "All");
       }
       if (role === "Data Commons Personnel" && hasPermissionKey) {
         return dataCommons?.some((dc) => dc === submission?.dataCommons);
@@ -130,7 +130,7 @@ export const PERMISSION_MAP = {
       const hasPermissionKey = user?.permissions?.includes("data_submission:confirm");
 
       if (role === "Federal Lead" && hasPermissionKey) {
-        return studies?.some((s) => s._id === submission.studyID);
+        return studies?.some((s) => s._id === submission.studyID || s._id === "All");
       }
       if (role === "Data Commons Personnel" && hasPermissionKey) {
         return dataCommons?.some((dc) => dc === submission?.dataCommons);

--- a/src/config/AuthPermissions.ts
+++ b/src/config/AuthPermissions.ts
@@ -68,7 +68,6 @@ export const PERMISSION_MAP = {
   data_submission: {
     view: NO_CONDITIONS,
     create: (user, submission) => {
-      const { role, dataCommons, studies } = user;
       const hasPermissionKey = user?.permissions?.includes("data_submission:create");
       const isSubmissionOwner = submission?.submitterID === user?._id;
       const isCollaborator = submission?.collaborators?.some((c) => c.collaboratorID === user?._id);
@@ -76,18 +75,7 @@ export const PERMISSION_MAP = {
       if (isCollaborator) {
         return true;
       }
-      // Submitters from the same study are able to view the same submissions
-      // Therefore, they must be the submission owner or collaborator with permission key
-      if (role === "Submitter" && isSubmissionOwner && hasPermissionKey) {
-        return true;
-      }
-      if (role === "Federal Lead" && isSubmissionOwner && hasPermissionKey) {
-        return studies?.some((s) => s._id === submission.studyID || s._id === "All");
-      }
-      if (role === "Data Commons Personnel" && isSubmissionOwner && hasPermissionKey) {
-        return dataCommons?.some((dc) => dc === submission?.dataCommons);
-      }
-      if (role === "Admin" && hasPermissionKey) {
+      if (isSubmissionOwner && hasPermissionKey) {
         return true;
       }
 


### PR DESCRIPTION
### Overview

The Data Submission create permission for 'Federal Lead' and 'Data Commons Personnel' roles were updated to restrict it to only applying to their own Data Submission.

### Change Details (Specifics)

- Updated 'Federal Lead' role Data Submission create permission to only be allowed to apply to their own Data Submissions
- Updated 'Data Commons Personnel' role Data Submission create permission to only be allowed to apply to their own Data Submissions
- Updated all Data Submission permissions to accept "All" study for Federal Leads as a valid study

### Related Ticket(s)

[CRDCDH-2212](https://tracker.nci.nih.gov/browse/CRDCDH-2212) (Task)
[CRDCDH-2023](https://tracker.nci.nih.gov/browse/CRDCDH-2023) (US 1)
[CRDCDH-1886](https://tracker.nci.nih.gov/browse/CRDCDH-1886) (US 2)
[CRDCDH-1887](https://tracker.nci.nih.gov/browse/CRDCDH-1887) (US 3)
