### PR TITLE
CRDCDH-2418 Update Submission Requests URL

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -3,6 +3,16 @@ server {
      server_name  localhost;
      root   /usr/share/nginx/html;
 
+    # 3.3.0 MIGRATION: Redirect /submissions to /submission-requests
+    location /submissions {
+        return 301 /submission-requests$is_args$args;
+    }
+    
+    # 3.3.0 MIGRATION: Redirect /submission/:uuid to submission-request/:uuid
+    location ~ ^/submission/([a-zA-Z0-9-]+)$ {
+        return 301 /submission-request/$1;
+    }
+
      location / {
          try_files $uri $uri/ /index.html;
      }

--- a/docs/Nginx.md
+++ b/docs/Nginx.md
@@ -36,6 +36,16 @@ http {
         listen       0.0.0.0:4010;
         server_name  localhost;
 
+        # 3.3.0 MIGRATION: Redirect /submissions to /submission-requests
+        location /submissions {
+            return 301 /submission-requests$is_args$args;
+        }
+        
+        # 3.3.0 MIGRATION: Redirect /submission/:uuid to submission-request/:uuid
+        location ~ ^/submission/([a-zA-Z0-9-]+)$ {
+            return 301 /submission-request/$1;
+        }
+
         # Authn
         location /api/authn/ {
             # proxy_pass http://localhost:4030/api/authn/;

--- a/src/components/ExportRequestButton/pdf/Generate.ts
+++ b/src/components/ExportRequestButton/pdf/Generate.ts
@@ -122,7 +122,7 @@ const writeHeader = (doc: JsPDF, request: Application): number => {
   // Click to view (overlapping link)
   doc.setTextColor(...COLOR_HYPERLINK);
   doc.textWithLink("here", CONTENT_MARGIN + 22, y, {
-    url: `${env.REACT_APP_NIH_REDIRECT_URL}/submission/${request._id}`,
+    url: `${env.REACT_APP_NIH_REDIRECT_URL}/submission-request/${request._id}`,
     align: "left",
   });
 

--- a/src/components/ProgressBar/ProgressBar.tsx
+++ b/src/components/ProgressBar/ProgressBar.tsx
@@ -105,7 +105,7 @@ const ProgressBar: FC<Props> = ({ section }) => {
       newSections.push({
         title,
         id,
-        url: `/submission/${_id}/${s}`,
+        url: `/submission-request/${_id}/${s}`,
         icon: status,
         selected: s === section,
       });

--- a/src/components/Questionnaire/FormContainer.tsx
+++ b/src/components/Questionnaire/FormContainer.tsx
@@ -91,7 +91,7 @@ const FormContainer = forwardRef<HTMLDivElement, Props>(
     const { readOnlyInputs } = useFormMode();
 
     const returnToSubmissions = () => {
-      navigate("/submissions");
+      navigate("/submission-requests");
     };
 
     return (

--- a/src/config/HeaderConfig.ts
+++ b/src/config/HeaderConfig.ts
@@ -27,7 +27,7 @@ export const HeaderLinks: NavBarItem[] = [
   },
   {
     name: "Submission Requests",
-    link: "/submissions",
+    link: "/submission-requests",
     id: "navbar-dropdown-submission-requests",
     className: "navMobileItem",
   },

--- a/src/content/dataSubmissions/DataSubmissionsListView.tsx
+++ b/src/content/dataSubmissions/DataSubmissionsListView.tsx
@@ -218,7 +218,7 @@ const columns: Column<T>[] = [
 ];
 
 /**
- * View for List of Questionnaire/Submissions
+ * View for List of Data Submissions
  *
  * @returns {JSX.Element}
  */

--- a/src/content/index.tsx
+++ b/src/content/index.tsx
@@ -181,12 +181,7 @@ const Home: FC = () => {
               Please login with a Login.gov account to make a data submission request or to upload
               data for approved submissions
             </div>
-            <Link
-              id="loginPageLoginButton"
-              className="loginPageLoginButton"
-              to="/login"
-              state={{ redirectState: "/submissions" }}
-            >
+            <Link id="loginPageLoginButton" className="loginPageLoginButton" to="/login">
               <strong>Log In</strong>
             </Link>
           </div>

--- a/src/content/questionnaire/FormView.tsx
+++ b/src/content/questionnaire/FormView.tsx
@@ -164,10 +164,10 @@ const FormView: FC<Props> = ({ section }: Props) => {
   const sectionKeys = Object.keys(map);
   const sectionIndex = sectionKeys.indexOf(activeSection);
   const prevSection = sectionKeys[sectionIndex - 1]
-    ? `/submission/${data?.["_id"]}/${sectionKeys[sectionIndex - 1]}`
+    ? `/submission-request/${data?.["_id"]}/${sectionKeys[sectionIndex - 1]}`
     : null;
   const nextSection = sectionKeys[sectionIndex + 1]
-    ? `/submission/${data?.["_id"]}/${sectionKeys[sectionIndex + 1]}`
+    ? `/submission-request/${data?.["_id"]}/${sectionKeys[sectionIndex + 1]}`
     : null;
   const isSectionD = activeSection === "D";
   const formContentRef = useRef(null);
@@ -228,7 +228,7 @@ const FormView: FC<Props> = ({ section }: Props) => {
     try {
       const r = await submitData();
       setOpenSubmitDialog(false);
-      navigate("/submissions");
+      navigate("/submission-requests");
 
       return r;
     } catch (err) {
@@ -258,7 +258,7 @@ const FormView: FC<Props> = ({ section }: Props) => {
     const res = await approveForm(reviewComment, true);
     setOpenApproveDialog(false);
     if (res?.status === "success") {
-      navigate("/submissions");
+      navigate("/submission-requests");
     } else {
       enqueueSnackbar(
         res.errorMessage || "An error occurred while approving the form. Please try again.",
@@ -292,7 +292,7 @@ const FormView: FC<Props> = ({ section }: Props) => {
         variant: "error",
       });
     } else {
-      navigate("/submissions");
+      navigate("/submission-requests");
     }
     setOpenInquireDialog(false);
     return res;
@@ -320,7 +320,7 @@ const FormView: FC<Props> = ({ section }: Props) => {
         variant: "error",
       });
     } else {
-      navigate("/submissions");
+      navigate("/submission-requests");
     }
     setOpenRejectDialog(false);
     return res;
@@ -345,7 +345,7 @@ const FormView: FC<Props> = ({ section }: Props) => {
 
     const res = await reopenForm();
     if (!res) {
-      navigate("/submissions", {
+      navigate("/submission-requests", {
         state: {
           error: "An error occurred while marking the form as In Progress. Please try again.",
         },
@@ -414,7 +414,7 @@ const FormView: FC<Props> = ({ section }: Props) => {
       saveResult.id !== data?.["_id"]
     ) {
       // NOTE: This currently triggers a form data refetch, which is not ideal
-      navigate(`/submission/${saveResult.id}/${activeSection}`, { replace: true });
+      navigate(`/submission-request/${saveResult.id}/${activeSection}`, { replace: true });
     }
 
     if (saveResult?.status === "success") {
@@ -493,7 +493,7 @@ const FormView: FC<Props> = ({ section }: Props) => {
   const saveAndNavigate = async () => {
     // Wait for the save handler to complete
     const res = await saveForm();
-    const reviewSectionUrl = `/submission/${data["_id"]}/REVIEW`; // TODO: Update to dynamic url instead
+    const reviewSectionUrl = `/submission-request/${data["_id"]}/REVIEW`; // TODO: Update to dynamic url instead
     const isNavigatingToReviewSection = blocker?.location?.pathname === reviewSectionUrl;
 
     setBlockedNavigate(false);
@@ -637,7 +637,7 @@ const FormView: FC<Props> = ({ section }: Props) => {
 
   // Redirect to ListView if no data is found and the form is in the error state
   if (status === FormStatus.ERROR && !data?._id) {
-    return <Navigate to="/submissions" state={{ error: error || "Unknown error" }} />;
+    return <Navigate to="/submission-requests" state={{ error: error || "Unknown error" }} />;
   }
 
   return (

--- a/src/content/questionnaire/ListView.test.tsx
+++ b/src/content/questionnaire/ListView.test.tsx
@@ -192,8 +192,8 @@ describe("ListView Component", () => {
     userEvent.click(button);
 
     await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith("/submission/new-application-id", {
-        state: { from: "/submissions" },
+      expect(mockNavigate).toHaveBeenCalledWith("/submission-request/new-application-id", {
+        state: { from: "/submission-requests" },
       });
     });
   });
@@ -223,8 +223,8 @@ describe("ListView Component", () => {
     userEvent.click(button);
 
     await waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith("/submission/new", {
-        state: { from: "/submissions" },
+      expect(mockNavigate).toHaveBeenCalledWith("/submission-request/new", {
+        state: { from: "/submission-requests" },
       });
     });
   });

--- a/src/content/questionnaire/ListView.tsx
+++ b/src/content/questionnaire/ListView.tsx
@@ -215,7 +215,10 @@ const columns: Column<T>[] = [
             ["New", "In Progress", "Inquired"].includes(a.status)
           ) {
             return (
-              <Link to={`/submission/${a?.["_id"]}`} state={{ from: "/submissions" }}>
+              <Link
+                to={`/submission-request/${a?.["_id"]}`}
+                state={{ from: "/submission-requests" }}
+              >
                 <StyledActionButton bg="#99E3BB" text="#156071" border="#63BA90">
                   Resume
                 </StyledActionButton>
@@ -239,7 +242,7 @@ const columns: Column<T>[] = [
           }
 
           return (
-            <Link to={`/submission/${a?.["_id"]}`} state={{ from: "/submissions" }}>
+            <Link to={`/submission-request/${a?.["_id"]}`} state={{ from: "/submission-requests" }}>
               <StyledActionButton bg="#89DDE6" text="#156071" border="#84B4BE">
                 View
               </StyledActionButton>
@@ -272,7 +275,7 @@ const columns: Column<T>[] = [
 ];
 
 /**
- * View for List of Questionnaire/Submissions
+ * View for List of Submission Requests
  *
  * @returns {JSX.Element}
  */
@@ -340,8 +343,8 @@ const ListingView: FC = () => {
       return;
     }
 
-    navigate(`/submission/${d?.saveApplication?.["_id"] || "new"}`, {
-      state: { from: "/submissions" },
+    navigate(`/submission-request/${d?.saveApplication?.["_id"] || "new"}`, {
+      state: { from: "/submission-requests" },
     });
   };
 
@@ -395,9 +398,9 @@ const ListingView: FC = () => {
   const handleOnReviewClick = useCallback(
     async ({ _id, status }: T) => {
       if (status !== "Submitted") {
-        navigate(`/submission/${_id}`, {
+        navigate(`/submission-request/${_id}`, {
           state: {
-            from: "/submissions",
+            from: "/submission-requests",
           },
         });
         return;
@@ -414,9 +417,9 @@ const ListingView: FC = () => {
           throw new Error("Unable to review Submission Request.");
         }
 
-        navigate(`/submission/${_id}`, {
+        navigate(`/submission-request/${_id}`, {
           state: {
-            from: "/submissions",
+            from: "/submission-requests",
           },
         });
       } catch (err) {

--- a/src/content/questionnaire/sections/A.tsx
+++ b/src/content/questionnaire/sections/A.tsx
@@ -117,7 +117,7 @@ const FormSectionA: FC<FormSectionProps> = ({ SectionOption, refs }: FormSection
   }, [refs]);
 
   useEffect(() => {
-    if (location?.state?.from === "/submissions") {
+    if (location?.state?.from === "/submission-requests") {
       return;
     }
 

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -45,11 +45,11 @@ const routes: RouteObject[] = [
         element: <ReleaseNotes />,
       },
       {
-        path: "/submissions",
+        path: "/submission-requests",
         element: (
           <RequireAuth
             component={<Questionnaire />}
-            redirectPath="/submissions"
+            redirectPath="/submission-requests"
             redirectName="Submission Requests"
           />
         ),
@@ -75,11 +75,11 @@ const routes: RouteObject[] = [
         ),
       },
       {
-        path: "/submission/:appId/:section?",
+        path: "/submission-request/:appId/:section?",
         element: (
           <RequireAuth
             component={<Questionnaire />}
-            redirectPath="/submissions"
+            redirectPath="/submission-requests"
             redirectName="Submission Requests"
           />
         ),


### PR DESCRIPTION
### Overview

This PR renames the Submission Request URL from "/submission[s]" to "/submission-request[s]", and provides a SEO-friendly redirect within our Nginx config.

> [!Warning]
> Some notes about the Nginx redirect:
>
> - The redirect only works when navigating from an external browser action, such as a bookmark or link from another application. Any **outdated** links from within our application will result in a 404 page, but I think I updated every outdated reference.
> - The redirect will forward any query parameters for the list page only (e.g. applied filters). I didn't forward the query params on the individual submission-request URL since I don't think we use them there.

### Change Details (Specifics)

- Rename `/submissions` and `/submission/{_ID}` to `/submission-requests` and `/submission-request/{_ID}`, respectively
- Create SEO-friendly (HTTP 301) redirects from the old URLs to the new ones
- Update all application-level references to the outdated URLs
- Remove the homepage redirect to submission requests after login (I don't think it was ever supposed to do that?)

### Related Ticket(s)

CRDCDH-2418 (FE Task)
CRDCDH-2385 (US)