### PR TITLE
CRDCDH-2624 Reset scroll position on navigate

### DIFF
--- a/src/components/ProgressBar/ProgressBar.tsx
+++ b/src/components/ProgressBar/ProgressBar.tsx
@@ -141,6 +141,7 @@ const ProgressBar: FC<Props> = ({ section }) => {
             data-testid={`progress-bar-section-${idx}`}
             aria-disabled={disabled || false}
             data-selected={selected || false}
+            preventScrollReset
           >
             <Stack direction="row" alignItems="center" justifyContent="center">
               <StyledAvatar>

--- a/src/content/questionnaire/FormView.tsx
+++ b/src/content/questionnaire/FormView.tsx
@@ -414,7 +414,10 @@ const FormView: FC<Props> = ({ section }: Props) => {
       saveResult.id !== data?.["_id"]
     ) {
       // NOTE: This currently triggers a form data refetch, which is not ideal
-      navigate(`/submission-request/${saveResult.id}/${activeSection}`, { replace: true });
+      navigate(`/submission-request/${saveResult.id}/${activeSection}`, {
+        replace: true,
+        preventScrollReset: true,
+      });
     }
 
     if (saveResult?.status === "success") {
@@ -572,7 +575,7 @@ const FormView: FC<Props> = ({ section }: Props) => {
     if (status === FormStatus.SAVING || !prevSection) {
       return;
     }
-    navigate(prevSection);
+    navigate(prevSection, { preventScrollReset: true });
   };
 
   const handleNextClick = () => {
@@ -582,7 +585,7 @@ const FormView: FC<Props> = ({ section }: Props) => {
     if (isSectionD && !allSectionsComplete) {
       return;
     }
-    navigate(nextSection);
+    navigate(nextSection, { preventScrollReset: true });
   };
 
   // Intercept browser navigation actions (e.g. closing the tab) with unsaved changes

--- a/src/layouts/index.tsx
+++ b/src/layouts/index.tsx
@@ -1,5 +1,5 @@
 import { FC, ReactNode } from "react";
-import { Outlet } from "react-router-dom";
+import { Outlet, ScrollRestoration } from "react-router-dom";
 import { styled } from "@mui/material";
 import Footer from "../components/Footer";
 import Header from "../components/Header";
@@ -19,9 +19,10 @@ type LayoutProps = {
 
 const Layout: FC<LayoutProps> = ({ children }) => (
   <SearchParamsProvider>
+    <ScrollRestoration />
     <Header />
-    <OverlayWindow />
     <StyledWrapper>
+      <OverlayWindow />
       {children || <Outlet />}
       <ScrollButton />
     </StyledWrapper>


### PR DESCRIPTION
### Overview

PR to simulate native browser functionality by moving the scroll position to the top of the page on navigate. The only exception is the Submission Request form, where the page should navigate to the top of the form (already implemented)

### Change Details (Specifics)

N/A

### Related Ticket(s)

CRDCDH-2624 (Task)
CRDCDH-2608 (US)