### PR TITLE
CRDCDH-2470 Skip duplicate node relationships in Model Navigator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10546,8 +10546,8 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/data-model-navigator": {
-      "version": "1.2.1",
-      "resolved": "git+ssh://git@github.com/CBIIT/Data-Model-Navigator.git#a6eaaef486e11ed0a652e9b13894267fc9f9bab9",
+      "version": "1.2.2",
+      "resolved": "git+ssh://git@github.com/CBIIT/Data-Model-Navigator.git#14b03bd6d5af3d3b2895f3be6bd0f4c37f4537c8",
       "license": "ISC",
       "dependencies": {
         "@material-ui/core": "^4.12.4",


### PR DESCRIPTION
### Overview

PR to address an issue where Data Models might (incorrectly) duplicate relationships between nodes, and that duplicate relationship results in the loading template (TSV) containing the column for the parent ID twice.

This is present in the CTDC Data Model for Data File node.

### Change Details (Specifics)

- Upgrade DMN to v1.2.2 https://github.com/CBIIT/Data-Model-Navigator/commit/5b3999470f65b63459888c5c990adad027242a35

### Related Ticket(s)

CRDCDH-2470 (Bug)
