### PR TITLE
fix: Close button not centered

### DIFF
--- a/src/components/ErrorDetailsDialog/index.tsx
+++ b/src/components/ErrorDetailsDialog/index.tsx
@@ -36,6 +36,7 @@ const StyledCloseButton = styled(Button)({
   letterSpacing: "0.32px",
   textTransform: "none",
   alignSelf: "center",
+  margin: "0 auto",
   marginTop: "45px",
 });
 


### PR DESCRIPTION
### Overview

Fix the ErrorDetailsDialog "Close" button not being centered. Unsure when this broke

### Change Details (Specifics)

N/A

### Related Ticket(s)

N/A
