### PR TITLE
CRDCDH-2454 Incorrect verbiage for restoring deleted SRs

### DIFF
--- a/src/components/CancelApplicationButton/index.test.tsx
+++ b/src/components/CancelApplicationButton/index.test.tsx
@@ -788,7 +788,7 @@ describe("Implementation Requirements", () => {
     }
   );
 
-  it("should render tailored dialog content for the 'Restore' variant", async () => {
+  it("should render tailored dialog content for the 'Restore' variant from Canceled", async () => {
     const { getByRole, getByTestId } = render(
       <Button
         application={{
@@ -816,6 +816,37 @@ describe("Implementation Requirements", () => {
     expect(getByTestId("delete-dialog-header")).toHaveTextContent("Restore Submission Request");
     expect(getByTestId("delete-dialog-description")).toHaveTextContent(
       "Are you sure you want to restore the previously canceled submission request for the study listed below?"
+    ); // Ignore study info, that is checked elsewhere
+  });
+
+  it("should render tailored dialog content for the 'Restore' variant from Deleted", async () => {
+    const { getByRole, getByTestId } = render(
+      <Button
+        application={{
+          ...baseApp,
+          status: "Deleted",
+          applicant: { ...baseApp.applicant, applicantID: "owner" },
+        }}
+      />,
+      {
+        wrapper: ({ children }) => (
+          <TestParent
+            user={{ ...baseUser, _id: "owner", permissions: ["submission_request:cancel"] }}
+          >
+            {children}
+          </TestParent>
+        ),
+      }
+    );
+
+    userEvent.click(getByTestId("cancel-restore-application-button"));
+
+    const dialog = getByRole("dialog");
+    expect(dialog).toBeInTheDocument();
+
+    expect(getByTestId("delete-dialog-header")).toHaveTextContent("Restore Submission Request");
+    expect(getByTestId("delete-dialog-description")).toHaveTextContent(
+      "Are you sure you want to restore the previously deleted submission request for the study listed below?"
     ); // Ignore study info, that is checked elsewhere
   });
 

--- a/src/components/CancelApplicationButton/index.tsx
+++ b/src/components/CancelApplicationButton/index.tsx
@@ -67,6 +67,8 @@ const CancelApplicationButton = ({ application, onCancel, disabled, ...rest }: P
 
   const isRestoreAction = useMemo<boolean>(() => RESTORE_STATUSES.includes(status), [status]);
 
+  const isFromDeletedStatus = useMemo<boolean>(() => status === "Deleted", [status]);
+
   const textValues = useMemo(
     () => ({
       icon: isRestoreAction ? (
@@ -77,7 +79,9 @@ const CancelApplicationButton = ({ application, onCancel, disabled, ...rest }: P
       tooltipText: `${isRestoreAction ? "Restore" : "Cancel"} submission request`,
       dialogTitle: `${isRestoreAction ? "Restore" : "Cancel"} Submission Request`,
       dialogDescription: isRestoreAction
-        ? `Are you sure you want to restore the previously canceled submission request for the study listed below?`
+        ? `Are you sure you want to restore the previously ${
+            isFromDeletedStatus ? "deleted" : "canceled"
+          } submission request for the study listed below?`
         : `Are you sure you want to cancel the submission request for the study listed below?`,
     }),
     [isRestoreAction]


### PR DESCRIPTION
### Overview

PR to update the verbiage used in the "Restore Submission Request" dialog when restoring DELETED submission requests.

### Change Details (Specifics)

- Change the phrase "[...] previously canceled" to "[...] previously deleted" when restoring a Deleted SR
- Update test coverage for this

### Related Ticket(s)

CRDCDH-2454
