### PR TITLE
Style Model Link & CLI Version Adornments

### DIFF
--- a/src/components/DataSubmissions/DataUpload.test.tsx
+++ b/src/components/DataSubmissions/DataUpload.test.tsx
@@ -137,7 +137,7 @@ describe("Basic Functionality", () => {
     );
 
     expect(getByTestId("uploader-cli-version-wrapper").textContent).toBe(
-      "(Uploader CLI Version: v2.3)"
+      "Uploader CLI Version: v2.3"
     );
 
     expect(queryByRole("tooltip")).not.toBeInTheDocument();

--- a/src/components/DataSubmissions/DataUpload.tsx
+++ b/src/components/DataSubmissions/DataUpload.tsx
@@ -63,10 +63,10 @@ const StyledTooltip = styled(Tooltip)(() => ({
 }));
 
 const StyledUploaderCLIVersionText = styled("span")(() => ({
+  color: "#000",
   fontWeight: 400,
-  fontSize: "14px",
-  lineHeight: "27px",
-  letterSpacing: "0.5px",
+  fontSize: "13px",
+  textTransform: "uppercase",
 }));
 
 const StyledVersionButton = styled(Button)(() => ({
@@ -74,11 +74,14 @@ const StyledVersionButton = styled(Button)(() => ({
   textDecoration: "underline",
   color: "#005A9E",
   cursor: "pointer",
+  fontSize: "13px",
   margin: 0,
+  marginTop: "-3px",
   padding: 0,
   minWidth: 0,
   textTransform: "none",
   "&:hover": {
+    background: "transparent",
     textDecoration: "underline",
   },
 }));
@@ -154,9 +157,8 @@ export const DataUpload: FC<Props> = ({ submission }: Props) => {
 
     return (
       <Stack direction="row" alignItems="center" ml="10px">
-        {/* TODO: Implement design */}
         <StyledUploaderCLIVersionText data-testid="uploader-cli-version-wrapper">
-          (Uploader CLI Version:{" "}
+          Uploader CLI Version:{" "}
           <StyledTooltip
             title={TOOLTIP_TEXT.FILE_UPLOAD.UPLOAD_CLI_VERSION}
             open={undefined}
@@ -168,11 +170,12 @@ export const DataUpload: FC<Props> = ({ submission }: Props) => {
               variant="text"
               onClick={() => setCLIDialogOpen(true)}
               data-testid="uploader-cli-version-button"
+              disableRipple
+              disableFocusRipple
             >
               v{version}
             </StyledVersionButton>
           </StyledTooltip>
-          )
         </StyledUploaderCLIVersionText>
       </Stack>
     );

--- a/src/components/DataSubmissions/MetadataUpload.test.tsx
+++ b/src/components/DataSubmissions/MetadataUpload.test.tsx
@@ -148,6 +148,36 @@ describe("Accessibility", () => {
 
     expect(await axe(container)).toHaveNoViolations();
   });
+
+  it("should not have accessibility violations for the Model Version element", async () => {
+    const { getByTestId } = render(
+      <MetadataUpload
+        submission={{
+          ...baseSubmission,
+          _id: "id-upload-button-text",
+          metadataValidationStatus: "New",
+          fileValidationStatus: "New",
+          dataCommons: "Test Data Common",
+          modelVersion: "1.9.3",
+        }}
+        onCreateBatch={jest.fn()}
+        onUpload={jest.fn()}
+      />,
+      {
+        wrapper: ({ children }) => (
+          <TestParent
+            mocks={[]}
+            context={{ ...baseContext, user: { ...baseUser, role: "Submitter" } }}
+          >
+            {children}
+          </TestParent>
+        ),
+      }
+    );
+
+    expect(getByTestId("metadata-upload-model-version")).toBeInTheDocument();
+    expect(await axe(getByTestId("metadata-upload-model-version"))).toHaveNoViolations();
+  });
 });
 
 describe("MetadataUpload Tooltip", () => {

--- a/src/components/DataSubmissions/MetadataUpload.test.tsx
+++ b/src/components/DataSubmissions/MetadataUpload.test.tsx
@@ -554,6 +554,64 @@ describe("Implementation Requirements", () => {
     jest.resetAllMocks();
   });
 
+  it("should render the Data Model version if it's provided", () => {
+    const { getByText, getByTestId } = render(
+      <MetadataUpload
+        submission={{
+          ...baseSubmission,
+          _id: "id-upload-button-text",
+          metadataValidationStatus: "New",
+          fileValidationStatus: "New",
+          dataCommons: "Test Data Common",
+          modelVersion: "1.9.3",
+        }}
+        onCreateBatch={jest.fn()}
+        onUpload={jest.fn()}
+      />,
+      {
+        wrapper: ({ children }) => (
+          <TestParent
+            mocks={[]}
+            context={{ ...baseContext, user: { ...baseUser, role: "Submitter" } }}
+          >
+            {children}
+          </TestParent>
+        ),
+      }
+    );
+
+    expect(getByTestId("metadata-upload-model-version")).toBeInTheDocument();
+    expect(getByText(/Test Data Common Data Model/i)).toBeVisible();
+    expect(getByText(/v1.9.3/i)).toBeVisible();
+  });
+
+  it("should not render the Data Model version if it's not provided", () => {
+    const { queryByTestId } = render(
+      <MetadataUpload
+        submission={{
+          ...baseSubmission,
+          _id: "id-upload-button-text",
+          metadataValidationStatus: "New",
+          fileValidationStatus: "New",
+        }}
+        onCreateBatch={jest.fn()}
+        onUpload={jest.fn()}
+      />,
+      {
+        wrapper: ({ children }) => (
+          <TestParent
+            mocks={[]}
+            context={{ ...baseContext, user: { ...baseUser, role: "Submitter" } }}
+          >
+            {children}
+          </TestParent>
+        ),
+      }
+    );
+
+    expect(queryByTestId("metadata-upload-model-version")).not.toBeInTheDocument();
+  });
+
   it("should render the Upload with text 'Uploading...' when metadata is uploading", async () => {
     const mocks: MockedResponse<CreateBatchResp | UpdateBatchResp>[] = [
       {

--- a/src/components/DataSubmissions/MetadataUpload.tsx
+++ b/src/components/DataSubmissions/MetadataUpload.tsx
@@ -93,6 +93,18 @@ const StyledTooltip = styled(Tooltip)(() => ({
   marginTop: "3.5px",
 }));
 
+const StyledModelVersionText = styled(Typography)({
+  color: "#000",
+  fontWeight: 400,
+  fontSize: "13px",
+  textTransform: "uppercase",
+  "& a": {
+    color: "#005A9E",
+    fontWeight: 700,
+    textTransform: "none",
+  },
+});
+
 type Props = {
   submission: Submission;
   readOnly?: boolean;
@@ -321,11 +333,10 @@ const MetadataUpload = ({ submission, readOnly, onCreateBatch, onUpload }: Props
           open={undefined}
           disableHoverListener={false}
         />
-        {/* TODO: Implement design */}
         {submission?.dataCommons && submission?.modelVersion && (
-          <span>
-            ({submission.dataCommons} Data Model: <NavigatorLink submission={submission} />)
-          </span>
+          <StyledModelVersionText data-testid="metadata-upload-model-version">
+            {submission.dataCommons} Data Model: <NavigatorLink submission={submission} />
+          </StyledModelVersionText>
         )}
       </Stack>
     ),


### PR DESCRIPTION
### Overview

This PR applies some minor styling changes to the Data Model link and CLI Version displays on the DS Dashboard, per the latest UX design.

> [!NOTE]
> The UX design specifies that these elements should be 10px font size, but when using that size, it's incredibly small and looks very different from the design (IMO). I increased it to 13px, which looks closer to the actual design. 

### Change Details (Specifics)

N/A

### Related Ticket(s)

CRDCDH-2159 (US 1 – DM Link)
CRDCDH-2274 (US 2 – CLI Vers)
