### PR TITLE
DX: Add import order linting using ESLint

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -112,7 +112,7 @@ const config = {
     "import/order": [
       "error",
       {
-        groups: ["builtin", "external", "internal", ["parent", "sibling", "index"]],
+        groups: ["builtin", "external", "internal", "parent", ["sibling", "index"]],
         alphabetize: {
           order: "asc",
           caseInsensitive: true,

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -109,6 +109,17 @@ const config = {
         optionalDependencies: false,
       },
     ],
+    "import/order": [
+      "error",
+      {
+        groups: ["builtin", "external", "internal", ["parent", "sibling", "index"]],
+        alphabetize: {
+          order: "asc",
+          caseInsensitive: true,
+        },
+        "newlines-between": "always",
+      },
+    ],
 
     /* jest and testing-library rules */
     "testing-library/prefer-screen-queries": "off",


### PR DESCRIPTION
### Overview

This PR addresses a missing ESLint configuration regarding the sorting order of imports throughout our app (currently just arbitrary for the most part).

New required order:

1. Built-in packages (e.g. Node)
2. External packages (e.g. MUI, React, ...)
3. Internal (`@/app/xxx` – We don't use this)
4. Relative/Local imports
  a. parent imports (`../Context/AuthContext`)
  b. siblings (`./PackageTable.tsx`)
  c. index (example?)

Additionally, ESLint will insert x1 newline between the groups listed above. I don't have a preference on this, so I'm fine if we disable this.

This lint rule is compatible with auto-formatting. 

### Change Details (Specifics)

N/A

### Related Ticket(s)

N/A
