### PR TITLE
CRDCDH-2188 Submission Request Status Tooltips

### DIFF
--- a/src/components/Questionnaire/ApproveFormDialog.tsx
+++ b/src/components/Questionnaire/ApproveFormDialog.tsx
@@ -75,10 +75,10 @@ const ApproveFormDialog: FC<Props> = ({
         onChange={handleCommentChange}
         maxLength={500}
         placeholder="500 characters allowed"
+        minRows={4}
         required
-        minRows={2}
-        maxRows={2}
         multiline
+        resize
         sx={{ paddingY: "16px" }}
       />
     </StyledDialog>

--- a/src/components/Questionnaire/ApproveFormDialog.tsx
+++ b/src/components/Questionnaire/ApproveFormDialog.tsx
@@ -75,7 +75,8 @@ const ApproveFormDialog: FC<Props> = ({
         onChange={handleCommentChange}
         maxLength={500}
         placeholder="500 characters allowed"
-        minRows={4}
+        minRows={5}
+        maxRows={10}
         required
         multiline
         resize

--- a/src/components/Questionnaire/InquireFormDialog.tsx
+++ b/src/components/Questionnaire/InquireFormDialog.tsx
@@ -75,10 +75,10 @@ const InquireFormDialog: FC<Props> = ({
         onChange={handleCommentChange}
         maxLength={500}
         placeholder="500 characters allowed"
+        minRows={4}
         required
-        minRows={2}
-        maxRows={2}
         multiline
+        resize
         sx={{ paddingY: "16px" }}
       />
     </StyledDialog>

--- a/src/components/Questionnaire/InquireFormDialog.tsx
+++ b/src/components/Questionnaire/InquireFormDialog.tsx
@@ -75,7 +75,8 @@ const InquireFormDialog: FC<Props> = ({
         onChange={handleCommentChange}
         maxLength={500}
         placeholder="500 characters allowed"
-        minRows={4}
+        minRows={5}
+        maxRows={10}
         required
         multiline
         resize

--- a/src/components/Questionnaire/RejectFormDialog.tsx
+++ b/src/components/Questionnaire/RejectFormDialog.tsx
@@ -75,7 +75,8 @@ const RejectFormDialog: FC<Props> = ({
         onChange={handleCommentChange}
         maxLength={500}
         placeholder="500 characters allowed"
-        minRows={4}
+        minRows={5}
+        maxRows={10}
         required
         multiline
         resize

--- a/src/components/Questionnaire/RejectFormDialog.tsx
+++ b/src/components/Questionnaire/RejectFormDialog.tsx
@@ -75,10 +75,10 @@ const RejectFormDialog: FC<Props> = ({
         onChange={handleCommentChange}
         maxLength={500}
         placeholder="500 characters allowed"
+        minRows={4}
         required
-        minRows={2}
-        maxRows={2}
         multiline
+        resize
         sx={{ paddingY: "16px" }}
       />
     </StyledDialog>

--- a/src/components/StatusBar/StatusBar.test.tsx
+++ b/src/components/StatusBar/StatusBar.test.tsx
@@ -2,6 +2,7 @@ import { FC, useMemo } from "react";
 import { BrowserRouter } from "react-router-dom";
 import { fireEvent, render, waitFor, within } from "@testing-library/react";
 import { axe } from "jest-axe";
+import userEvent from "@testing-library/user-event";
 import { ContextState, Context as FormCtx, Status as FormStatus } from "../Contexts/FormContext";
 import StatusBar from "./StatusBar";
 import StatusApproved from "../../assets/history/submissionRequest/StatusApproved.svg";
@@ -435,4 +436,73 @@ describe("StatusBar > History Modal Tests", () => {
 
     await waitFor(() => expect(queryByTestId("status-bar-history-dialog")).toBeNull());
   });
+
+  it("should render a icon when there are pending conditions and the status is 'Approved'", async () => {
+    const data = {
+      history: [
+        { dateTime: "2009-11-24T01:25:45Z", status: "Approved" },
+        { dateTime: "2009-11-24T01:10:45Z", status: "In Progress" },
+      ],
+      pendingConditions: ["condition xyz please resolve it"],
+      conditional: true,
+    };
+
+    const { getByTestId, getByText, getByRole } = render(<BaseComponent data={data} />);
+
+    userEvent.click(getByText("Full History"));
+
+    const approvedItem = getByTestId("history-item-0");
+    expect(within(approvedItem).getByTestId("history-item-0-status")).toHaveTextContent(
+      /Approved/i
+    ); // sanity check
+    expect(within(approvedItem).getByTestId("status-bar-pending-conditions")).toBeVisible();
+
+    userEvent.hover(within(approvedItem).getByTestId("status-bar-pending-conditions"));
+
+    await waitFor(() => {
+      expect(getByRole("tooltip")).toBeVisible();
+    });
+
+    expect(getByRole("tooltip")).toHaveTextContent(data.pendingConditions[0]);
+
+    const inProgressItem = getByTestId("history-item-1");
+    expect(within(inProgressItem).getByTestId("history-item-1-status")).toHaveTextContent(
+      /In Progress/i
+    );
+    expect(() => within(inProgressItem).getByTestId("status-bar-pending-conditions")).toThrow();
+  });
+
+  it.each<[ApplicationStatus, string]>([
+    ["New", "The request form was created."],
+    ["In Progress", "The request form was being filled out."],
+    ["Submitted", "The request form was submitted for review."],
+    ["Approved", "The request form was reviewed and approved. No further action is needed."],
+    ["Rejected", "The request form was reviewed and rejected. No further action is needed."],
+    ["Inquired", "Additional information or clarification was required from the submitter."],
+    // TODO: Uncomment when the statuses are added to the application
+    // ["Canceled", "The request form was manually canceled by the user and is no longer active."],
+    // [
+    //   "Deleted",
+    //   "The request form was automatically deleted by the system due to inactivity and is no longer active.",
+    // ],
+  ])(
+    "should provide a tooltip on the history item for the status '%s'",
+    async (status, tooltip) => {
+      const data = {
+        history: [{ dateTime: "2009-11-24T01:25:45Z", status }],
+      };
+
+      const { getByText, getByTestId, getByRole } = render(<BaseComponent data={data} />);
+
+      userEvent.click(getByText("Full History"));
+
+      userEvent.hover(within(getByTestId("history-item-0")).getByText(new RegExp(status, "i")));
+
+      await waitFor(() => {
+        expect(getByRole("tooltip")).toBeVisible();
+      });
+
+      expect(getByRole("tooltip")).toHaveTextContent(tooltip);
+    }
+  );
 });

--- a/src/components/StatusBar/StatusBar.test.tsx
+++ b/src/components/StatusBar/StatusBar.test.tsx
@@ -474,13 +474,14 @@ describe("StatusBar > History Modal Tests", () => {
 
   it.each<[ApplicationStatus, string]>([
     ["New", "The request form was created."],
-    ["In Progress", "The request form was being filled out."],
+    ["In Progress", "The request form was started but not submitted."],
     ["Submitted", "The request form was submitted for review."],
-    ["Approved", "The request form was reviewed and approved. No further action is needed."],
-    ["Rejected", "The request form was reviewed and rejected. No further action is needed."],
-    ["Inquired", "Additional information or clarification was required from the submitter."],
+    ["In Review", "The request form is under evaluation by the Submission Review Committee."],
+    ["Approved", "The request form was reviewed and approved."],
+    ["Rejected", "The request form was reviewed and rejected."],
+    ["Inquired", "Additional information or clarification was requested from the submitter."],
     // TODO: Uncomment when the statuses are added to the application
-    // ["Canceled", "The request form was manually canceled by the user and is no longer active."],
+    // ["Canceled", "The request form was manually canceled by the submitter and is no longer active."],
     // [
     //   "Deleted",
     //   "The request form was automatically deleted by the system due to inactivity and is no longer active.",

--- a/src/components/StatusBar/components/HistorySection.tsx
+++ b/src/components/StatusBar/components/HistorySection.tsx
@@ -7,6 +7,7 @@ import { FormatDate } from "../../../utils";
 import HistoryDialog from "../../HistoryDialog";
 import { ReactComponent as BellIcon } from "../../../assets/icons/border_filled_bell_icon.svg";
 import Tooltip from "../../Tooltip";
+import { TOOLTIP_TEXT } from "../../../config/QuestionnaireTooltips";
 
 /**
  * Determines the text color for a History event based
@@ -67,7 +68,7 @@ const StyledBellIcon = styled(BellIcon)({
 /**
  * Status Bar History Section
  *
- * @returns {JSX.Element}
+ * @returns The History Section of the Status Bar
  */
 const HistorySection: FC = () => {
   const {
@@ -77,22 +78,34 @@ const HistorySection: FC = () => {
 
   const buildStatusWrapper = useCallback(
     (status: ApplicationStatus): React.FC<{ children: React.ReactNode }> => {
-      if (!conditional || !pendingConditions?.length || status !== "Approved") {
-        return ({ children }) => <span>{children}</span>;
+      // Show pending conditions if they exist
+      if ((conditional || pendingConditions?.length > 0) && status === "Approved") {
+        return ({ children }) => (
+          <Tooltip
+            title={pendingConditions?.join(" ")}
+            placement="top"
+            open={undefined}
+            disableHoverListener={false}
+            arrow
+          >
+            <Stack direction="row" alignItems="center" data-testid="status-bar-pending-conditions">
+              {children}
+              <StyledBellIcon />
+            </Stack>
+          </Tooltip>
+        );
       }
 
+      // No pending conditions, show tooltip with status description
       return ({ children }) => (
         <Tooltip
-          title={pendingConditions?.join(" ")}
+          title={TOOLTIP_TEXT.STATUS_DESCRIPTIONS[status]}
           placement="top"
           open={undefined}
           disableHoverListener={false}
           arrow
         >
-          <Stack direction="row" alignItems="center">
-            {children}
-            <StyledBellIcon />
-          </Stack>
+          <span>{children}</span>
         </Tooltip>
       );
     },

--- a/src/config/QuestionnaireTooltips.ts
+++ b/src/config/QuestionnaireTooltips.ts
@@ -1,0 +1,18 @@
+/**
+ * An object containing all the tooltip text for the Questionnaire/Submission Request page.
+ */
+export const TOOLTIP_TEXT = {
+  STATUS_DESCRIPTIONS: {
+    New: "The request form was created.",
+    "In Progress": "The request form was being filled out.",
+    Submitted: "The request form was submitted for review.",
+    Approved: "The request form was reviewed and approved. No further action is needed.",
+    Rejected: "The request form was reviewed and rejected. No further action is needed.",
+    Inquired: "Additional information or clarification was required from the submitter.",
+    Canceled: "The request form was manually canceled by the user and is no longer active.",
+    Deleted:
+      "The request form was automatically deleted by the system due to inactivity and is no longer active.",
+  },
+} as const;
+
+export type TooltipText = typeof TOOLTIP_TEXT;

--- a/src/config/QuestionnaireTooltips.ts
+++ b/src/config/QuestionnaireTooltips.ts
@@ -1,15 +1,19 @@
 /**
  * An object containing all the tooltip text for the Questionnaire/Submission Request page.
  */
-export const TOOLTIP_TEXT = {
+export const TOOLTIP_TEXT: {
+  // TODO: Change to ApplicationStatus
+  STATUS_DESCRIPTIONS: Record<string, string>;
+} = {
   STATUS_DESCRIPTIONS: {
     New: "The request form was created.",
-    "In Progress": "The request form was being filled out.",
+    "In Progress": "The request form was started but not submitted.",
     Submitted: "The request form was submitted for review.",
-    Approved: "The request form was reviewed and approved. No further action is needed.",
-    Rejected: "The request form was reviewed and rejected. No further action is needed.",
-    Inquired: "Additional information or clarification was required from the submitter.",
-    Canceled: "The request form was manually canceled by the user and is no longer active.",
+    "In Review": "The request form is under evaluation by the Submission Review Committee.",
+    Approved: "The request form was reviewed and approved.",
+    Rejected: "The request form was reviewed and rejected.",
+    Inquired: "Additional information or clarification was requested from the submitter.",
+    Canceled: "The request form was manually canceled by the submitter and is no longer active.",
     Deleted:
       "The request form was automatically deleted by the system due to inactivity and is no longer active.",
   },


### PR DESCRIPTION
### Overview

PR to add general improvements to the Submission Request page.

> [!NOTE]
> I commented out tests for `Canceled` and `Deleted` statuses due to TypeScript issues, I'll uncomment them in CRDCDH-2187.

### Change Details (Specifics)

- Render tooltips on the status transition in the Submission Request History Dialog
- Add test coverage for SR History Dialog changes (tooltips and also conditional approval didn't have any coverage)
- Increase the height of Review Comments inputs (Approve, Inquire, Reject) and make them resizable

### Related Ticket(s)

CRDCDH-2188 (FE Task)
CRDCDH-2158 (US)
