### PR TITLE
CRDCDH-2422 Reorganized package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,18 +18,11 @@
         "@mui/material": "^5.13.1",
         "@mui/utils": "^5.15.20",
         "@mui/x-date-pickers": "^6.8.0",
-        "@testing-library/jest-dom": "^5.16.5",
-        "@testing-library/react": "^13.4.0",
-        "@testing-library/user-event": "^13.5.0",
-        "@types/eslint": "^8.56.7",
-        "@types/react-transition-group": "^4.4.10",
         "amazon-quicksight-embedding-sdk": "^2.8.0",
         "data-model-navigator": "github:CBIIT/Data-Model-Navigator#CRDC-DH",
         "dayjs": "^1.11.8",
         "graphql": "^16.7.1",
         "graphql-tag": "^2.12.6",
-        "jest-axe": "^8.0.0",
-        "jest-fail-on-console": "^3.3.0",
         "jspdf": "^2.5.2",
         "lodash": "^4.17.21",
         "notistack": "^3.0.1",
@@ -61,6 +54,10 @@
         "@storybook/react-webpack5": "^8.6.4",
         "@storybook/test": "^8.6.4",
         "@storybook/testing-library": "^0.2.2",
+        "@testing-library/jest-dom": "^5.16.5",
+        "@testing-library/react": "^13.4.0",
+        "@testing-library/user-event": "^13.5.0",
+        "@types/eslint": "^8.56.7",
         "@types/jest": "^29.5.11",
         "@types/jest-axe": "^3.5.9",
         "@types/lodash": "^4.14.198",
@@ -68,6 +65,7 @@
         "@types/papaparse": "^5.3.14",
         "@types/react": "^18.2.42",
         "@types/react-dom": "^18.2.17",
+        "@types/react-transition-group": "^4.4.10",
         "@types/recharts": "^1.8.29",
         "@types/redux": "^3.6.0",
         "@types/redux-logger": "^3.0.10",
@@ -84,7 +82,9 @@
         "eslint-plugin-prettier": "^5.1.3",
         "eslint-plugin-storybook": "^0.9.0",
         "husky": "^8.0.3",
+        "jest-axe": "^8.0.0",
         "jest-canvas-mock": "^2.5.2",
+        "jest-fail-on-console": "^3.3.0",
         "prettier": "^3.1.1",
         "storybook": "^8.6.4",
         "storybook-addon-apollo-client": "^8.1.2",
@@ -99,7 +99,8 @@
     "node_modules/@adobe/css-tools": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.2.tgz",
-      "integrity": "sha512-baYZExFpsdkBNuvGKTKWCwKH57HRZLVtycZS05WTQNVOiXVSeAki3nU35zlRbToeMW8aHlJfyS+1C4BOv27q0A=="
+      "integrity": "sha512-baYZExFpsdkBNuvGKTKWCwKH57HRZLVtycZS05WTQNVOiXVSeAki3nU35zlRbToeMW8aHlJfyS+1C4BOv27q0A==",
+      "dev": true
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -3843,6 +3844,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
       "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
+      "dev": true,
       "dependencies": {
         "jest-get-type": "^29.6.3"
       },
@@ -3854,6 +3856,7 @@
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
       "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+      "dev": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
@@ -6902,6 +6905,7 @@
     },
     "node_modules/@testing-library/dom": {
       "version": "8.20.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
@@ -6919,6 +6923,7 @@
     },
     "node_modules/@testing-library/dom/node_modules/chalk": {
       "version": "4.1.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -6933,6 +6938,7 @@
     },
     "node_modules/@testing-library/jest-dom": {
       "version": "5.16.5",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@adobe/css-tools": "^4.0.1",
@@ -6953,6 +6959,7 @@
     },
     "node_modules/@testing-library/react": {
       "version": "13.4.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
@@ -6969,6 +6976,7 @@
     },
     "node_modules/@testing-library/user-event": {
       "version": "13.5.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.5"
@@ -6997,6 +7005,7 @@
     },
     "node_modules/@types/aria-query": {
       "version": "5.0.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/babel__core": {
@@ -7378,6 +7387,7 @@
       "version": "29.5.11",
       "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.11.tgz",
       "integrity": "sha512-S2mHmYIVe13vrm6q4kN6fLYYAka15ALQki/vgDC3mIukEOx8WJlv0kQPM+d4w8Gp6u0uSdKND04IlTXBv0rwnQ==",
+      "dev": true,
       "dependencies": {
         "expect": "^29.0.0",
         "pretty-format": "^29.0.0"
@@ -7406,6 +7416,7 @@
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
       "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
       "dependencies": {
         "@sinclair/typebox": "^0.27.8"
       },
@@ -7417,6 +7428,7 @@
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
       "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+      "dev": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -7432,12 +7444,14 @@
     "node_modules/@types/jest/node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA=="
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "dev": true
     },
     "node_modules/@types/jest/node_modules/@types/yargs": {
       "version": "17.0.32",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
       "integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
+      "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
       }
@@ -7446,6 +7460,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -7461,6 +7476,7 @@
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
       "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
@@ -7469,6 +7485,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
       "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
+      "dev": true,
       "dependencies": {
         "@jest/expect-utils": "^29.7.0",
         "jest-get-type": "^29.6.3",
@@ -7484,6 +7501,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
       "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
         "diff-sequences": "^29.6.3",
@@ -7498,6 +7516,7 @@
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
       "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+      "dev": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
@@ -7506,6 +7525,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
       "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+      "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
         "jest-diff": "^29.7.0",
@@ -7520,6 +7540,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
       "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
+      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
         "@jest/types": "^29.6.3",
@@ -7539,6 +7560,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
       "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+      "dev": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
         "@types/node": "*",
@@ -7555,6 +7577,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
       "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
@@ -7568,6 +7591,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -7668,6 +7692,7 @@
       "version": "18.2.17",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.17.tgz",
       "integrity": "sha512-rvrT/M7Df5eykWFxn6MYt5Pem/Dbyc1N8Y0S9Mrkw2WFCRiqUgw9P7ul2NpwsXCSM1DVdENzdG9J5SreqfAIWg==",
+      "dev": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -7795,6 +7820,7 @@
     },
     "node_modules/@types/testing-library__jest-dom": {
       "version": "5.14.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/jest": "*"
@@ -9503,6 +9529,7 @@
     },
     "node_modules/chalk": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -10243,6 +10270,7 @@
     },
     "node_modules/css.escape": {
       "version": "1.5.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cssdb": {
@@ -11609,6 +11637,7 @@
     },
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/dom-converter": {
@@ -14357,6 +14386,7 @@
     },
     "node_modules/indent-string": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -15028,6 +15058,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/jest-axe/-/jest-axe-8.0.0.tgz",
       "integrity": "sha512-4kNcNn7J0jPO4jANEYZOHeQ/tSBvkXS+MxTbX1CKbXGd0+ZbRGDn/v/8IYWI/MmYX15iLVyYRnRev9X3ksePWA==",
+      "dev": true,
       "dependencies": {
         "axe-core": "4.7.2",
         "chalk": "4.1.2",
@@ -15042,6 +15073,7 @@
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
       "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
       "dependencies": {
         "@sinclair/typebox": "^0.27.8"
       },
@@ -15052,12 +15084,14 @@
     "node_modules/jest-axe/node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA=="
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "dev": true
     },
     "node_modules/jest-axe/node_modules/axe-core": {
       "version": "4.7.2",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.7.2.tgz",
       "integrity": "sha512-zIURGIS1E1Q4pcrMjp+nnEh+16G56eG/MUllJH8yEvw7asDo7Ac9uhC9KIH5jzpITueEZolfYglnCGIuSBz39g==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -15066,6 +15100,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -15081,6 +15116,7 @@
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
       "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
@@ -15089,6 +15125,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
       "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
         "diff-sequences": "^29.6.3",
@@ -15103,6 +15140,7 @@
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
       "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+      "dev": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
@@ -15111,6 +15149,7 @@
       "version": "29.2.2",
       "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.2.2.tgz",
       "integrity": "sha512-4DkJ1sDPT+UX2MR7Y3od6KtvRi9Im1ZGLGgdLFLm4lPexbTaCgJW5NN3IOXlQHF7NSHY/VHhflQ+WoKtD/vyCw==",
+      "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
         "jest-diff": "^29.2.1",
@@ -15125,6 +15164,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
       "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
       "dependencies": {
         "@jest/schemas": "^29.6.3",
         "ansi-styles": "^5.0.0",
@@ -15138,6 +15178,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -15409,7 +15450,8 @@
     "node_modules/jest-fail-on-console": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/jest-fail-on-console/-/jest-fail-on-console-3.3.0.tgz",
-      "integrity": "sha512-J9rnFQvQwkcGJw01zCEKe2Uag+E926lFgIyaQGep2LqhQH7OCRHyD+tm/jnNoKlSRnOBO60DmzMjeQAVI3f5cw=="
+      "integrity": "sha512-J9rnFQvQwkcGJw01zCEKe2Uag+E926lFgIyaQGep2LqhQH7OCRHyD+tm/jnNoKlSRnOBO60DmzMjeQAVI3f5cw==",
+      "dev": true
     },
     "node_modules/jest-get-type": {
       "version": "27.5.1",
@@ -16606,6 +16648,7 @@
     },
     "node_modules/lz-string": {
       "version": "1.5.0",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "lz-string": "bin/bin.js"
@@ -17405,6 +17448,7 @@
     },
     "node_modules/min-indent": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -20170,6 +20214,7 @@
     },
     "node_modules/redent": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "indent-string": "^4.0.0",
@@ -21433,6 +21478,7 @@
     },
     "node_modules/strip-indent": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "min-indent": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -5,6 +5,22 @@
     "node": ">=22.0.0 <23.0.0",
     "npm": ">=10.0.0"
   },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "eject": "react-scripts eject",
+    "test": "TZ=UTC react-scripts test",
+    "test:ci": "TZ=UTC CI=true react-scripts test --passWithNoTests --coverage --maxWorkers=2 --maxConcurrent=2 --logHeapUsage --collectCoverageFrom=src/**/*.{js,ts,jsx,tsx} --collectCoverageFrom=!src/**/*.stories.{js,ts,jsx,tsx}",
+    "lint": "eslint . --ignore-path .gitignore",
+    "lint:ci": "eslint . --ignore-path .gitignore --max-warnings 0",
+    "lint:fix": "eslint --fix . --ignore-path .gitignore",
+    "format:fix": "prettier --ignore-path .gitignore --write \"**/*.{js,jsx,ts,tsx}\"",
+    "typecheck": "tsc --noEmit",
+    "prepare": "husky install",
+    "storybook": "storybook dev -p 6006",
+    "build-storybook": "storybook build",
+    "chromatic": "chromatic --exit-zero-on-changes"
+  },
   "dependencies": {
     "@apollo/client": "^3.9.8",
     "@axe-core/react": "^4.9.0",
@@ -16,18 +32,11 @@
     "@mui/material": "^5.13.1",
     "@mui/utils": "^5.15.20",
     "@mui/x-date-pickers": "^6.8.0",
-    "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^13.4.0",
-    "@testing-library/user-event": "^13.5.0",
-    "@types/eslint": "^8.56.7",
-    "@types/react-transition-group": "^4.4.10",
     "amazon-quicksight-embedding-sdk": "^2.8.0",
     "data-model-navigator": "github:CBIIT/Data-Model-Navigator#CRDC-DH",
     "dayjs": "^1.11.8",
     "graphql": "^16.7.1",
     "graphql-tag": "^2.12.6",
-    "jest-axe": "^8.0.0",
-    "jest-fail-on-console": "^3.3.0",
     "jspdf": "^2.5.2",
     "lodash": "^4.17.21",
     "notistack": "^3.0.1",
@@ -46,37 +55,6 @@
     "redux": "^4.2.1",
     "web-vitals": "^2.1.4"
   },
-  "overrides": {
-    "typescript": "^5.4.3"
-  },
-  "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
-    "eject": "react-scripts eject",
-    "test": "TZ=UTC react-scripts test",
-    "test:ci": "TZ=UTC CI=true react-scripts test --passWithNoTests --coverage --maxWorkers=2 --maxConcurrent=2 --logHeapUsage --collectCoverageFrom=src/**/*.{js,ts,jsx,tsx} --collectCoverageFrom=!src/**/*.stories.{js,ts,jsx,tsx}",
-    "lint": "eslint . --ignore-path .gitignore",
-    "lint:ci": "eslint . --ignore-path .gitignore --max-warnings 0",
-    "lint:fix": "eslint --fix . --ignore-path .gitignore",
-    "format:fix": "prettier --ignore-path .gitignore --write \"**/*.{js,jsx,ts,tsx}\"",
-    "typecheck": "tsc --noEmit",
-    "prepare": "husky install",
-    "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build",
-    "chromatic": "chromatic --exit-zero-on-changes"
-  },
-  "browserslist": {
-    "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
-    ],
-    "development": [
-      "last 1 chrome version",
-      "last 1 firefox version",
-      "last 1 safari version"
-    ]
-  },
   "devDependencies": {
     "@aws-sdk/client-quicksight": "^3.637.0",
     "@storybook/addon-a11y": "^8.6.4",
@@ -90,6 +68,10 @@
     "@storybook/react-webpack5": "^8.6.4",
     "@storybook/test": "^8.6.4",
     "@storybook/testing-library": "^0.2.2",
+    "@testing-library/jest-dom": "^5.16.5",
+    "@testing-library/react": "^13.4.0",
+    "@testing-library/user-event": "^13.5.0",
+    "@types/eslint": "^8.56.7",
     "@types/jest": "^29.5.11",
     "@types/jest-axe": "^3.5.9",
     "@types/lodash": "^4.14.198",
@@ -97,6 +79,7 @@
     "@types/papaparse": "^5.3.14",
     "@types/react": "^18.2.42",
     "@types/react-dom": "^18.2.17",
+    "@types/react-transition-group": "^4.4.10",
     "@types/recharts": "^1.8.29",
     "@types/redux": "^3.6.0",
     "@types/redux-logger": "^3.0.10",
@@ -113,11 +96,28 @@
     "eslint-plugin-prettier": "^5.1.3",
     "eslint-plugin-storybook": "^0.9.0",
     "husky": "^8.0.3",
+    "jest-axe": "^8.0.0",
     "jest-canvas-mock": "^2.5.2",
+    "jest-fail-on-console": "^3.3.0",
     "prettier": "^3.1.1",
     "storybook": "^8.6.4",
     "storybook-addon-apollo-client": "^8.1.2",
     "typescript": "^5.4.3",
     "webpack": "^5.98.0"
+  },
+  "overrides": {
+    "typescript": "^5.4.3"
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
   }
 }


### PR DESCRIPTION
### Overview

Reorganized the sections within package.json and moved deps between dependencies and devDependencies, to better reflect their purpose.

### Change Details (Specifics)

- Move deps between dependencies and devDependencies and vice versa. Also sorted them
- Moved "scripts" section closer to the top, and less important sections ("overrides", "browserlist") to the bottom

Notes:
- The "overrides" section should remain until we upgrade the TypeScript version. Otherwise if you have a newer global TypeScript version installed then there seems to be some conflicts.
- The "@typescript-eslint/eslint-plugin" can be slightly upgraded, but not enough to get rid of the "unsupported typescript version". This is due to CRA being deprecated and being a blocker. Will need to upgrade when we transition away from CRA.
- The "@axe-core/react" dep should be moved to devDeps, but the way we use it in src/index.tsx forces us to have it in deps.
- I upgraded a bunch of packages, but broke some stuff.. Will need to be PR'ed separately.

### Related Ticket(s)

[CRDCDH-2422](https://tracker.nci.nih.gov/browse/CRDCDH-2422)
