### PR TITLE
CRDCDH-2184 Fix missing `required` asterisks

### DIFF
--- a/src/components/StyledFormComponents/StyledAsterisk.tsx
+++ b/src/components/StyledFormComponents/StyledAsterisk.tsx
@@ -1,6 +1,7 @@
+import { forwardRef } from "react";
 import { styled } from "@mui/material";
 
-const Asterisk = styled("span")(() => ({
+const StyledAsterisk = styled("span")(() => ({
   color: "#C93F08",
   marginLeft: "2px",
   fontWeight: 700,
@@ -9,6 +10,12 @@ const Asterisk = styled("span")(() => ({
   lineHeight: "18.8px",
 }));
 
-const StyledAsterisk = () => <Asterisk>*</Asterisk>;
+const Asterisk = forwardRef<HTMLSpanElement, React.HTMLAttributes<HTMLSpanElement>>(
+  (props, ref) => (
+    <StyledAsterisk ref={ref} {...props}>
+      *
+    </StyledAsterisk>
+  )
+);
 
-export default StyledAsterisk;
+export default Asterisk;

--- a/src/content/users/ProfileView.tsx
+++ b/src/content/users/ProfileView.tsx
@@ -37,6 +37,7 @@ import { useSearchParamsContext } from "../../components/Contexts/SearchParamsCo
 import BaseSelect from "../../components/StyledFormComponents/StyledSelect";
 import BaseOutlinedInput from "../../components/StyledFormComponents/StyledOutlinedInput";
 import BaseAutocomplete from "../../components/StyledFormComponents/StyledAutocomplete";
+import BaseAsterisk from "../../components/StyledFormComponents/StyledAsterisk";
 import useProfileFields, { VisibleFieldState } from "../../hooks/useProfileFields";
 import AccessRequest from "../../components/AccessRequest";
 import PermissionPanel from "../../components/PermissionPanel";
@@ -113,8 +114,8 @@ const StyledField = styled("div", { shouldForwardProp: (p) => p !== "visible" })
 const StyledLabel = styled("span")({
   color: "#356AAD",
   fontWeight: "700",
-  marginRight: "40px",
-  minWidth: "127px",
+  marginRight: "30px",
+  minWidth: "137px",
 });
 
 const BaseInputStyling = {
@@ -150,6 +151,12 @@ const StyledTag = styled("div")({
   position: "absolute",
   paddingLeft: "12px",
 });
+
+const StyledAsterisk = styled(BaseAsterisk, { shouldForwardProp: (p) => p !== "visible" })<{
+  visible?: boolean;
+}>(({ visible = true }) => ({
+  display: visible ? undefined : "none",
+}));
 
 /**
  * User Profile View Component
@@ -395,7 +402,6 @@ const ProfileView: FC<Props> = ({ _id, viewType }: Props) => {
           <StyledProfileIcon>
             <img src={profileIcon} alt="profile icon" />
           </StyledProfileIcon>
-
           <StyledContentStack
             direction="column"
             justifyContent="center"
@@ -421,7 +427,10 @@ const ProfileView: FC<Props> = ({ _id, viewType }: Props) => {
                   {user.email}
                 </StyledField>
                 <StyledField>
-                  <StyledLabel id="firstNameLabel">First name</StyledLabel>
+                  <StyledLabel id="firstNameLabel">
+                    First name
+                    <StyledAsterisk visible={VisibleFieldState.includes(fieldset.firstName)} />
+                  </StyledLabel>
                   {VisibleFieldState.includes(fieldset.firstName) ? (
                     <StyledTextField
                       {...register("firstName", {
@@ -438,7 +447,10 @@ const ProfileView: FC<Props> = ({ _id, viewType }: Props) => {
                   )}
                 </StyledField>
                 <StyledField>
-                  <StyledLabel id="lastNameLabel">Last name</StyledLabel>
+                  <StyledLabel id="lastNameLabel">
+                    Last name
+                    <StyledAsterisk visible={VisibleFieldState.includes(fieldset.lastName)} />
+                  </StyledLabel>
                   {VisibleFieldState.includes(fieldset.lastName) ? (
                     <StyledTextField
                       {...register("lastName", {
@@ -455,7 +467,10 @@ const ProfileView: FC<Props> = ({ _id, viewType }: Props) => {
                   )}
                 </StyledField>
                 <StyledField>
-                  <StyledLabel id="userRoleLabel">Role</StyledLabel>
+                  <StyledLabel id="userRoleLabel">
+                    Role
+                    <StyledAsterisk visible={VisibleFieldState.includes(fieldset.role)} />
+                  </StyledLabel>
                   {VisibleFieldState.includes(fieldset.role) ? (
                     <Controller
                       name="role"
@@ -485,7 +500,10 @@ const ProfileView: FC<Props> = ({ _id, viewType }: Props) => {
                   )}
                 </StyledField>
                 <StyledField visible={fieldset.studies !== "HIDDEN"}>
-                  <StyledLabel id="userStudies">Studies</StyledLabel>
+                  <StyledLabel id="userStudies">
+                    Studies
+                    <StyledAsterisk visible={VisibleFieldState.includes(fieldset.studies)} />
+                  </StyledLabel>
                   {VisibleFieldState.includes(fieldset.studies) ? (
                     <Controller
                       name="studies"
@@ -526,7 +544,10 @@ const ProfileView: FC<Props> = ({ _id, viewType }: Props) => {
                   ) : null}
                 </StyledField>
                 <StyledField>
-                  <StyledLabel id="userStatusLabel">Account Status</StyledLabel>
+                  <StyledLabel id="userStatusLabel">
+                    Account Status
+                    <StyledAsterisk visible={VisibleFieldState.includes(fieldset.userStatus)} />
+                  </StyledLabel>
                   {VisibleFieldState.includes(fieldset.userStatus) ? (
                     <Controller
                       name="userStatus"
@@ -549,7 +570,10 @@ const ProfileView: FC<Props> = ({ _id, viewType }: Props) => {
                   )}
                 </StyledField>
                 <StyledField visible={fieldset.dataCommons !== "HIDDEN"}>
-                  <StyledLabel id="userDataCommons">Data Commons</StyledLabel>
+                  <StyledLabel id="userDataCommons">
+                    Data Commons
+                    <StyledAsterisk visible={VisibleFieldState.includes(fieldset.dataCommons)} />
+                  </StyledLabel>
                   {VisibleFieldState.includes(fieldset.dataCommons) ? (
                     <Controller
                       name="dataCommons"

--- a/src/content/users/ProfileView.tsx
+++ b/src/content/users/ProfileView.tsx
@@ -30,7 +30,7 @@ import {
   UpdateMyUserInput,
   UpdateMyUserResp,
 } from "../../graphql";
-import { formatFullStudyName, formatIDP, formatStudySelectionValue } from "../../utils";
+import { formatFullStudyName, formatIDP, formatStudySelectionValue, Logger } from "../../utils";
 import { DataCommons } from "../../config/DataCommons";
 import usePageTitle from "../../hooks/usePageTitle";
 import { useSearchParamsContext } from "../../components/Contexts/SearchParamsContext";
@@ -258,7 +258,8 @@ const ProfileView: FC<Props> = ({ _id, viewType }: Props) => {
       setSaving(false);
 
       if (errors || !d?.updateMyUser) {
-        enqueueSnackbar(errors || "Unable to save profile changes", { variant: "error" });
+        Logger.error("ProfileView: Error from API", errors);
+        enqueueSnackbar("Unable to save profile changes", { variant: "error" });
         return;
       }
 
@@ -279,7 +280,8 @@ const ProfileView: FC<Props> = ({ _id, viewType }: Props) => {
       setSaving(false);
 
       if (errors || !d?.editUser) {
-        enqueueSnackbar(errors || "Unable to save user profile changes", { variant: "error" });
+        Logger.error("ProfileView: Error from API", errors);
+        enqueueSnackbar("Unable to save user profile changes", { variant: "error" });
         return;
       }
 

--- a/src/content/users/ProfileView.tsx
+++ b/src/content/users/ProfileView.tsx
@@ -518,7 +518,11 @@ const ProfileView: FC<Props> = ({ _id, viewType }: Props) => {
                             <TextField
                               {...params}
                               placeholder={studiesField?.length > 0 ? undefined : "Select studies"}
-                              inputProps={{ "aria-labelledby": "userStudies", ...inputProps }}
+                              inputProps={{
+                                "aria-labelledby": "userStudies",
+                                required: studiesField.length === 0,
+                                ...inputProps,
+                              }}
                               onBlur={sortStudyOptions}
                             />
                           )}
@@ -589,6 +593,7 @@ const ProfileView: FC<Props> = ({ _id, viewType }: Props) => {
                           disabled={fieldset.dataCommons === "DISABLED"}
                           MenuProps={{ disablePortal: true }}
                           inputProps={{ "aria-labelledby": "userDataCommons" }}
+                          required
                           multiple
                         >
                           {DataCommons.map((dc) => (


### PR DESCRIPTION
### Overview

PR to update the ProfileView to ensure asterisks are shown near required fields, and HTML5 validation errors are visible.

> [!NOTE]
> The tests are failing due to the base branch, but everything works locally.

### Change Details (Specifics)

- Fix the studies and data commons field missing the HTML5 required attribute
- Update the StyledAsterisk (form components) to forward the ref so we can add additional styling to the component
- Update all ProfileView fields to conditionally render the asterisk if applicable
  - Users editing their own profile see FN and LN as required
  - Others with User Management permissions see Role/Studies/etc as required
- Remove forwarding of the API error to the snackbar, as it contains very non-user-friendly details

### Related Ticket(s)

CRDCDH-2184
