### PR TITLE
CRDCDH-2450 Add react-specific caching policies

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -13,8 +13,22 @@ server {
         return 301 /submission-request/$1;
     }
 
-     location / {
-         try_files $uri $uri/ /index.html;
+    location / {
+        location ~ index.html {
+            add_header Cache-Control "private, no-cache, no-store, must-revalidate";
+            add_header Expires "Sat, 01 Jan 2000 00:00:00 GMT";
+            add_header Pragma no-cache;
+        }
+
+        location ~ js/injectEnv.js {
+            expires 1h;
+        }
+
+        location ~* \.(gif|jpe?g|png|webp|ico|svg|css|js|mp4)$ {
+            expires 1M;
+        }
+            
+        try_files $uri $uri/ /index.html;
      }
 
      location /nginx_status {

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -15,9 +15,9 @@ server {
 
     location / {
         location ~ index.html {
-            add_header Cache-Control "private, no-cache, no-store, must-revalidate";
-            add_header Expires "Sat, 01 Jan 2000 00:00:00 GMT";
-            add_header Pragma no-cache;
+            expires -1;
+            if_modified_since off;
+            etag off;
         }
 
         location ~ js/injectEnv.js {


### PR DESCRIPTION
### Overview

This PR changes the production Nginx caching policies to align with a more React-specific deployment. Specifically:

- Enforce NO caching on the index.html file, which references the React chunks
- Enforce 1hr max cache on the injectEnv.js file
- Enforce a 1mo cache duration for most static assets

These are somewhat arbitrary baselines, but we can adjust as needed.

### Change Details (Specifics)

N/A

### Related Ticket(s)

CRDCDH-2450 (Task)
