### PR TITLE
CRDCDH-2415 Fix Data File Size sorting by size instead of string

### DIFF
--- a/src/content/dataSubmissions/DataSubmissionsListView.tsx
+++ b/src/content/dataSubmissions/DataSubmissionsListView.tsx
@@ -186,7 +186,7 @@ const columns: Column<T>[] = [
     renderValue: (a) => a.dataFileSize.formatted || 0,
     hideable: true,
     defaultHidden: true,
-    field: "dataFileSize",
+    fieldKey: "dataFileSize.size",
     sx: {
       minWidth: "90px",
       width: "90px",


### PR DESCRIPTION
### Overview

The sorting for the "dataFileSize" field was sorting by string instead of the numerical size. Updated to use the number of bytes instead of sorting by string. 

### Change Details (Specifics)

N/A

### Related Ticket(s)

[CRDCDH-2415](https://tracker.nci.nih.gov/browse/CRDCDH-2415)
