### PR TITLE
fix: Checkbox disabled state not visually apparent

### DIFF
--- a/src/content/questionnaire/sections/A.tsx
+++ b/src/content/questionnaire/sections/A.tsx
@@ -34,8 +34,9 @@ const StyledFormControlLabel = styled(FormControlLabel)({
   "& .MuiFormControlLabel-label": {
     color: "#083A50",
     fontWeight: "700",
+    userSelect: "none",
   },
-  "& .MuiCheckbox-root": {
+  "& .MuiCheckbox-root:not(.Mui-disabled)": {
     color: "#005EA2 !important",
   },
 });
@@ -231,6 +232,7 @@ const FormSectionA: FC<FormSectionProps> = ({ SectionOption, refs }: FormSection
                 readOnly={readOnlyInputs}
               />
             }
+            disabled={readOnlyInputs}
           />
           <input
             id="section-a-primary-contact-same-as-pi-checkbox"


### PR DESCRIPTION
### Overview

This PR addresses a concern from QA that the checkbox on Section A is not visually represented as disabled. I added one CSS exclusion to the checkbox styling so it doesn't target disabled checkboxes.

Screenshot of different states, all of which pass Axe and Wave 508 audits:

Enabled, Unchecked
<img width="436" alt="Enabled--Unchecked" src="https://github.com/user-attachments/assets/ee1c19b6-23fc-4a02-ad5b-b008c0f74df5" />

Enabled, Checked
<img width="436" alt="Enabled--Checked" src="https://github.com/user-attachments/assets/ca3d95a2-450b-4dc3-b00a-19000314f1a1" />

Disabled, Unchecked
<img width="436" alt="Disabled--Unchecked" src="https://github.com/user-attachments/assets/8d228c73-d9de-4c0b-9945-adc164d7127c" />

Disabled, Checked
<img width="436" alt="Disabled--Checked" src="https://github.com/user-attachments/assets/43caa76c-53f2-4d8e-b8d5-25fc7b4b4ddf" />


### Change Details (Specifics)

N/A

### Related Ticket(s)

CRDCDH-2305 (Task, no US)
