### PR TITLE
CRDCDH-2697 Update batch status styling based on status value

### DIFF
--- a/src/content/dataSubmissions/DataActivity.tsx
+++ b/src/content/dataSubmissions/DataActivity.tsx
@@ -110,7 +110,10 @@ const columns: Column<Batch>[] = [
   {
     label: "Status",
     renderValue: (data) => (
-      <Box textTransform="capitalize" sx={{ ...batchStatusStyles[data?.status ?? "Uploaded"] }}>
+      <Box
+        textTransform="capitalize"
+        sx={{ ...(batchStatusStyles[data?.status] ?? batchStatusStyles["Uploaded"]) }}
+      >
         {data.status}
       </Box>
     ),

--- a/src/content/dataSubmissions/DataActivity.tsx
+++ b/src/content/dataSubmissions/DataActivity.tsx
@@ -9,7 +9,7 @@ import React, {
 } from "react";
 import { useLazyQuery } from "@apollo/client";
 import { isEqual } from "lodash";
-import { Box, Button, styled } from "@mui/material";
+import { Box, Button, styled, SxProps } from "@mui/material";
 import { useSnackbar } from "notistack";
 import { LIST_BATCHES, ListBatchesResp } from "../../graphql";
 import GenericTable, { Column } from "../../components/GenericTable";
@@ -25,11 +25,6 @@ import StyledTooltip from "../../components/StyledFormComponents/StyledTooltip";
 
 const StyledDateTooltip = styled(StyledTooltip)({
   cursor: "pointer",
-});
-
-const StyledRejectedStatus = styled("div")({
-  color: "#B54717",
-  fontWeight: 600,
 });
 
 const StyledFileCountButton = styled(Button)({
@@ -66,6 +61,21 @@ const StyledErrorDetailsButton = styled(Button)({
   },
 });
 
+const batchStatusStyles: Record<BatchStatus, SxProps> = {
+  Uploading: {
+    color: "#3800F0",
+    fontWeight: 600,
+  },
+  Failed: {
+    color: "#B54717",
+    fontWeight: 600,
+  },
+  Uploaded: {
+    color: "black",
+    fontWeight: 400,
+  },
+};
+
 const columns: Column<Batch>[] = [
   {
     label: "Batch ID",
@@ -100,12 +110,8 @@ const columns: Column<Batch>[] = [
   {
     label: "Status",
     renderValue: (data) => (
-      <Box textTransform="capitalize">
-        {data.status === "Failed" ? (
-          <StyledRejectedStatus>{data.status}</StyledRejectedStatus>
-        ) : (
-          data.status
-        )}
+      <Box textTransform="capitalize" sx={{ ...batchStatusStyles[data?.status ?? "Uploaded"] }}>
+        {data.status}
       </Box>
     ),
     field: "status",


### PR DESCRIPTION
### Overview

Created a mapping for the existing styling of the batch statuses, and added styling for the "Uploading" status.

### Change Details (Specifics)

N/A

### Related Ticket(s)

[CRDCDH-2697](https://tracker.nci.nih.gov/browse/CRDCDH-2697) (Task)
[CRDCDH-2612](https://tracker.nci.nih.gov/browse/CRDCDH-2612) (US)
[CRDCDH-2696](https://tracker.nci.nih.gov/browse/CRDCDH-2696) (UX)
