### PR TITLE
CRDCDH-2271 Limit Collaborator editing for specific Submission statuses

### DIFF
--- a/src/components/Collaborators/CollaboratorsDialog.test.tsx
+++ b/src/components/Collaborators/CollaboratorsDialog.test.tsx
@@ -400,4 +400,64 @@ describe("CollaboratorsDialog Component", () => {
     expect(getByTestId("collaborators-dialog-cancel-button")).toBeInTheDocument();
     expect(queryByTestId("collaborators-dialog-close-button")).not.toBeInTheDocument();
   });
+
+  it.each<SubmissionStatus>(["Completed", "Canceled", "Deleted"])(
+    "should not allow changes when submission status is '%s'",
+    async (status) => {
+      mockUseAuthContext.mockReturnValue({
+        user: {
+          ...mockUser,
+          permissions: ["data_submission:view", "data_submission:create"],
+        } as User,
+        status: AuthStatus.LOADED,
+      });
+      mockUseSubmissionContext.mockReturnValue({
+        data: { getSubmission: { ...mockSubmission, status } as Submission },
+        updateQuery: mockUpdateQuery,
+      });
+
+      const mockOnClose = jest.fn();
+      const { getByTestId, queryByTestId } = render(
+        <TestParent>
+          <CollaboratorsDialog open onClose={mockOnClose} onSave={jest.fn()} />
+        </TestParent>
+      );
+
+      expect(queryByTestId("collaborators-dialog-save-button")).not.toBeInTheDocument();
+      expect(queryByTestId("collaborators-dialog-cancel-button")).not.toBeInTheDocument();
+      expect(getByTestId("collaborators-dialog-close-button")).toBeInTheDocument();
+    }
+  );
+
+  it.each<SubmissionStatus>([
+    "New",
+    "In Progress",
+    "Rejected",
+    "Released",
+    "Submitted",
+    "Withdrawn",
+  ])("should allow changes when submission status is '%s'", async (status) => {
+    mockUseAuthContext.mockReturnValue({
+      user: {
+        ...mockUser,
+        permissions: ["data_submission:view", "data_submission:create"],
+      } as User,
+      status: AuthStatus.LOADED,
+    });
+    mockUseSubmissionContext.mockReturnValue({
+      data: { getSubmission: { ...mockSubmission, status } as Submission },
+      updateQuery: mockUpdateQuery,
+    });
+
+    const mockOnClose = jest.fn();
+    const { getByTestId, queryByTestId } = render(
+      <TestParent>
+        <CollaboratorsDialog open onClose={mockOnClose} onSave={jest.fn()} />
+      </TestParent>
+    );
+
+    expect(getByTestId("collaborators-dialog-save-button")).toBeInTheDocument();
+    expect(getByTestId("collaborators-dialog-cancel-button")).toBeInTheDocument();
+    expect(queryByTestId("collaborators-dialog-close-button")).not.toBeInTheDocument();
+  });
 });

--- a/src/components/Collaborators/CollaboratorsDialog.tsx
+++ b/src/components/Collaborators/CollaboratorsDialog.tsx
@@ -93,6 +93,16 @@ const StyledDescription = styled(Typography)({
   marginBottom: "44px",
 });
 
+/**
+ * A set of Submission statuses where the collaborator dialog actions
+ * should be disabled
+ */
+export const DISABLE_COLLABORATOR_DIALOG_STATUSES: SubmissionStatus[] = [
+  "Completed",
+  "Canceled",
+  "Deleted",
+];
+
 type Props = {
   onClose: () => void;
   onSave: (collaborators: Collaborator[]) => void;
@@ -112,7 +122,8 @@ const CollaboratorsDialog = ({ onClose, onSave, open, ...rest }: Props) => {
   const canModifyCollaborators = useMemo(
     () =>
       hasPermission(user, "data_submission", "create", null, true) &&
-      submission?.getSubmission?.submitterID === user?._id,
+      submission?.getSubmission?.submitterID === user?._id &&
+      !DISABLE_COLLABORATOR_DIALOG_STATUSES.includes(submission?.getSubmission?.status),
     [user, submission?.getSubmission]
   );
 

--- a/src/components/DataSubmissions/DataSubmissionSummary.tsx
+++ b/src/components/DataSubmissions/DataSubmissionSummary.tsx
@@ -225,7 +225,7 @@ const DataSubmissionSummary: FC<Props> = ({ dataSubmission }) => {
               <StyledTooltip
                 placement="top"
                 title="Click to add new collaborators or view existing ones."
-                disableHoverListener={false}
+                disableHoverListener={!dataSubmission}
                 slotProps={{
                   tooltip: { "data-testid": "collaborators-button-tooltip" } as unknown,
                 }}


### PR DESCRIPTION
### Overview

Restrict the Submitter from modifying the Collaborators within the dialog when a submission is in Completed, Canceled, or Deleted status.

### Change Details (Specifics)

N/A

### Related Ticket(s)

[CRDCDH-2271](https://tracker.nci.nih.gov/browse/CRDCDH-2271) (Task)
[CRDCDH-2035](https://tracker.nci.nih.gov/browse/CRDCDH-2035) (US)
