### PR TITLE
CRDCDH-2331 Remove `z-index` from footer

### DIFF
--- a/src/components/Footer/FooterDesktop.tsx
+++ b/src/components/Footer/FooterDesktop.tsx
@@ -8,7 +8,6 @@ const StyledFooter = styled("footer")({
   borderTop: "1px solid #6C727B",
   bottom: 0,
   width: "100%",
-  zIndex: 10,
   position: "relative",
 });
 

--- a/src/components/Footer/FooterMobile.tsx
+++ b/src/components/Footer/FooterMobile.tsx
@@ -7,7 +7,6 @@ const StyledFooter = styled("footer")({
   backgroundColor: "#1B496E",
   bottom: 0,
   width: "100%",
-  zIndex: 10,
   position: "relative",
 });
 

--- a/src/components/Footer/FooterTablet.tsx
+++ b/src/components/Footer/FooterTablet.tsx
@@ -8,7 +8,6 @@ const StyledFooter = styled("footer")({
   borderTop: "1px solid #6C727B",
   bottom: 0,
   width: "100%",
-  zIndex: 10,
   position: "relative",
 });
 


### PR DESCRIPTION
### Overview

PR to remove z-index from the footer, which causes it to overlap with page content. 

### Change Details (Specifics)

N/A

### Related Ticket(s)

CRDCDH-2331
