### PR TITLE
fix: Sort the order of AuthRoles per the US

### DIFF
--- a/src/config/AuthRoles.ts
+++ b/src/config/AuthRoles.ts
@@ -1,14 +1,15 @@
 /**
  * Defines a list of valid user roles that can be assigned to a user.
  *
+ * @note This list is rendered in the UI exactly as ordered here, without additional sorting.
  * @see {@link UserRole}
  */
 export const Roles: UserRole[] = [
   "User",
   "Submitter",
+  "Data Commons Personnel",
   "Federal Lead",
   "Admin",
-  "Data Commons Personnel",
 ];
 
 /**


### PR DESCRIPTION
### Overview

Sort the User Roles array to reflect the order described in the User Story. 

### Change Details (Specifics)

N/A

### Related Ticket(s)

N/A
