### PR TITLE
fix: Broken alignment of statistic label

### DIFF
--- a/src/components/NodeChart/index.tsx
+++ b/src/components/NodeChart/index.tsx
@@ -28,6 +28,7 @@ const StyledPieChartLabel = styled(Typography)({
   lineHeight: "21px",
   marginBottom: "12px",
   userSelect: "none",
+  textAlign: "center",
 });
 
 const StyledChartContainer = styled(Box)({
@@ -85,11 +86,7 @@ const NodeChart: FC<Props> = ({ label, centerCount, data }: Props) => {
     <StyledChartContainer ref={containerRef}>
       {reformattedLabel && (
         <StyledPieChartLabel>
-          <TruncatedText
-            text={reformattedLabel}
-            wrapperSx={{ margin: "0 auto" }}
-            maxCharacters={14}
-          />
+          <TruncatedText text={reformattedLabel} maxCharacters={14} />
         </StyledPieChartLabel>
       )}
       <PieChart width={150} height={150}>


### PR DESCRIPTION
### Overview

PR to fix the alignment of the node chart statistics label. Since the element is no longer a block, we need to use text align instead.

https://www.chromatic.com/test?appId=67cb4ee7b4e3bf6f42f5a7c5&id=681e2362173f1a199aca29ce

### Change Details (Specifics)

N/A

### Related Ticket(s)

N/A
