### PR TITLE
CRDCDH-2260 Model Navigator - Add Release Notes tab

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8897,7 +8897,7 @@
     },
     "node_modules/data-model-navigator": {
       "version": "1.1.34",
-      "resolved": "git+ssh://git@github.com/CBIIT/Data-Model-Navigator.git#b5d4f1873e646784b35dcc7a3c8eebc83f768bb3",
+      "resolved": "git+ssh://git@github.com/CBIIT/Data-Model-Navigator.git#cbb8d58843ec253d93f6cfcfadf472b91eeae1f3",
       "license": "ISC",
       "dependencies": {
         "@material-ui/core": "^4.12.4",

--- a/src/hooks/useBuildReduxStore.ts
+++ b/src/hooks/useBuildReduxStore.ts
@@ -169,7 +169,10 @@ const useBuildReduxStore = (): ReduxStoreResult => {
 
     store.dispatch({
       type: "RECEIVE_CHANGELOG_INFO",
-      data: changelogMD,
+      data: {
+        changelogMD,
+        changelogTabName: "Version History",
+      },
     });
 
     // MVP-2 M2 NOTE: This resets the search history to prevent the data models

--- a/src/hooks/useBuildReduxStore.ts
+++ b/src/hooks/useBuildReduxStore.ts
@@ -4,7 +4,9 @@ import {
   ddgraph,
   moduleReducers as submission,
   versionInfo,
+  changelogInfo,
   getModelExploreData,
+  getChangelog,
 } from "data-model-navigator";
 import { useLazyQuery } from "@apollo/client";
 import { defaultTo } from "lodash";
@@ -27,7 +29,7 @@ export type ReduxStoreResult = [
 ];
 
 const makeStore = (): Store => {
-  const reducers = { ddgraph, versionInfo, submission };
+  const reducers = { ddgraph, versionInfo, submission, changelogInfo };
   const newStore = createStore(combineReducers(reducers));
 
   // @ts-ignore
@@ -86,6 +88,12 @@ const useBuildReduxStore = (): ReduxStoreResult => {
     setStatus("loading");
 
     const assets = buildAssetUrls(datacommon, modelVersion);
+
+    const changelogMD = await getChangelog(assets?.changelog)?.catch((e) => {
+      Logger.error(e);
+      return null;
+    });
+
     const response = await getModelExploreData(...assets.model_files)?.catch((e) => {
       Logger.error(e);
       return null;
@@ -157,6 +165,11 @@ const useBuildReduxStore = (): ReduxStoreResult => {
         },
         graphViewConfig,
       },
+    });
+
+    store.dispatch({
+      type: "RECEIVE_CHANGELOG_INFO",
+      data: changelogMD,
     });
 
     // MVP-2 M2 NOTE: This resets the search history to prevent the data models

--- a/src/types/DataCommon.d.ts
+++ b/src/types/DataCommon.d.ts
@@ -60,6 +60,12 @@ type ManifestAssets = {
    */
   "readme-file": string;
   /**
+   * The file name of the Data Model release notes file.
+   *
+   * @example "release-notes.md"
+   */
+  "release-notes": string;
+  /**
    * The relative URL for the Model Navigator logo.
    *
    * @example "model-navigator-logo.png"

--- a/src/types/DataModelNavigator.d.ts
+++ b/src/types/DataModelNavigator.d.ts
@@ -72,6 +72,11 @@ type ModelAssetUrls = {
    * @since 3.1.0
    */
   navigator_icon: string;
+  /**
+   * the URL to the Data Model Release Notes file
+   * If this is null, the Release Notes tab will not be displayed
+   */
+  changelog?: string;
 };
 
 type FacetSearchData = {

--- a/src/utils/dataModelUtils.test.ts
+++ b/src/utils/dataModelUtils.test.ts
@@ -21,6 +21,7 @@ describe("fetchManifest cases", () => {
         "readme-file": "cds-model-readme.md",
         "loading-file": "cds-loading.zip",
         "current-version": "1.0",
+        "release-notes": "release-notes.md",
         versions: [],
       },
     };
@@ -39,6 +40,7 @@ describe("fetchManifest cases", () => {
         "readme-file": "cds-model-readme.md",
         "loading-file": "cds-loading.zip",
         "current-version": "1.0",
+        "release-notes": "release-notes.md",
         versions: [],
       },
     };
@@ -60,6 +62,7 @@ describe("fetchManifest cases", () => {
         "readme-file": "cds-model-readme.md",
         "loading-file": "cds-loading.zip",
         "current-version": "1.0",
+        "release-notes": "release-notes.md",
         versions: [],
       },
     };
@@ -115,6 +118,7 @@ describe("buildAssetUrls cases", () => {
         "model-files": ["model-file", "prop-file"],
         "readme-file": "readme-file",
         "loading-file": "loading-file-zip-name",
+        "release-notes": "release-notes.md",
       } as ManifestAssets,
     } as DataCommon;
 
@@ -128,6 +132,7 @@ describe("buildAssetUrls cases", () => {
       readme: `${MODEL_FILE_REPO}prod/cache/test-name/1.0/readme-file`,
       loading_file: `${MODEL_FILE_REPO}prod/cache/test-name/1.0/loading-file-zip-name`,
       navigator_icon: expect.any(String),
+      changelog: `${MODEL_FILE_REPO}prod/cache/test-name/1.0/release-notes.md`,
     });
   });
 

--- a/src/utils/dataModelUtils.ts
+++ b/src/utils/dataModelUtils.ts
@@ -54,6 +54,9 @@ export const buildAssetUrls = (model: DataCommon, modelVersion: string): ModelAs
     navigator_icon: assets?.["model-navigator-logo"]
       ? `${MODEL_FILE_REPO}${tier}/cache/${name}/${version}/${assets?.["model-navigator-logo"]}`
       : GenericModelLogo,
+    changelog: assets?.["release-notes"]
+      ? `${MODEL_FILE_REPO}${tier}/cache/${name}/${assets?.["current-version"]}/${assets?.["release-notes"]}`
+      : null,
   };
 };
 

--- a/src/utils/dataModelUtils.ts
+++ b/src/utils/dataModelUtils.ts
@@ -55,7 +55,7 @@ export const buildAssetUrls = (model: DataCommon, modelVersion: string): ModelAs
       ? `${MODEL_FILE_REPO}${tier}/cache/${name}/${version}/${assets?.["model-navigator-logo"]}`
       : GenericModelLogo,
     changelog: assets?.["release-notes"]
-      ? `${MODEL_FILE_REPO}${tier}/cache/${name}/${assets?.["current-version"]}/${assets?.["release-notes"]}`
+      ? `${MODEL_FILE_REPO}${tier}/cache/${name}/${version}/${assets?.["release-notes"]}`
       : null,
   };
 };


### PR DESCRIPTION
### Overview

Added support for displaying Release Notes as a tab using markdown.

> [!NOTE]
> It is currently setup to use the latest release notes. This may change, will address in separate PR if necessary.

### Change Details (Specifics)

- Retrieved the latest changelog/release notes assets from the DMN manifest and updated the Redux state to display as a tab in the DMN
- DMN changes in https://github.com/CBIIT/Data-Model-Navigator/pull/155

### Related Ticket(s)

[CRDCDH-2260](https://tracker.nci.nih.gov/browse/CRDCDH-2260) (Task)
[CRDCDH-2231](https://tracker.nci.nih.gov/browse/CRDCDH-2231) (US)
