### PR TITLE
CRDCDH-2651 Bug: Fix reset button in column visibility popper

### DIFF
--- a/src/components/GenericTable/ColumnVisibilityPopper.test.tsx
+++ b/src/components/GenericTable/ColumnVisibilityPopper.test.tsx
@@ -9,11 +9,12 @@ type Column = {
   fieldKey?: string;
   label: string;
   hideable?: boolean;
+  defaultHidden?: boolean;
 };
 
 const columns: Column[] = [
   { field: "name", label: "Name", hideable: false },
-  { field: "age", label: "Age" },
+  { field: "age", label: "Age", defaultHidden: true },
   { field: "email", label: "Email" },
 ];
 
@@ -169,11 +170,10 @@ describe("ColumnVisibilityPopper", () => {
     });
   });
 
-  it("resets columns to visible", () => {
-    // Set age and email to false
+  it("should reset columns back to default", () => {
     columnVisibilityModel = {
-      name: true,
-      age: false,
+      name: false,
+      age: true,
       email: false,
     };
 
@@ -184,7 +184,7 @@ describe("ColumnVisibilityPopper", () => {
 
     expect(setColumnVisibilityModel).toHaveBeenCalledWith({
       name: true,
-      age: true,
+      age: false, // default hidden
       email: true,
     });
   });

--- a/src/hooks/useColumnVisibility.ts
+++ b/src/hooks/useColumnVisibility.ts
@@ -51,7 +51,7 @@ export const useColumnVisibility = <C>({
     columns.reduce<ColumnVisibilityModel>((adjustedModel, column) => {
       const key = getColumnKey(column);
       const isHideable = column.hideable !== false;
-      adjustedModel[key] = isHideable ? model[key] ?? !column.defaultHidden : true;
+      adjustedModel[key] = isHideable ? model?.[key] ?? !column.defaultHidden : true;
       return adjustedModel;
     }, {});
 


### PR DESCRIPTION
### Overview

Previously, the "RESET" button in the column visibility popper just set all columns to visible. This was updated to instead reset to default.

### Change Details (Specifics)

- Fixed "RESET" button in the column visibility popper to reset to default based on columns that are hidden by default
- Fixed issue where deleting local storage value for column visibility caused site to crash

### Related Ticket(s)

[CRDCDH-2651](https://tracker.nci.nih.gov/browse/CRDCDH-2651)
