### PR TITLE
CRDCDH-2502 508 Accessibility Regressions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10546,8 +10546,8 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/data-model-navigator": {
-      "version": "1.2.2",
-      "resolved": "git+ssh://git@github.com/CBIIT/Data-Model-Navigator.git#14b03bd6d5af3d3b2895f3be6bd0f4c37f4537c8",
+      "version": "1.2.4",
+      "resolved": "git+ssh://git@github.com/CBIIT/Data-Model-Navigator.git#f1a936964b1ae013a395711374c4ec1c421eed6b",
       "license": "ISC",
       "dependencies": {
         "@material-ui/core": "^4.12.4",

--- a/src/components/AdminPortal/Organizations/StudyTooltip.tsx
+++ b/src/components/AdminPortal/Organizations/StudyTooltip.tsx
@@ -3,10 +3,10 @@ import { Typography, styled } from "@mui/material";
 import Tooltip from "../../Tooltip";
 import { formatFullStudyName } from "../../../utils";
 
-const StyledStudyCount = styled(Typography)<{ component: ElementType }>(({ theme }) => ({
+const StyledStudyCount = styled(Typography)<{ component: ElementType }>(() => ({
   textDecoration: "underline",
   cursor: "pointer",
-  color: theme.palette.primary.main,
+  color: "#0B6CB1",
 }));
 
 const StyledList = styled("ul")({

--- a/src/components/AdminPortal/Studies/ApprovedStudyFilters.tsx
+++ b/src/components/AdminPortal/Studies/ApprovedStudyFilters.tsx
@@ -166,7 +166,7 @@ const ApprovedStudyFilters = ({ onChange }: Props) => {
           }}
         />
       </StyledFormControl>
-      <StyledInlineLabel htmlFor="status-filter">Access Type</StyledInlineLabel>
+      <StyledInlineLabel htmlFor="accessType-filter">Access Type</StyledInlineLabel>
       <StyledFormControl>
         <Controller
           name="accessType"

--- a/src/components/Carousel/index.tsx
+++ b/src/components/Carousel/index.tsx
@@ -59,11 +59,6 @@ const StyledWrapper = styled("div", {
   },
 }));
 
-const removeAriaHidden = () => {
-  const elements = document.querySelectorAll(".react-multi-carousel-item");
-  elements.forEach((e) => e.removeAttribute("aria-hidden"));
-};
-
 /**
  * Provides a general carousel component for displaying multiple items
  * at the same time.
@@ -84,7 +79,6 @@ const ContentCarousel: FC<Props> = ({ children, locked, ...props }: Props) => {
         draggable={!locked}
         arrows={!locked}
         beforeChange={handleBeforeChange}
-        afterChange={removeAriaHidden}
         itemClass="custom-carousel-item"
         customLeftArrow={<CustomLeftArrow />}
         customRightArrow={<CustomRightArrow />}

--- a/src/components/DataSubmissions/ValidationStatistics.stories.tsx
+++ b/src/components/DataSubmissions/ValidationStatistics.stories.tsx
@@ -1,0 +1,95 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import ValidationStatistics from "./ValidationStatistics";
+
+type CustomStoryProps = React.ComponentProps<typeof ValidationStatistics>;
+
+const meta: Meta<CustomStoryProps> = {
+  title: "Data Submissions / Validation Statistics",
+  component: ValidationStatistics,
+  tags: ["autodocs"],
+  argTypes: {
+    dataSubmission: {
+      control: false,
+    },
+    statistics: {
+      control: false,
+    },
+  },
+} satisfies Meta<CustomStoryProps>;
+
+type Story = StoryObj<CustomStoryProps>;
+
+const mockData: SubmissionStatistic[] = [
+  {
+    nodeName: "mock-node",
+    total: 200,
+    new: 50,
+    passed: 50,
+    warning: 50,
+    error: 50,
+  },
+  {
+    nodeName: "mock-node-2",
+    total: 75,
+    new: 10,
+    passed: 50,
+    warning: 15,
+    error: 0,
+  },
+  {
+    nodeName: "mock-node-3",
+    total: 300,
+    new: 0,
+    passed: 0,
+    warning: 0,
+    error: 300,
+  },
+  {
+    nodeName: "mock-node-4",
+    total: 150,
+    new: 125,
+    passed: 25,
+    warning: 0,
+    error: 0,
+  },
+  {
+    nodeName: "mock-node-5",
+    total: 400,
+    new: 380,
+    passed: 0,
+    warning: 20,
+    error: 0,
+  },
+  {
+    nodeName: "mock-node-6",
+    total: 100,
+    new: 50,
+    passed: 50,
+    warning: 0,
+    error: 0,
+  },
+];
+
+export const Default: Story = {
+  args: {
+    dataSubmission: {
+      _id: "mock id",
+    } as Submission,
+    statistics: [...mockData],
+  },
+};
+
+export const NoData: Story = {
+  args: {
+    dataSubmission: {
+      _id: "mock id",
+    } as Submission,
+    statistics: [],
+  },
+};
+
+export const Loading: Story = {
+  args: {},
+};
+
+export default meta;

--- a/src/components/NodeChart/index.tsx
+++ b/src/components/NodeChart/index.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback, useMemo, useState } from "react";
+import React, { FC, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Box, Typography, styled } from "@mui/material";
 import { PieChart, Pie, Label, Cell } from "recharts";
 import { isEqual } from "lodash";
@@ -50,9 +50,10 @@ const StyledChartContainer = styled(Box)({
 const NodeChart: FC<Props> = ({ label, centerCount, data }: Props) => {
   const [hoveredSlice, setHoveredSlice] = useState<PieSectorDataItem>(null);
 
-  const dataset: PieSectorDataItem[] = useMemo(() => data.filter(({ value }) => value > 0), [data]);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const dataset = useMemo<PieSectorDataItem[]>(() => data.filter(({ value }) => value > 0), [data]);
 
-  const showDefaultCenter: boolean = useMemo(
+  const showDefaultCenter = useMemo<boolean>(
     () => (dataset.length === 0 && hoveredSlice === null) || hoveredSlice?.value === 0,
     [dataset, hoveredSlice]
   );
@@ -72,8 +73,16 @@ const NodeChart: FC<Props> = ({ label, centerCount, data }: Props) => {
   const onMouseOver = useCallback((data) => setHoveredSlice(data), []);
   const onMouseLeave = useCallback(() => setHoveredSlice(null), []);
 
+  // NOTE: Remove accessibility attributes from the chart
+  // to prevent 508 violations when the parent container is not visible
+  useEffect(() => {
+    containerRef?.current
+      .querySelectorAll("g[tabindex]")
+      ?.forEach((e) => e.removeAttribute("tabindex"));
+  }, [containerRef]);
+
   return (
-    <StyledChartContainer>
+    <StyledChartContainer ref={containerRef}>
       {reformattedLabel && (
         <StyledPieChartLabel>
           <TruncatedText

--- a/src/components/TruncatedText/index.test.tsx
+++ b/src/components/TruncatedText/index.test.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { render, waitFor } from "@testing-library/react";
 import { axe } from "jest-axe";
 import userEvent from "@testing-library/user-event";
-import TruncatedText from ".";
+import TruncatedText from "./index";
 
 describe("Accessibility", () => {
   it("should have no violations", async () => {
@@ -152,6 +152,22 @@ describe("Basic Functionality", () => {
 
     expect(textLabel).toHaveStyle("color: red");
     expect(textLabel).toHaveStyle("margin-top: 90px");
+  });
+
+  it("should not forward the wrapperSx prop to the DOM element", () => {
+    const { getByTestId } = render(
+      <TruncatedText text="Styled text" wrapperSx={{ color: "red", marginTop: "90px" }} />
+    );
+
+    expect(getByTestId("truncated-text-wrapper")).not.toHaveAttribute("sx");
+  });
+
+  it("should not forward the labelSx prop to the DOM element", () => {
+    const { getByTestId } = render(
+      <TruncatedText text="Styled text" labelSx={{ color: "red", marginTop: "90px" }} />
+    );
+
+    expect(getByTestId("truncated-text-label")).not.toHaveAttribute("sx");
   });
 });
 

--- a/src/components/TruncatedText/index.tsx
+++ b/src/components/TruncatedText/index.tsx
@@ -11,7 +11,7 @@ const StyledText = styled("span")(() => ({
 }));
 
 const StyledTextWrapper = styled("span", {
-  shouldForwardProp: (p) => p !== "truncated" && p !== "underline",
+  shouldForwardProp: (p) => p !== "truncated" && p !== "underline" && p !== "sx",
 })<{ truncated: boolean; underline: boolean }>(({ truncated, underline }) => ({
   display: "block",
   textDecoration: truncated && underline ? "underline" : "none",
@@ -76,8 +76,8 @@ const TruncatedText: FC<Props> = ({
   underline = true,
   ellipsis = true,
   disableInteractiveTooltip = true,
-  wrapperSx,
-  labelSx,
+  wrapperSx = {},
+  labelSx = {},
 }: Props) => {
   const isTruncated = text?.length > maxCharacters;
   const displayText = isTruncated

--- a/src/content/ModelNavigator/NavigatorView.stories.tsx
+++ b/src/content/ModelNavigator/NavigatorView.stories.tsx
@@ -3,10 +3,12 @@ import NavigatorView from "./NavigatorView";
 import { DataCommonProvider } from "../../components/Contexts/DataCommonContext";
 import ErrorBoundary from "../../components/ErrorBoundary";
 import { DataCommons } from "../../config/DataCommons";
+import env from "../../env";
 
 type CustomStoryProps = React.ComponentProps<typeof NavigatorView> & {
   model: string;
   version?: string;
+  tier?: AppEnv["REACT_APP_DEV_TIER"];
 };
 
 const meta: Meta<CustomStoryProps> = {
@@ -22,18 +24,34 @@ const meta: Meta<CustomStoryProps> = {
     version: {
       control: "text",
       description: "The version of the model to display",
-      defaultValue: "latest",
+    },
+    tier: {
+      control: "select",
+      description: "The deployment tier",
+      options: ["dev", "dev2", "qa", "qa2", "stage", "prod"],
     },
   },
   parameters: { layout: "fullscreen" },
   decorators: [
-    (Story, context) => (
-      <ErrorBoundary key={`${context.args.model}-${context.args.version}`}>
-        <DataCommonProvider DataCommon={context.args.model}>
-          <Story />
-        </DataCommonProvider>
-      </ErrorBoundary>
-    ),
+    (Story, context) => {
+      try {
+        // Remove the model manifest from session storage
+        sessionStorage.removeItem("manifest");
+
+        // Set the dev tier to fetch the correct manifest from
+        env.REACT_APP_DEV_TIER = context.args.tier;
+      } catch (e) {
+        /* empty */
+      }
+
+      return (
+        <ErrorBoundary key={`${context.args.tier}-${context.args.model}-${context.args.version}`}>
+          <DataCommonProvider DataCommon={context.args.model}>
+            <Story />
+          </DataCommonProvider>
+        </ErrorBoundary>
+      );
+    },
   ],
 } satisfies Meta<CustomStoryProps>;
 
@@ -44,5 +62,6 @@ export const ModelNavigator: Story = {
   args: {
     model: "CDS",
     version: "latest",
+    tier: "dev",
   },
 };

--- a/src/content/ModelNavigator/NavigatorView.stories.tsx
+++ b/src/content/ModelNavigator/NavigatorView.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import NavigatorView from "./NavigatorView";
+import { DataCommonProvider } from "../../components/Contexts/DataCommonContext";
+import ErrorBoundary from "../../components/ErrorBoundary";
+import { DataCommons } from "../../config/DataCommons";
+
+type CustomStoryProps = React.ComponentProps<typeof NavigatorView> & {
+  model: string;
+  version?: string;
+};
+
+const meta: Meta<CustomStoryProps> = {
+  title: "Pages / Model Navigator",
+  component: NavigatorView,
+  args: {},
+  argTypes: {
+    model: {
+      control: "select",
+      description: "The model to display",
+      options: DataCommons.map((model) => model.name),
+    },
+    version: {
+      control: "text",
+      description: "The version of the model to display",
+      defaultValue: "latest",
+    },
+  },
+  parameters: { layout: "fullscreen" },
+  decorators: [
+    (Story, context) => (
+      <ErrorBoundary key={`${context.args.model}-${context.args.version}`}>
+        <DataCommonProvider DataCommon={context.args.model}>
+          <Story />
+        </DataCommonProvider>
+      </ErrorBoundary>
+    ),
+  ],
+} satisfies Meta<CustomStoryProps>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ModelNavigator: Story = {
+  args: {
+    model: "CDS",
+    version: "latest",
+  },
+};

--- a/src/content/questionnaire/ListFilters.tsx
+++ b/src/content/questionnaire/ListFilters.tsx
@@ -296,7 +296,7 @@ const ListFilters = ({ applicationData, onChange }: FilterProps) => {
                 size="small"
                 placeholder="Minimum 3 characters required"
                 inputProps={{
-                  "aria-labelledby": "submitter-name-filter",
+                  id: "submitter-name-filter",
                   "data-testid": "submitter-name-input",
                 }}
                 required
@@ -319,12 +319,12 @@ const ListFilters = ({ applicationData, onChange }: FilterProps) => {
                         {...params}
                         placeholder="Select programs"
                         inputProps={{
-                          "aria-labelledby": "programName-filter",
                           required: !programNameFilter?.length,
                           ...inputProps,
                         }}
                       />
                     )}
+                    id="programName-filter"
                     onChange={(_, value) => {
                       handleFilterChange("programName");
                       field.onChange(value);
@@ -346,7 +346,7 @@ const ListFilters = ({ applicationData, onChange }: FilterProps) => {
 
           <Grid item xs={3}>
             <StyledFormControl>
-              <StyledInlineLabel htmlFor="study-filter">Study</StyledInlineLabel>
+              <StyledInlineLabel htmlFor="study-name-filter">Study</StyledInlineLabel>
               <StyledTextField
                 {...register("studyName", {
                   setValueAs: (val) => val?.trim(),
@@ -357,7 +357,7 @@ const ListFilters = ({ applicationData, onChange }: FilterProps) => {
                 size="small"
                 placeholder="Minimum 3 characters required"
                 inputProps={{
-                  "aria-labelledby": "study-name-filter",
+                  id: "study-name-filter",
                   "data-testid": "study-name-input",
                 }}
                 required


### PR DESCRIPTION
### Overview

This PR addresses 508 accessibility regressions and/or new issues introduced over the span of 3.2.0 development.

> [!NOTE]
> Details on the Data Submission Statistics 508 issue:
> The carousel is (correctly) marking the containers that aren't visible as `aria-hidden`, but the nested charts have `tabindex` attributes on them, which causes a accessibility issue.
>
> The only working solution I could find for the 508 issues on the carousel was to override the tabIndex attributes on the pie chart elements by manipulating the DOM directly. Recharts does not seem to provide a way to pass props to the SVG's `<g>` element, which are the ones with the tabindex.
 
### Change Details (Specifics)

- Fix the following 508 issues in the core frontend app
  - Incorrect htmlFor attribute on accessType filter
  - `other X` studies color contrast
  - Bad reference on htmlFor attributes
  - aria-hidden elements should not be focusable
- Fix the following 508 issues in model navigator (https://github.com/CBIIT/Data-Model-Navigator/compare/28eeb0f2bae2f59c33825ccdeea123d82a56057f...f1a936964b1ae013a395711374c4ec1c421eed6b)
  - Autocomplete input missing aria-label
  - Scrollable region missing keyboard access
  - Buttons must have decernible text
  - Interactive controls must not be nested
  - Color contrast on "show more" button
- Added a story for the Model Navigator implementation
  - This is different from the storybook in the DMN package; this one uses our implementation to run, including fetching the manifest from our GitHub repo
- Added a story for the ValidationStatistics component
- Fix unrelated issue – TruncatedText was passing `sx` prop to the DOM element

### Related Ticket(s)

CRDCDH-2502 (Bug)