### PR TITLE
CRDCDH-2595 Allow Federal Lead role to manage the Federal Lead users

### DIFF
--- a/src/content/users/ListView.tsx
+++ b/src/content/users/ListView.tsx
@@ -284,7 +284,7 @@ const ListingView: FC = () => {
     if (newSearchParams?.toString() !== searchParams?.toString()) {
       setSearchParams(newSearchParams);
     }
-  }, [user?.role, roleFilter, statusFilter, touchedFilters]);
+  }, [roleFilter, statusFilter, touchedFilters]);
 
   const setTablePage = (page: number) => {
     tableRef.current?.setPage(page, true);

--- a/src/content/users/ListView.tsx
+++ b/src/content/users/ListView.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useRef, useState } from "react";
+import React, { FC, useEffect, useMemo, useRef, useState } from "react";
 import { useQuery } from "@apollo/client";
 import {
   Alert,
@@ -7,7 +7,6 @@ import {
   Container,
   FormControl,
   MenuItem,
-  Select,
   Stack,
   TableCell,
   TableHead,
@@ -22,6 +21,8 @@ import { compareStrings, formatIDP, sortData } from "../../utils";
 import usePageTitle from "../../hooks/usePageTitle";
 import GenericTable, { Column } from "../../components/GenericTable";
 import { useSearchParamsContext } from "../../components/Contexts/SearchParamsContext";
+import { useAuthContext } from "../../components/Contexts/AuthContext";
+import StyledSelect from "../../components/StyledFormComponents/StyledSelect";
 
 type T = ListUsersResp["listUsers"][number];
 
@@ -55,38 +56,6 @@ const StyledFormControl = styled(FormControl)({
 const StyledInlineLabel = styled("label")({
   padding: "0 10px",
   fontWeight: "700",
-});
-
-const StyledSelect = styled(Select)({
-  borderRadius: "8px",
-  "& .MuiInputBase-input": {
-    fontWeight: 400,
-    fontSize: "16px",
-    fontFamily: "'Nunito', 'Rubik', sans-serif",
-    padding: "10px",
-    height: "20px",
-  },
-  "& .MuiOutlinedInput-notchedOutline": {
-    borderColor: "#6B7294",
-  },
-  "&.Mui-focused .MuiOutlinedInput-notchedOutline": {
-    border: "1px solid #209D7D",
-    boxShadow:
-      "2px 2px 4px 0px rgba(38, 184, 147, 0.10), -1px -1px 6px 0px rgba(38, 184, 147, 0.20)",
-  },
-  "& .Mui-disabled": {
-    cursor: "not-allowed",
-  },
-  "& .MuiList-root": {
-    padding: "0 !important",
-  },
-  "& .MuiMenuItem-root.Mui-selected": {
-    background: "#3E7E6D !important",
-    color: "#FFFFFF !important",
-  },
-  "& .MuiMenuItem-root:hover": {
-    background: "#D5EDE5",
-  },
 });
 
 const StyledHeaderCell = styled(TableCell)({
@@ -214,6 +183,7 @@ const columns: Column<T>[] = [
 const ListingView: FC = () => {
   usePageTitle("Manage Users");
 
+  const { user } = useAuthContext();
   const { state } = useLocation();
   const { searchParams, setSearchParams } = useSearchParamsContext();
   const [dataset, setDataset] = useState<T[]>([]);
@@ -222,7 +192,7 @@ const ListingView: FC = () => {
 
   const { watch, setValue, control } = useForm<FilterForm>({
     defaultValues: {
-      role: "All",
+      role: user?.role === "Federal Lead" ? "Federal Lead" : "All",
       status: "All",
     },
   });
@@ -230,6 +200,14 @@ const ListingView: FC = () => {
   const roleFilter = watch("role");
   const statusFilter = watch("status");
   const tableRef = useRef<TableMethods>(null);
+
+  const filteredRoles: UserRole[] = useMemo(() => {
+    if (user?.role === "Federal Lead") {
+      return ["Federal Lead"];
+    }
+
+    return Roles;
+  }, [user?.role]);
 
   const { data, loading, error } = useQuery<ListUsersResp>(LIST_USERS, {
     context: { clientName: "backend" },
@@ -260,7 +238,7 @@ const ListingView: FC = () => {
   };
 
   const isRoleFilterOption = (role: string): role is FilterForm["role"] =>
-    ["All", ...Roles].includes(role);
+    ["All", ...filteredRoles].includes(role);
   const isStatusFilterOption = (status: string): status is FilterForm["status"] =>
     ["All", "Inactive", "Active"].includes(status);
 
@@ -285,9 +263,15 @@ const ListingView: FC = () => {
 
     const newSearchParams = new URLSearchParams(searchParams);
 
-    if (roleFilter && roleFilter !== "All") {
+    if (
+      roleFilter &&
+      ((user?.role === "Federal Lead" && roleFilter !== "Federal Lead") || roleFilter !== "All")
+    ) {
       newSearchParams.set("role", roleFilter);
-    } else if (roleFilter === "All") {
+    } else if (
+      roleFilter === "All" ||
+      (user?.role === "Federal Lead" && roleFilter === "Federal Lead")
+    ) {
       newSearchParams.delete("role");
     }
     if (statusFilter && statusFilter !== "All") {
@@ -330,6 +314,7 @@ const ListingView: FC = () => {
                 <StyledSelect
                   {...field}
                   value={field.value}
+                  disabled={user?.role === "Federal Lead"}
                   MenuProps={{ disablePortal: true }}
                   inputProps={{ id: "role-filter" }}
                   onChange={(e) => {
@@ -338,7 +323,7 @@ const ListingView: FC = () => {
                   }}
                 >
                   <MenuItem value="All">All</MenuItem>
-                  {Roles.map((role) => (
+                  {filteredRoles.map((role) => (
                     <MenuItem key={role} value={role}>
                       {role}
                     </MenuItem>

--- a/src/content/users/ListView.tsx
+++ b/src/content/users/ListView.tsx
@@ -265,7 +265,8 @@ const ListingView: FC = () => {
 
     if (
       roleFilter &&
-      ((user?.role === "Federal Lead" && roleFilter !== "Federal Lead") || roleFilter !== "All")
+      ((user?.role === "Federal Lead" && roleFilter !== "Federal Lead") ||
+        (user?.role !== "Federal Lead" && roleFilter !== "All"))
     ) {
       newSearchParams.set("role", roleFilter);
     } else if (
@@ -283,7 +284,7 @@ const ListingView: FC = () => {
     if (newSearchParams?.toString() !== searchParams?.toString()) {
       setSearchParams(newSearchParams);
     }
-  }, [roleFilter, statusFilter, touchedFilters]);
+  }, [user?.role, roleFilter, statusFilter, touchedFilters]);
 
   const setTablePage = (page: number) => {
     tableRef.current?.setPage(page, true);

--- a/src/content/users/ProfileView.tsx
+++ b/src/content/users/ProfileView.tsx
@@ -524,6 +524,7 @@ const ProfileView: FC<Props> = ({ _id, viewType }: Props) => {
                           {...field}
                           size="small"
                           onChange={(e) => handleRoleChange(field, e?.target?.value as UserRole)}
+                          disabled={fieldset.role === "DISABLED"}
                           MenuProps={{ disablePortal: true }}
                           inputProps={{ "aria-labelledby": "userRoleLabel" }}
                         >

--- a/src/hooks/useProfileFields.test.ts
+++ b/src/hooks/useProfileFields.test.ts
@@ -150,7 +150,24 @@ describe("Profile View", () => {
     }
   );
 
-  it.each<UserRole>(["Submitter", "Federal Lead"])(
+  it.each<UserRole>(["Federal Lead"])(
+    "should return UNLOCKED for all fields except role on the profile page for role %s modifying a Federal Lead",
+    (role) => {
+      const user = { _id: "User-A", role } as User;
+      const profileOf: Pick<User, "_id" | "role"> = { _id: "User-A", role: "Federal Lead" };
+
+      jest.spyOn(Auth, "useAuthContext").mockReturnValue({ user } as Auth.ContextState);
+
+      const { result } = renderHook(() => useProfileFields(profileOf, "profile"));
+
+      expect(result.current.role).toBe("DISABLED");
+      expect(result.current.userStatus).toBe("UNLOCKED");
+      expect(result.current.permissions).toBe("UNLOCKED");
+      expect(result.current.notifications).toBe("UNLOCKED");
+    }
+  );
+
+  it.each<UserRole>(["Submitter"])(
     "should return READ_ONLY for the studies field on the profile page for role %s",
     (role) => {
       const user = { _id: "User-A", role } as User;
@@ -192,13 +209,7 @@ describe("Profile View", () => {
     }
   );
 
-  it.each<UserRole>([
-    "User",
-    "Submitter",
-    "Federal Lead",
-    "Data Commons Personnel",
-    "fake role" as UserRole,
-  ])(
+  it.each<UserRole>(["User", "Submitter", "Data Commons Personnel", "fake role" as UserRole])(
     "should return DISABLED for the permissions and notifications panel on the profile page for role %s",
     (role) => {
       const user = { _id: "User-A", role } as User;

--- a/src/hooks/useProfileFields.test.ts
+++ b/src/hooks/useProfileFields.test.ts
@@ -122,6 +122,28 @@ describe("Users View", () => {
       expect(result.current.notifications).toBe("UNLOCKED");
     }
   );
+
+  it.each<UserRole>(["Admin", "Data Commons Personnel", "Federal Lead", "Submitter", "User"])(
+    "should return defaults for all fields on the users page for role %s when they do not have the user:manage permission",
+    (role) => {
+      const user = { _id: "User-A", role, permissions: [] } as User;
+      const profileOf: Pick<User, "_id" | "role"> = { _id: "User-A", role: "Federal Lead" };
+
+      jest.spyOn(Auth, "useAuthContext").mockReturnValue({ user } as Auth.ContextState);
+
+      const { result } = renderHook(() => useProfileFields(profileOf, "users"));
+
+      expect(result.current.firstName).toBe("READ_ONLY");
+      expect(result.current.lastName).toBe("READ_ONLY");
+      expect(result.current.role).toBe("READ_ONLY");
+      expect(result.current.userStatus).toBe("READ_ONLY");
+      expect(result.current.dataCommons).toBe("HIDDEN");
+      expect(result.current.studies).toBe("HIDDEN");
+      expect(result.current.institution).toBe("HIDDEN");
+      expect(result.current.permissions).toBe("HIDDEN");
+      expect(result.current.notifications).toBe("HIDDEN");
+    }
+  );
 });
 
 describe("Profile View", () => {

--- a/src/hooks/useProfileFields.ts
+++ b/src/hooks/useProfileFields.ts
@@ -102,6 +102,18 @@ const useProfileFields = (
     fields.dataCommons = "HIDDEN";
   }
 
+  if (profileOf?.role === "Federal Lead" && user?.role === "Federal Lead") {
+    fields.role = "DISABLED";
+    fields.userStatus = "UNLOCKED";
+    fields.permissions = "UNLOCKED";
+    fields.notifications = "UNLOCKED";
+
+    fields.studies = RequiresStudiesAssigned.includes(profileOf?.role) ? "UNLOCKED" : "HIDDEN";
+    fields.institution = RequiresInstitutionAssigned.includes(profileOf?.role)
+      ? "UNLOCKED"
+      : "HIDDEN";
+  }
+
   return fields;
 };
 

--- a/src/hooks/useProfileFields.ts
+++ b/src/hooks/useProfileFields.ts
@@ -107,11 +107,6 @@ const useProfileFields = (
     fields.userStatus = "UNLOCKED";
     fields.permissions = "UNLOCKED";
     fields.notifications = "UNLOCKED";
-
-    fields.studies = RequiresStudiesAssigned.includes(profileOf?.role) ? "UNLOCKED" : "HIDDEN";
-    fields.institution = RequiresInstitutionAssigned.includes(profileOf?.role)
-      ? "UNLOCKED"
-      : "HIDDEN";
   }
 
   return fields;

--- a/src/hooks/useProfileFields.ts
+++ b/src/hooks/useProfileFields.ts
@@ -83,7 +83,7 @@ const useProfileFields = (
 
   // Editable for user with permission to Manage Users
   if (canManage && viewType === "users") {
-    fields.role = "UNLOCKED";
+    fields.role = user?.role === "Federal Lead" ? "DISABLED" : "UNLOCKED";
     fields.userStatus = "UNLOCKED";
     fields.permissions = "UNLOCKED";
     fields.notifications = "UNLOCKED";
@@ -100,13 +100,6 @@ const useProfileFields = (
     fields.dataCommons = canManage && viewType === "users" ? "UNLOCKED" : "READ_ONLY";
   } else {
     fields.dataCommons = "HIDDEN";
-  }
-
-  if (profileOf?.role === "Federal Lead" && user?.role === "Federal Lead") {
-    fields.role = "DISABLED";
-    fields.userStatus = "UNLOCKED";
-    fields.permissions = "UNLOCKED";
-    fields.notifications = "UNLOCKED";
   }
 
   return fields;


### PR DESCRIPTION
### Overview

Update to allow Federal Leads to modify other Federal Lead users, except for their role.

> [!NOTE]
> The BE will handle filtering out Federal Lead users from the listUsers API. Currently, they are being filtered on the FE since pagination/sorting/filtering is on the FE, but the API is still returning all users of all roles.

### Change Details (Specifics)

- In the Manage Users list page, it was updated so that the Federal Lead role is selected by default as a filter, and disable the select, since there is no other options available
- Updated searchParams to use the Federal Lead role as the default when user is a Federal Lead
- Unlocked all fields within the Profile View while editing another Federal Lead user, except for the role field
- Updated select inputs to use the styled components instead

### Related Ticket(s)

[CRDCDH-2595](https://tracker.nci.nih.gov/browse/CRDCDH-2595) (Task)
[CRDCDH-2546](https://tracker.nci.nih.gov/browse/CRDCDH-2546) (US)
