### PR TITLE
CRDCDH-2265 Support multi-select status selection

### DIFF
--- a/src/components/DataSubmissions/DataSubmissionListFilters.test.tsx
+++ b/src/components/DataSubmissions/DataSubmissionListFilters.test.tsx
@@ -267,22 +267,6 @@ describe("DataSubmissionListFilters Component", () => {
 
     userEvent.click(orgSelectList.getByTestId("organization-option-Org2"));
 
-    const statusSelect = within(getByTestId("status-select")).getByRole("button");
-
-    userEvent.click(statusSelect);
-
-    const statusSelectList = within(statusSelect.parentElement).getByRole("listbox", {
-      hidden: true,
-    });
-
-    await waitFor(() => {
-      expect(within(statusSelectList).getByTestId("status-option-All")).toBeInTheDocument();
-      expect(within(statusSelectList).getByTestId("status-option-New")).toBeInTheDocument();
-      expect(within(statusSelectList).getByTestId("status-option-Submitted")).toBeInTheDocument();
-    });
-
-    userEvent.click(within(statusSelectList).getByTestId("status-option-Submitted"));
-
     const dataCommonsSelect = within(getByTestId("data-commons-select")).getByRole("button");
 
     userEvent.click(dataCommonsSelect);
@@ -334,7 +318,7 @@ describe("DataSubmissionListFilters Component", () => {
       expect(mockOnChange).toHaveBeenCalledWith(
         expect.objectContaining({
           organization: "Org2",
-          status: "Submitted",
+          status: expect.arrayContaining(["New", "Submitted"]),
           name: "Test Submission",
           dbGaPID: "12345",
           submitterName: "Submitter1",
@@ -347,7 +331,9 @@ describe("DataSubmissionListFilters Component", () => {
 
     await waitFor(() => {
       expect(getByTestId("organization-select-input")).toHaveValue("All");
-      expect(getByTestId("status-select-input")).toHaveValue("All");
+      expect(getByTestId("status-select-input")).toHaveValue(
+        ["New", "In Progress", "Submitted", "Withdrawn", "Released", "Rejected"].join(",")
+      );
       expect(getByTestId("data-commons-select-input")).toHaveValue("All");
       expect(getByTestId("submission-name-input")).toHaveValue("");
       expect(getByTestId("dbGaPID-input")).toHaveValue("");
@@ -357,7 +343,7 @@ describe("DataSubmissionListFilters Component", () => {
     expect(mockOnChange).toHaveBeenCalledWith(
       expect.objectContaining({
         organization: "All",
-        status: "All",
+        status: ["New", "In Progress", "Submitted", "Withdrawn", "Released", "Rejected"],
         dataCommons: "All",
         name: "",
         dbGaPID: "",
@@ -647,7 +633,7 @@ describe("DataSubmissionListFilters Component", () => {
     expect(mockOnChange).toHaveBeenCalledWith(
       expect.objectContaining({
         organization: "Org1",
-        status: "Submitted",
+        status: ["Submitted"],
         dataCommons: "DataCommon1",
         name: "Test",
         dbGaPID: "123",
@@ -657,6 +643,37 @@ describe("DataSubmissionListFilters Component", () => {
 
     userEvent.clear(getByTestId("dbGaPID-input"));
     userEvent.clear(getByTestId("submission-name-input"));
+  });
+
+  it("initializes study field based on searchParams and ignores invalid options", async () => {
+    const initialEntries = ["/?status=Deleted&status=RandomFakeStatus"];
+
+    const mockOnChange = jest.fn();
+    const mockOnColumnVisibilityModelChange = jest.fn();
+
+    const { getByTestId } = render(
+      <TestParent initialEntries={initialEntries} userRole="Admin">
+        <DataSubmissionListFilters
+          columns={columns}
+          organizations={organizations}
+          submitterNames={submitterNames}
+          dataCommons={dataCommons}
+          columnVisibilityModel={columnVisibilityModel}
+          onColumnVisibilityModelChange={mockOnColumnVisibilityModelChange}
+          onChange={mockOnChange}
+        />
+      </TestParent>
+    );
+
+    await waitFor(() => {
+      expect(getByTestId("status-select-input")).toHaveValue("Deleted");
+    });
+
+    expect(mockOnChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: ["Deleted"],
+      })
+    );
   });
 
   it("initializes form fields to default when searchParams are empty", async () => {
@@ -681,7 +698,9 @@ describe("DataSubmissionListFilters Component", () => {
 
     await waitFor(() => {
       expect(getByTestId("organization-select-input")).toHaveValue("All");
-      expect(getByTestId("status-select-input")).toHaveValue("All");
+      expect(getByTestId("status-select-input")).toHaveValue(
+        ["New", "In Progress", "Submitted", "Withdrawn", "Released", "Rejected"].join(",")
+      );
       expect(getByTestId("data-commons-select-input")).toHaveValue("All");
       expect(getByTestId("submission-name-input")).toHaveValue("");
       expect(getByTestId("dbGaPID-input")).toHaveValue("");
@@ -691,7 +710,7 @@ describe("DataSubmissionListFilters Component", () => {
     expect(mockOnChange).toHaveBeenCalledWith(
       expect.objectContaining({
         organization: "All",
-        status: "All",
+        status: ["New", "In Progress", "Submitted", "Withdrawn", "Released", "Rejected"],
         dataCommons: "All",
         name: "",
         dbGaPID: "",
@@ -724,7 +743,7 @@ describe("DataSubmissionListFilters Component", () => {
       expect(mockOnChange).toHaveBeenCalledWith(
         expect.objectContaining({
           organization: "All",
-          status: "All",
+          status: ["New", "In Progress", "Submitted", "Withdrawn", "Released", "Rejected"],
           dataCommons: "All",
           name: "",
           dbGaPID: "",

--- a/src/content/dataSubmissions/DataSubmissionsListView.tsx
+++ b/src/content/dataSubmissions/DataSubmissionsListView.tsx
@@ -16,6 +16,7 @@ import TruncatedText from "../../components/TruncatedText";
 import StyledTooltip from "../../components/StyledFormComponents/StyledTooltip";
 import { useColumnVisibility } from "../../hooks/useColumnVisibility";
 import DataSubmissionListFilters, {
+  defaultValues,
   FilterForm,
 } from "../../components/DataSubmissions/DataSubmissionListFilters";
 
@@ -243,14 +244,7 @@ const ListingView: FC = () => {
   const [dataCommons, setDataCommons] = useState<string[]>([]);
   const [totalData, setTotalData] = useState<number>(0);
   const tableRef = useRef<TableMethods>(null);
-  const filtersRef = useRef<FilterForm>({
-    organization: "All",
-    status: "All",
-    dataCommons: "All",
-    name: "",
-    dbGaPID: "",
-    submitterName: "All",
-  });
+  const filtersRef = useRef<FilterForm>({ ...defaultValues });
 
   const [listSubmissions, { refetch }] = useLazyQuery<ListSubmissionsResp, ListSubmissionsInput>(
     LIST_SUBMISSIONS,
@@ -281,7 +275,7 @@ const ListingView: FC = () => {
       const { data: d, error } = await listSubmissions({
         variables: {
           organization: organization ?? "All",
-          status: status ?? "All",
+          status,
           dataCommons: dc ?? "All",
           submitterName: submitterName ?? "All",
           name: name || undefined,
@@ -365,8 +359,6 @@ const ListingView: FC = () => {
         padding="57px 0 0 25px"
         body={
           <StyledBannerBody direction="row" alignItems="center" justifyContent="flex-end">
-            {/* NOTE For MVP-2: Organization Owners are just Users */}
-            {/* Create a submission only available to org owners and submitters that have organizations assigned */}
             <CreateDataSubmissionDialog onCreate={handleOnCreateSubmission} />
           </StyledBannerBody>
         }

--- a/src/graphql/listSubmissions.ts
+++ b/src/graphql/listSubmissions.ts
@@ -1,6 +1,7 @@
+import { TypedDocumentNode } from "@apollo/client";
 import gql from "graphql-tag";
 
-export const query = gql`
+export const query: TypedDocumentNode<Response, Input> = gql`
   query listSubmissions(
     $organization: String
     $status: String
@@ -57,7 +58,7 @@ export const query = gql`
 
 export type Input = {
   organization?: string;
-  status?: SubmissionStatus | "All";
+  status?: SubmissionStatus[];
   dataCommons?: string;
   name?: string;
   dbGaPID?: string;


### PR DESCRIPTION
### Overview

This PR allows multi-selection of the Data Submission List > Status Filter.

> [!NOTE]
> This PR is on hold waiting for BE.

### Change Details (Specifics)

- Update the Status input to multi-select
- Change searchParams implementation for the status field to an array-based implementation (status=x1&status=x2...)
- Update the order of the option list
- Export the default form values and use that for the Data Submission List formRef instead of duplicating fields
- Remove very very old MVP-1 note

### Related Ticket(s)

CRDCDH-2265 (Task)
CRDCDH-2206 (US)