### PR TITLE
Fine-tune Version Adornment Styling

### DIFF
--- a/src/components/DataSubmissions/DataUpload.tsx
+++ b/src/components/DataSubmissions/DataUpload.tsx
@@ -65,7 +65,7 @@ const StyledTooltip = styled(Tooltip)(() => ({
 const StyledUploaderCLIVersionText = styled("span")(() => ({
   color: "#000",
   fontWeight: 400,
-  fontSize: "13px",
+  fontSize: "11.5px",
   textTransform: "uppercase",
 }));
 
@@ -74,9 +74,10 @@ const StyledVersionButton = styled(Button)(() => ({
   textDecoration: "underline",
   color: "#005A9E",
   cursor: "pointer",
-  fontSize: "13px",
+  fontSize: "11.5px",
   margin: 0,
   marginTop: "-3px",
+  marginLeft: "3px",
   padding: 0,
   minWidth: 0,
   textTransform: "none",

--- a/src/components/DataSubmissions/MetadataUpload.tsx
+++ b/src/components/DataSubmissions/MetadataUpload.tsx
@@ -96,9 +96,10 @@ const StyledTooltip = styled(Tooltip)(() => ({
 const StyledModelVersionText = styled(Typography)({
   color: "#000",
   fontWeight: 400,
-  fontSize: "13px",
+  fontSize: "11.5px",
   textTransform: "uppercase",
   "& a": {
+    paddingLeft: "3px",
     color: "#005A9E",
     fontWeight: 700,
     textTransform: "none",


### PR DESCRIPTION
### Overview

Adjusted per KC request (smaller font, more gap between version label and the version itself). I left the font color alone since it's still what the design uses. 

LMK if it needs to be adjusted further. 

### Change Details (Specifics)

N/A

### Related Ticket(s)

N/A
