### PR TITLE
CRDCDH-2694 Fix boolean value rendering in Comparison Table

### DIFF
--- a/src/components/ErrorDetailsDialog/index.stories.tsx
+++ b/src/components/ErrorDetailsDialog/index.stories.tsx
@@ -42,6 +42,7 @@ const mockReleasedDataQuery: MockedResponse<RetrieveReleasedDataResp, RetrieveRe
           props: JSON.stringify({
             mock_node_data_name: "foo",
             baz: 1,
+            bool_value: true,
             more_cols: "Yes that is true",
           }),
         },
@@ -51,6 +52,7 @@ const mockReleasedDataQuery: MockedResponse<RetrieveReleasedDataResp, RetrieveRe
           props: JSON.stringify({
             mock_node_data_name: "bar",
             baz: 2,
+            bool_value: false,
             more_cols: "No that is false",
           }),
         },

--- a/src/components/NodeComparison/ComparisonTable.test.tsx
+++ b/src/components/NodeComparison/ComparisonTable.test.tsx
@@ -142,6 +142,49 @@ describe("Basic Functionality", () => {
     expect(getByText(/example 03/i)).toBeInTheDocument();
     expect(getByText(/example 04/i)).toBeInTheDocument();
   });
+
+  it.each<boolean>([true, false])("should render the boolean %s value correctly", (value) => {
+    const { getAllByText } = render(
+      <ComparisonTable
+        newNode={{
+          ...baseNode,
+          props: JSON.stringify({ mock_node_data_name: "example 01", baz: value }),
+        }}
+        existingNode={{
+          ...baseNode,
+          props: JSON.stringify({ mock_node_data_name: "example 02", baz: value }),
+        }}
+        loading={false}
+      />
+    );
+
+    expect(getAllByText(value.toString())).toHaveLength(2);
+    expect(getAllByText(value.toString())[0]).toBeInTheDocument();
+    expect(getAllByText(value.toString())[1]).toBeInTheDocument();
+  });
+
+  it.each<number>([0, 900, 10.5, -99999999])(
+    "should render the number %s value correctly",
+    (value) => {
+      const { getAllByText } = render(
+        <ComparisonTable
+          newNode={{
+            ...baseNode,
+            props: JSON.stringify({ mock_node_data_name: "example 01", baz: value }),
+          }}
+          existingNode={{
+            ...baseNode,
+            props: JSON.stringify({ mock_node_data_name: "example 02", baz: value }),
+          }}
+          loading={false}
+        />
+      );
+
+      expect(getAllByText(value.toString())).toHaveLength(2);
+      expect(getAllByText(value.toString())[0]).toBeInTheDocument();
+      expect(getAllByText(value.toString())[1]).toBeInTheDocument();
+    }
+  );
 });
 
 describe("Implementation Requirements", () => {

--- a/src/components/NodeComparison/ComparisonTable.tsx
+++ b/src/components/NodeComparison/ComparisonTable.tsx
@@ -11,7 +11,7 @@ import {
 } from "@mui/material";
 import { FC, memo, useMemo } from "react";
 import { RetrieveReleasedDataResp } from "../../graphql";
-import { safeParse } from "../../utils";
+import { coerceToString, safeParse } from "../../utils";
 import Repeater from "../Repeater";
 
 const StyledAlert = styled(Alert)({
@@ -84,6 +84,8 @@ export type ComparisonTableProps = {
   loading: boolean;
 };
 
+type ParsedNodeProps = Record<string, string | number | boolean>;
+
 /**
  * Builds a dynamic table to compare the dataset between two data records
  * Handles loading state
@@ -91,12 +93,9 @@ export type ComparisonTableProps = {
  * @returns The NodeComparisonTable component
  */
 const ComparisonTable: FC<ComparisonTableProps> = ({ newNode, existingNode, loading }) => {
-  const newProps = useMemo<Record<string, string | number>>(
-    () => safeParse(newNode?.props),
-    [newNode]
-  );
+  const newProps = useMemo<ParsedNodeProps>(() => safeParse(newNode?.props), [newNode]);
 
-  const existingProps = useMemo<Record<string, string | number>>(
+  const existingProps = useMemo<ParsedNodeProps>(
     () => safeParse(existingNode?.props),
     [existingNode]
   );
@@ -139,14 +138,16 @@ const ComparisonTable: FC<ComparisonTableProps> = ({ newNode, existingNode, load
                 <StyledTableCell width={BLANK_COL_WIDTH}>Existing</StyledTableCell>
                 {allPropertyNames.map((property) => (
                   <StyledTableCell key={property}>
-                    {existingProps?.[property] || ""}
+                    {coerceToString(existingProps?.[property])}
                   </StyledTableCell>
                 ))}
               </TableRow>
               <TableRow data-testid="node-comparison-table-new">
                 <StyledTableCell width={BLANK_COL_WIDTH}>New</StyledTableCell>
                 {allPropertyNames.map((property) => (
-                  <StyledTableCell key={property}>{newProps?.[property] || ""}</StyledTableCell>
+                  <StyledTableCell key={property}>
+                    {coerceToString(newProps?.[property])}
+                  </StyledTableCell>
                 ))}
               </TableRow>
             </>


### PR DESCRIPTION
### Overview

This PR fixes an issue where React does not natively render boolean values (unsure why), so we have to coerce them into a string.

### Change Details (Specifics)

- Coerce Node Comparison data into string before rendering
- Update Error Details Dialog storybook to cover a scenario where boolean values are in the node comparison dataset

### Related Ticket(s)

CRDCDH-2694 (Bug)
