### PR TITLE
CRDCDH-2319 Bug: Fix Submission Request submit permission logic 

### DIFF
--- a/src/components/ProgressBar/ProgressBar.test.tsx
+++ b/src/components/ProgressBar/ProgressBar.test.tsx
@@ -315,6 +315,7 @@ describe("Basic Functionality", () => {
           user={{
             ...BaseUser,
             _id: "some-other-user",
+            role: "Admin",
             permissions: ["submission_request:view", "submission_request:submit"],
           }}
         />
@@ -349,6 +350,7 @@ describe("Basic Functionality", () => {
           user={{
             ...BaseUser,
             _id: "user-id-01",
+            role: "Admin",
             permissions: ["submission_request:view"], // Only possible to view the submission request, no submit or review
           }}
         />

--- a/src/config/AuthPermissions.test.ts
+++ b/src/config/AuthPermissions.test.ts
@@ -148,39 +148,14 @@ describe("submission_request:submit Permission", () => {
   ];
 
   it.each(validStatuses)(
-    "should allow the form owner to submit if the status is '%s' without the permission",
+    "should allow a user with 'submission_request:submit' permission key if the status is '%s'",
     (status) => {
-      const user = createUser("Submitter", []);
-
-      const application: Application = {
-        ...baseApplication,
-        status,
-        applicant: {
-          ...baseApplication.applicant,
-          applicantID: "user-1",
-        },
-      };
-
-      expect(hasPermission(user, "submission_request", "submit", application)).toBe(true);
-    }
-  );
-
-  it.each(validStatuses)(
-    "should allow a user with 'submission_request:submit' permission key if the status is '%s', even if not owner",
-    (status) => {
-      const user = createUser("Submitter", ["submission_request:submit"]);
+      const user = createUser("Admin", ["submission_request:submit"]);
       const application: Application = { ...baseApplication, status };
 
       expect(hasPermission(user, "submission_request", "submit", application)).toBe(true);
     }
   );
-
-  it("should deny submission if the user is not the owner AND lacks the 'submission_request:submit' permission key", () => {
-    const user = createUser("Submitter", []);
-    const application: Application = { ...baseApplication, status: "In Progress" };
-
-    expect(hasPermission(user, "submission_request", "submit", application)).toBe(false);
-  });
 
   it.each(invalidStatuses)("should deny submission if the application status is '%s'", (status) => {
     const user = createUser("Submitter", ["submission_request:submit"]);
@@ -194,6 +169,55 @@ describe("submission_request:submit Permission", () => {
 
     expect(hasPermission(user, "submission_request", "submit", undefined)).toBe(false);
     expect(hasPermission(user, "submission_request", "submit", null)).toBe(false);
+  });
+
+  it.each<UserRole>(["User", "Submitter"])(
+    "should allow a user with role '%s' to submit with 'submission_request:submit' permission key if they are the form owner",
+    (role) => {
+      const user = createUser(role, ["submission_request:submit"]);
+      const application: Application = {
+        ...baseApplication,
+        status: "In Progress",
+        applicant: { ...baseApplication.applicant, applicantID: "user-1" },
+      };
+
+      expect(hasPermission(user, "submission_request", "submit", application)).toBe(true);
+    }
+  );
+
+  it.each<UserRole>(["User", "Submitter"])(
+    "should deny a user with role '%s' to submit with 'submission_request:submit' permission key if they are not the form owner",
+    (role) => {
+      const user = createUser(role, ["submission_request:submit"]);
+      const application: Application = {
+        ...baseApplication,
+        status: "In Progress",
+        applicant: { ...baseApplication.applicant, applicantID: "some-other-user" },
+      };
+
+      expect(hasPermission(user, "submission_request", "submit", application)).toBe(false);
+    }
+  );
+
+  it.each<UserRole>(["Admin", "Data Commons Personnel", "Federal Lead"])(
+    "should allow a user with role '%s' to submit with 'submission_request:submit' permission key, regardless of form owner",
+    (role) => {
+      const user = createUser(role, ["submission_request:submit"]);
+      const application: Application = {
+        ...baseApplication,
+        status: "In Progress",
+        applicant: { ...baseApplication.applicant, applicantID: "some-other-user" },
+      };
+
+      expect(hasPermission(user, "submission_request", "submit", application)).toBe(true);
+    }
+  );
+
+  it("should deny submission if the user is not the owner AND lacks the 'submission_request:submit' permission key", () => {
+    const user = createUser("Admin", []);
+    const application: Application = { ...baseApplication, status: "In Progress" };
+
+    expect(hasPermission(user, "submission_request", "submit", application)).toBe(false);
   });
 });
 

--- a/src/config/AuthPermissions.ts
+++ b/src/config/AuthPermissions.ts
@@ -1,3 +1,5 @@
+import { CanSubmitOnlyTheirOwnSubmissionRequestRoles } from "./AuthRoles";
+
 const NO_CONDITIONS = "NO CONDITIONS";
 
 type PermissionCheck<Key extends keyof Permissions> =
@@ -46,19 +48,20 @@ export const PERMISSION_MAP = {
     view: NO_CONDITIONS,
     create: NO_CONDITIONS,
     submit: (user, application) => {
+      const { role } = user;
       const isFormOwner = application?.applicant?.applicantID === user?._id;
       const hasPermissionKey = user?.permissions?.includes("submission_request:submit");
       const submitStatuses: ApplicationStatus[] = ["In Progress", "Inquired"];
 
-      // Check for implicit permission as well as for the permission key
-      if (!isFormOwner && !hasPermissionKey) {
-        return false;
-      }
       if (!submitStatuses?.includes(application?.status)) {
         return false;
       }
 
-      return true;
+      if (CanSubmitOnlyTheirOwnSubmissionRequestRoles.includes(role)) {
+        return isFormOwner && hasPermissionKey;
+      }
+
+      return hasPermissionKey;
     },
     review: NO_CONDITIONS,
   },

--- a/src/config/AuthRoles.ts
+++ b/src/config/AuthRoles.ts
@@ -16,3 +16,9 @@ export const Roles: UserRole[] = [
  * A set of roles that are constrained to a set of studies.
  */
 export const RequiresStudiesAssigned: UserRole[] = ["Submitter", "Federal Lead"];
+
+/**
+ * A set of roles that are constrained to only be able to submit their own
+ * Submission Request forms and cannot submit on behalf of other users.
+ */
+export const CanSubmitOnlyTheirOwnSubmissionRequestRoles: UserRole[] = ["User", "Submitter"];


### PR DESCRIPTION
### Overview

The logic for the "submission_request:submit" permission was incorrect. Updated to reflect user stories.

### Change Details (Specifics)

- Removed implicit permission
- The "User" and "Submitter" roles can only submit their own submissions. Checked for form ownership, and permission key
- The other roles can submit on behalf of another user. They just required the permission key
- Updated tests to better reflected expected behavior

### Related Ticket(s)

[CRDCDH-2319](https://tracker.nci.nih.gov/browse/CRDCDH-2319)
