### PR TITLE
CRDCDH-2156 HOTFIX: Tooltip should ignore interactivity

### DIFF
--- a/src/components/StatusBar/components/HistorySection.tsx
+++ b/src/components/StatusBar/components/HistorySection.tsx
@@ -86,6 +86,7 @@ const HistorySection: FC = () => {
             placement="top"
             open={undefined}
             disableHoverListener={false}
+            disableInteractive
             arrow
           >
             <Stack direction="row" alignItems="center" data-testid="status-bar-pending-conditions">
@@ -103,6 +104,7 @@ const HistorySection: FC = () => {
           placement="top"
           open={undefined}
           disableHoverListener={false}
+          disableInteractive
           arrow
         >
           <span>{children}</span>


### PR DESCRIPTION
### Overview

This PR is a hotfix for the CRDCDH-2156 submission request status descriptions – Trying to hover over each status is very challenging because the tooltip is not disappearing.

<details><summary>Issue</summary>
<p>

https://github.com/user-attachments/assets/e3b60b79-2680-41b9-a0ca-545d854fe012

</p>
</details> 

### Change Details (Specifics)

N/A

### Related Ticket(s)

CRDCDH-2156
