### PR TITLE
CRDCDH-2472 Hotfix: Fix table page not persisting after page reload

### DIFF
--- a/src/components/InstitutionListFilters/index.tsx
+++ b/src/components/InstitutionListFilters/index.tsx
@@ -94,6 +94,9 @@ const InstitutionListFilters = ({ onChange }: Props) => {
   }, [searchParams?.get("name"), searchParams?.get("status")]);
 
   useEffect(() => {
+    if (!touchedFilters.name && !touchedFilters.status) {
+      return;
+    }
     const newSearchParams = new URLSearchParams(searchParams);
 
     if (statusFilter && statusFilter !== "All") {
@@ -108,10 +111,10 @@ const InstitutionListFilters = ({ onChange }: Props) => {
       newSearchParams.delete("name");
     }
 
-    if (newSearchParams.toString() !== searchParams.toString()) {
+    if (newSearchParams?.toString() !== searchParams?.toString()) {
       setSearchParams(newSearchParams);
     }
-  }, [nameFilter, statusFilter]);
+  }, [nameFilter, statusFilter, touchedFilters]);
 
   const handleFilterChange = (field: keyof FilterForm) => {
     setTouchedFilters((prev) => ({ ...prev, [field]: true }));

--- a/src/content/Institutions/ListView.tsx
+++ b/src/content/Institutions/ListView.tsx
@@ -2,6 +2,7 @@ import { useRef, useState } from "react";
 import { Box, Button, Container, Stack, styled, TableCell, TableHead } from "@mui/material";
 import { useLazyQuery } from "@apollo/client";
 import { Link } from "react-router-dom";
+import { isEqual } from "lodash";
 import usePageTitle from "../../hooks/usePageTitle";
 import FormAlert from "../../components/FormAlert";
 import PageBanner from "../../components/PageBanner";
@@ -166,6 +167,10 @@ const ListView = () => {
   };
 
   const handleOnFiltersChange = (data: FilterForm) => {
+    if (isEqual(data, filtersRef.current)) {
+      return;
+    }
+
     filtersRef.current = data;
     setTablePage(0);
   };


### PR DESCRIPTION
### Overview

Found additional issues while testing. Fixed issue where you select a page other than 1 and reload, but the page would not persist. Also, fixed issue where there was a lot of extra changes being made to search params with the same values, causing weird URL flicker.

### Change Details (Specifics)

N/A

### Related Ticket(s)

[CRDCDH-2472](https://tracker.nci.nih.gov/browse/CRDCDH-2472)
