### PR TITLE
CRDCDH-2695 Reset validation statuses when model version is changed

### DIFF
--- a/src/components/ModelSelection/FormDialog.test.tsx
+++ b/src/components/ModelSelection/FormDialog.test.tsx
@@ -291,7 +291,7 @@ describe("Implementation Requirements", () => {
       "Change Data Model Version"
     );
     expect(getByTestId("model-version-dialog-body")).toHaveTextContent(
-      "Changing the model version for an in-progress submission may require rerunning validation to ensure alignment with the selected version."
+      "Changing the model version for an in-progress submission will reset all validation results. The submitter will need to re-run the validation to ensure alignment with the new model version."
     );
     expect(getByTestId("model-version-dialog-submit-button")).toHaveTextContent("Save");
     expect(getByTestId("model-version-dialog-cancel-button")).toHaveTextContent("Cancel");

--- a/src/components/ModelSelection/FormDialog.tsx
+++ b/src/components/ModelSelection/FormDialog.tsx
@@ -130,8 +130,9 @@ const FormDialog: FC<Props> = ({ dataCommons, modelVersion, onSubmitForm, onClos
       </StyledHeader>
       <StyledDialogContent>
         <StyledBodyText data-testid="model-version-dialog-body" variant="body1">
-          Changing the model version for an in-progress submission may require rerunning validation
-          to ensure alignment with the selected version.
+          Changing the model version for an in-progress submission will reset all validation
+          results. The submitter will need to re-run the validation to ensure alignment with the new
+          model version.
         </StyledBodyText>
         <StyledForm>
           <Box>

--- a/src/components/ModelSelection/index.tsx
+++ b/src/components/ModelSelection/index.tsx
@@ -102,6 +102,8 @@ const ModelSelection: FC<Props> = ({ disabled, ...rest }: Props) => {
           ...prev,
           getSubmission: {
             ...prev.getSubmission,
+            metadataValidationStatus: "New",
+            fileValidationStatus: "New",
             modelVersion: d.updateSubmissionModelVersion.modelVersion,
           },
         }));


### PR DESCRIPTION
### Overview

When the model version is updated, the validation statuses are reset. This is in-sync with the BE, without having to retrieve the entire submission again.

### Change Details (Specifics)

- Set both metadata and data file validation statuses to "New"
- Updated warning dialog message

### Related Ticket(s)

[CRDCDH-2695](https://tracker.nci.nih.gov/browse/CRDCDH-2695) (Task)
[CRDCDH-2632](https://tracker.nci.nih.gov/browse/CRDCDH-2632) (US)
