### PR TITLE
CRDCDH-2701 Rename "Primary Contact" to "Data Concierge"

### DIFF
--- a/src/components/DataSubmissions/DataSubmissionSummary.test.tsx
+++ b/src/components/DataSubmissions/DataSubmissionSummary.test.tsx
@@ -155,7 +155,7 @@ describe("Basic Functionality", () => {
     expect(getByText("Study")).toBeVisible();
     expect(getByText("Data Commons")).toBeVisible();
     expect(getByText("Program")).toBeVisible();
-    expect(getByText("Primary Contact")).toBeVisible();
+    expect(getByText("Data Concierge")).toBeVisible();
 
     // Check values
     expect(getByText("Test Submission...")).toBeVisible();
@@ -168,7 +168,7 @@ describe("Basic Functionality", () => {
 
     expect(getByText("2")).toBeVisible();
 
-    const emailLink = getByLabelText("Email Primary Contact");
+    const emailLink = getByLabelText("Email Data Concierge");
     expect(emailLink).toBeVisible();
     expect(emailLink).toHaveAttribute("href", "mailto:concierge@test.com");
   });
@@ -211,7 +211,7 @@ describe("Basic Functionality", () => {
     });
   });
 
-  it("renders the Primary Contact with name and email link when email is provided", () => {
+  it("renders the Data Concierge with name and email link when email is provided", () => {
     const dataSubmission: RecursivePartial<Submission> = {
       conciergeName: "Test Concierge",
       conciergeEmail: "concierge@test.com",
@@ -223,15 +223,15 @@ describe("Basic Functionality", () => {
       </BaseComponent>
     );
 
-    expect(getByText("Primary Contact")).toBeVisible();
+    expect(getByText("Data Concierge")).toBeVisible();
     expect(getByText("Test Concierge")).toBeVisible();
 
-    const emailLink = getByLabelText("Email Primary Contact");
+    const emailLink = getByLabelText("Email Data Concierge");
     expect(emailLink).toBeVisible();
     expect(emailLink).toHaveAttribute("href", "mailto:concierge@test.com");
   });
 
-  it("renders the Primary Contact with name only when email is not provided", () => {
+  it("renders the Data Concierge with name only when email is not provided", () => {
     const dataSubmission: RecursivePartial<Submission> = {
       conciergeName: "Test Concierge",
       conciergeEmail: null,
@@ -243,10 +243,10 @@ describe("Basic Functionality", () => {
       </BaseComponent>
     );
 
-    expect(getByText("Primary Contact")).toBeVisible();
+    expect(getByText("Data Concierge")).toBeVisible();
     expect(getByText("Test Concierge")).toBeVisible();
 
-    const emailLink = queryByLabelText("Email Primary Contact");
+    const emailLink = queryByLabelText("Email Data Concierge");
     expect(emailLink).toBeNull();
   });
 

--- a/src/components/DataSubmissions/DataSubmissionSummary.tsx
+++ b/src/components/DataSubmissions/DataSubmissionSummary.tsx
@@ -256,7 +256,7 @@ const DataSubmissionSummary: FC<Props> = ({ dataSubmission }) => {
             value={dataSubmission?.organization?.name ?? "NA"}
           />
           <SubmissionHeaderProperty
-            label="Primary Contact"
+            label="Data Concierge"
             value={
               <Stack direction="row" alignItems="center" spacing={1.375}>
                 <StyledConciergeName>
@@ -270,7 +270,7 @@ const DataSubmissionSummary: FC<Props> = ({ dataSubmission }) => {
                 {dataSubmission?.conciergeName && dataSubmission?.conciergeEmail && (
                   <StyledEmailWrapper
                     href={`mailto:${dataSubmission?.conciergeEmail}`}
-                    aria-label="Email Primary Contact"
+                    aria-label="Email Data Concierge"
                     data-testid="email-primary-contact-link"
                   >
                     <EmailIconSvg />

--- a/src/content/dataSubmissions/DataSubmissionsListView.tsx
+++ b/src/content/dataSubmissions/DataSubmissionsListView.tsx
@@ -170,7 +170,7 @@ const columns: Column<T>[] = [
     },
   },
   {
-    label: "Primary Contact",
+    label: "Data Concierge",
     renderValue: (a) => <TruncatedText text={a.conciergeName} />,
     field: "conciergeName",
     hideable: true,

--- a/src/content/organizations/ListView.tsx
+++ b/src/content/organizations/ListView.tsx
@@ -142,7 +142,7 @@ const columns: Column<T>[] = [
     },
   },
   {
-    label: "Primary Contact",
+    label: "Data Concierge",
     renderValue: (a) => <TruncatedText text={a.conciergeName} maxCharacters={15} />,
     comparator: (a, b) => (a?.conciergeName || "").localeCompare(b?.conciergeName || ""),
     field: "conciergeName",

--- a/src/content/organizations/OrganizationView.tsx
+++ b/src/content/organizations/OrganizationView.tsx
@@ -515,7 +515,7 @@ const OrganizationView: FC<Props> = ({ _id }: Props) => {
                 />
               </StyledField>
               <StyledField>
-                <StyledLabel id="primaryContactLabel">Primary Contact</StyledLabel>
+                <StyledLabel id="primaryContactLabel">Data Concierge</StyledLabel>
                 <Controller
                   name="conciergeID"
                   control={control}

--- a/src/content/organizations/OrganizationView.tsx
+++ b/src/content/organizations/OrganizationView.tsx
@@ -515,7 +515,7 @@ const OrganizationView: FC<Props> = ({ _id }: Props) => {
                 />
               </StyledField>
               <StyledField>
-                <StyledLabel id="primaryContactLabel">Data Concierge</StyledLabel>
+                <StyledLabel id="dataConciergeLabel">Data Concierge</StyledLabel>
                 <Controller
                   name="conciergeID"
                   control={control}
@@ -526,7 +526,7 @@ const OrganizationView: FC<Props> = ({ _id }: Props) => {
                       value={field.value || ""}
                       MenuProps={{ disablePortal: true }}
                       inputProps={{
-                        "aria-labelledby": "primaryContactLabel",
+                        "aria-labelledby": "dataConciergeLabel",
                       }}
                       error={!!errors.conciergeID}
                     >

--- a/src/content/studies/ListView.tsx
+++ b/src/content/studies/ListView.tsx
@@ -167,7 +167,7 @@ const columns: Column<ApprovedStudy>[] = [
     },
   },
   {
-    label: "Primary Contact",
+    label: "Data Concierge",
     renderValue: (a) => {
       const primaryContactName = a.primaryContact
         ? `${a.primaryContact?.firstName || ""} ${a.primaryContact?.lastName || ""}`?.trim()

--- a/src/content/studies/StudyView.tsx
+++ b/src/content/studies/StudyView.tsx
@@ -626,7 +626,7 @@ const StudyView: FC<Props> = ({ _id }: Props) => {
 
               <StyledField sx={{ alignItems: "flex-start" }}>
                 <StyledLabel id="primaryContactLabel" sx={{ paddingTop: "10px" }}>
-                  Primary Contact
+                  Data Concierge
                 </StyledLabel>
                 <Stack
                   direction="column"
@@ -636,7 +636,7 @@ const StudyView: FC<Props> = ({ _id }: Props) => {
                 >
                   <StyledCheckboxFormGroup>
                     <Tooltip
-                      title="Disabled due to this study is associated with multiple programs; manually assign a Primary Contact."
+                      title="Disabled due to this study is associated with multiple programs; manually assign a Data Concierge."
                       placement="top"
                       open={undefined}
                       disableHoverListener={
@@ -661,7 +661,7 @@ const StudyView: FC<Props> = ({ _id }: Props) => {
                             }
                           />
                         }
-                        label="Same as the Program Primary Contact"
+                        label="Same as the Program Data Concierge"
                       />
                     </Tooltip>
                   </StyledCheckboxFormGroup>

--- a/src/content/studies/StudyView.tsx
+++ b/src/content/studies/StudyView.tsx
@@ -625,7 +625,7 @@ const StudyView: FC<Props> = ({ _id }: Props) => {
               </StyledField>
 
               <StyledField sx={{ alignItems: "flex-start" }}>
-                <StyledLabel id="primaryContactLabel" sx={{ paddingTop: "10px" }}>
+                <StyledLabel id="dataConciergeLabel" sx={{ paddingTop: "10px" }}>
                   Data Concierge
                 </StyledLabel>
                 <Stack
@@ -679,7 +679,7 @@ const StudyView: FC<Props> = ({ _id }: Props) => {
                         }
                         MenuProps={{ disablePortal: true }}
                         inputProps={{
-                          "aria-labelledby": "primaryContactLabel",
+                          "aria-labelledby": "dataConciergeLabel",
                         }}
                         data-testid="primaryContactID-select"
                         error={!!errors.primaryContactID}

--- a/src/content/users/ProfileView.tsx
+++ b/src/content/users/ProfileView.tsx
@@ -292,7 +292,7 @@ const ProfileView: FC<Props> = ({ _id, viewType }: Props) => {
       fetchPolicy: "cache-and-network",
       skip: user?.role !== "Data Commons Personnel" || viewType !== "users",
       onError: (error) => {
-        Logger.error("ProfileView: Error checking primary contact status", error);
+        Logger.error("ProfileView: Error checking data concierge status", error);
       },
     }
   );

--- a/src/types/ApprovedStudies.d.ts
+++ b/src/types/ApprovedStudies.d.ts
@@ -40,7 +40,7 @@ type ApprovedStudy = {
    */
   programs: Organization[];
   /**
-   * The User object of the Primary contact associcated with the study
+   * The User object of the Primary contact associated with the study
    */
   primaryContact: User;
   /**


### PR DESCRIPTION
### Overview

This PR renames the term Primary Contact to Data Concierge anywhere pertaining to Data Submissions, with the only exception being the Submission Request pages. 

Internally we still just use Primary Contact (e.g. queries)

### Change Details (Specifics)

N/A 

### Related Ticket(s)

CRDCDH-2701
CRDCDH-2635
