### PR TITLE
fix: ErrorDetailsDialog should scroll on page body, not dialog body

### DIFF
--- a/src/components/ErrorDetailsDialog/index.tsx
+++ b/src/components/ErrorDetailsDialog/index.tsx
@@ -145,6 +145,7 @@ const ErrorDetailsDialog = ({
       onClose={handleCloseDialog}
       data-testid="error-details-dialog"
       aria-labelledby="error-details-title"
+      scroll="body"
       {...rest}
     >
       <StyledCloseDialogButton


### PR DESCRIPTION
### Overview

Fixes an issue where, when the content of the Error details dialog is very tall, the dialog shows a scrollbar inside itself instead of using the page body to scroll. 

This doesn't need to be merged before the demo.

### Change Details (Specifics)

N/A

### Related Ticket(s)

CRDCDH-2149