### PR TITLE
fix: Version changing not rebuilding UI

### DIFF
--- a/src/content/ModelNavigator/Controller.tsx
+++ b/src/content/ModelNavigator/Controller.tsx
@@ -14,7 +14,7 @@ const ModelNavigatorController: React.FC = () => {
   }
 
   return (
-    <DataCommonProvider key={model} DataCommon={model}>
+    <DataCommonProvider key={`${model}_${version}`} DataCommon={model}>
       <ErrorBoundary errorMessage="Unable to load the Model Navigator for the requested model">
         <NavigatorView version={version} />
       </ErrorBoundary>


### PR DESCRIPTION
### Overview

This is a hotfix for CRDCDH-2266; If you're on an old version of the Data Model, then click the Navigator link from the navbar, the URL updates, but the UI never rebuilds the latest model version.

### Change Details (Specifics)

N/A

### Related Ticket(s)

CRDCDH-2266