### PR TITLE
CRDCDH-2530 Fix Overlapping in PDF Table export

### DIFF
--- a/src/components/ExportRequestButton/index.stories.tsx
+++ b/src/components/ExportRequestButton/index.stories.tsx
@@ -1,0 +1,99 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Stack } from "@mui/material";
+import { Context as FormContext, Status as FormStatus } from "../Contexts/FormContext";
+import Button from "./index";
+import { InitialApplication, InitialQuestionnaire } from "../../config/InitialValues";
+
+const baseApplication: Application = {
+  ...InitialApplication,
+  applicant: {
+    applicantID: "mock-applicant-id",
+    applicantName: "John Doe",
+    applicantEmail: "john.doe@example.com",
+  },
+  questionnaireData: {
+    ...InitialQuestionnaire,
+  },
+  status: "In Progress",
+  submittedDate: "2023-10-01T00:00:00Z",
+};
+
+type CustomStoryProps = {
+  FormStatus: FormStatus;
+  application: Application;
+} & React.ComponentProps<typeof Button>;
+
+const meta: Meta<CustomStoryProps> = {
+  title: "Submission Requests / Export Request Button",
+  component: Button,
+  tags: ["autodocs"],
+  parameters: {},
+  argTypes: {
+    application: {
+      control: {
+        disable: true,
+      },
+    },
+    FormStatus: {
+      description: "Form status",
+      control: "select",
+      options: Object.values(FormStatus),
+    },
+  },
+  decorators: [
+    (Story) => (
+      <Stack spacing={5} width="100%" justifyContent="center" alignItems="center">
+        <div data-pdf-print-region="1">mock PDF content</div>
+        <Story />
+      </Stack>
+    ),
+    (Story, context) => (
+      <FormContext.Provider
+        value={{
+          status: context.args.FormStatus,
+          data: context.args.application,
+        }}
+      >
+        <Story />
+      </FormContext.Provider>
+    ),
+  ],
+  render: ({ FormStatus, application, ...rest }) => <Button {...rest} />,
+} satisfies Meta<CustomStoryProps>;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    FormStatus: FormStatus.LOADED,
+    application: baseApplication,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    ...Default.args,
+    disabled: true,
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    ...Default.args,
+    FormStatus: FormStatus.LOADING,
+  },
+};
+
+export const Hovered: Story = {
+  args: {
+    ...Default.args,
+  },
+  parameters: {
+    pseudo: {
+      hover: true,
+      selectors: "MuiButtonBase-root",
+    },
+  },
+};
+
+export default meta;

--- a/src/components/Questionnaire/ReviewFileTypeTable.tsx
+++ b/src/components/Questionnaire/ReviewFileTypeTable.tsx
@@ -29,7 +29,7 @@ const StyledTableHeaderRow = styled(TableRow)(() => ({
 
 const StyledTableRow = styled(TableRow)(() => ({
   "&.MuiTableRow-root": {
-    height: "40px",
+    height: "55px",
     padding: 0,
     justifyContent: "space-between",
     alignItems: "center",


### PR DESCRIPTION
### Overview

This PR is an attempted fix for the content overlapping happening in the table of the Submission Request PDF export. I'm not really sure if this will fix it 100%, but increasing the row height seemed to solve the issue.

### Change Details (Specifics)

- Bump the row height of the Review page table 
- Add a very basic storybook for the export PDF button

### Related Ticket(s)

CRDCDH-2530
