### PR TITLE
CRDCDH-2098 Hotfix: Allow review permission to validate before and after submitted submission

### DIFF
--- a/src/components/DataSubmissions/ValidationControls.tsx
+++ b/src/components/DataSubmissions/ValidationControls.tsx
@@ -83,11 +83,14 @@ const ValidateMap: Partial<
   Record<Submission["status"], (user: User, submission: Submission) => boolean>
 > = {
   "In Progress": (user: User, submission: Submission) =>
-    hasPermission(user, "data_submission", "create", submission),
+    hasPermission(user, "data_submission", "create", submission) ||
+    hasPermission(user, "data_submission", "review", submission),
   Withdrawn: (user: User, submission: Submission) =>
-    hasPermission(user, "data_submission", "create", submission),
+    hasPermission(user, "data_submission", "create", submission) ||
+    hasPermission(user, "data_submission", "review", submission),
   Rejected: (user: User, submission: Submission) =>
-    hasPermission(user, "data_submission", "create", submission),
+    hasPermission(user, "data_submission", "create", submission) ||
+    hasPermission(user, "data_submission", "review", submission),
   Submitted: (user: User, submission: Submission) =>
     hasPermission(user, "data_submission", "review", submission),
 };


### PR DESCRIPTION
### Overview

Allow users with the "review" permission to validate before and after a Data Submission has been submitted.

### Change Details (Specifics)

N/A

### Related Ticket(s)

[CRDCDH-2098](https://tracker.nci.nih.gov/browse/CRDCDH-2098) (Task)
[CRDCDH-2023](https://tracker.nci.nih.gov/browse/CRDCDH-2023) (US)
