### PR TITLE
CRDCDH-2698 Submit button improvements

### DIFF
--- a/docs/Data_Submissions.mdx
+++ b/docs/Data_Submissions.mdx
@@ -16,6 +16,8 @@ The following table outlines the conditions for which a Data Submission must mee
 
 | Requirement                                                    | Description                                                                                              | Admin Submit | Regular Submit |
 | -------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- | ------------ | -------------- |
+| Validation must not be running                                 | The `metadataValidationStatus` and `fileValidationStatus` should not be `Validating`.                    | ❌           | ❌             |
+| No uploading batches                                           | There should be no batches with status `Uploading` for the submission.                                   | ❌           | ❌             |
 | Submission Status                                              | The submission status must be one of: `In Progress`, `Withdrawn`, or `Rejected` to submit                | ❌           | ❌             |
 | Metadata validation for 'Delete' intention                     | Metadata validation should be initialized for submissions with the intention `Delete`.                   | ❌           | ❌             |
 | Metadata validation for 'Metadata Only' submissions            | Metadata validation should be initialized for submissions with the data type `Metadata Only`.            | ❌           | ❌             |
@@ -23,8 +25,6 @@ The following table outlines the conditions for which a Data Submission must mee
 | Metadata validation for 'Metadata and Data Files' submissions  | Metadata validation should be initialized for submissions with the data type `Metadata and Data Files`.  | ❌           | ❌             |
 | Validation must have been run                                  | The `metadataValidationStatus` and `fileValidationStatus` should not be `New`.                           | ❌           | ❌             |
 | Submission must not have orphaned files                        | No `QCResult` should contain the error message `Orphaned file found`.                                    | ❌           | ❌             |
-| Validation must not be running                                 | The `metadataValidationStatus` and `fileValidationStatus` should not be `Validating`.                    | ❌           | ❌             |
-| No uploading batches                                           | There should be no batches with status `Uploading` for the submission.                                   | ❌           | ❌             |
 | Validation must have passed                                    | The `metadataValidationStatus` and `fileValidationStatus` should not be `Error`.                         | ✅           | ❌             |
 | **All checks passed**                                          | All above conditions have passed.                                                                        | ❌           | ✅             |
 

--- a/docs/Data_Submissions.mdx
+++ b/docs/Data_Submissions.mdx
@@ -13,15 +13,19 @@ The following table outlines the conditions for which a Data Submission must mee
 - ❌: If the condition is not met, the submission cannot be submitted.
 - ✅: If the condition is not met, the submission can still be submitted.
 
-| Requirement | Description | Admin Submit | Regular Submit |
-| --- | --- | --- | --- |
-| Submission Status | The submission status must be one of: `In Progress`, `Withdrawn`, or `Rejected` to submit | ❌ | ❌ |
-| No uploading batches | There should be no batches with status `Uploading` for the submission. | ❌ | ❌ |
-| Submission must not have orphaned files | No `QCResult` should contain the error message `Orphaned file found`. | ❌ | ❌ |
-| Validation must not be running | The `metadataValidationStatus` and `fileValidationStatus` should not be `Validating`. | ❌ | ❌ |
-| Validation must have been run | The `metadataValidationStatus` and `fileValidationStatus` should not be `New`. | ❌ | ❌ |
-| Validation must have passed | The `metadataValidationStatus` and `fileValidationStatus` should not be `Error`. | ✅ | ❌ |
-| Metadata validation for 'Delete' intention | Metadata validation should be initialized for submissions with the intention `Delete`. | ❌ | ❌ |
-| Metadata validation for 'Metadata Only' submissions | Metadata validation should be initialized for submissions with the data type `Metadata Only`. | ❌ | ❌ |
-| Data file validation for 'Metadata and Data Files' submissions | Data file validation should be initialized for submissions with the data type `Metadata and Data Files`. | ❌ | ❌ |
-| Metadata validation for 'Metadata and Data Files' submissions | Metadata validation should be initialized for submissions with the data type `Metadata and Data Files`. | ❌ | ❌ |
+
+| Requirement                                                    | Description                                                                                              | Admin Submit | Regular Submit |
+| -------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- | ------------ | -------------- |
+| Submission Status                                              | The submission status must be one of: `In Progress`, `Withdrawn`, or `Rejected` to submit                | ❌           | ❌             |
+| Metadata validation for 'Delete' intention                     | Metadata validation should be initialized for submissions with the intention `Delete`.                   | ❌           | ❌             |
+| Metadata validation for 'Metadata Only' submissions            | Metadata validation should be initialized for submissions with the data type `Metadata Only`.            | ❌           | ❌             |
+| Data file validation for 'Metadata and Data Files' submissions | Data file validation should be initialized for submissions with the data type `Metadata and Data Files`. | ❌           | ❌             |
+| Metadata validation for 'Metadata and Data Files' submissions  | Metadata validation should be initialized for submissions with the data type `Metadata and Data Files`.  | ❌           | ❌             |
+| Validation must have been run                                  | The `metadataValidationStatus` and `fileValidationStatus` should not be `New`.                           | ❌           | ❌             |
+| Submission must not have orphaned files                        | No `QCResult` should contain the error message `Orphaned file found`.                                    | ❌           | ❌             |
+| Validation must not be running                                 | The `metadataValidationStatus` and `fileValidationStatus` should not be `Validating`.                    | ❌           | ❌             |
+| No uploading batches                                           | There should be no batches with status `Uploading` for the submission.                                   | ❌           | ❌             |
+| Validation must have passed                                    | The `metadataValidationStatus` and `fileValidationStatus` should not be `Error`.                         | ✅           | ❌             |
+| **All checks passed**                                          | All above conditions have passed.                                                                        | ❌           | ✅             |
+
+**NOTE:** Conditions are run in sequence by criticality (most critical first). The first failing condition's tooltip appears.

--- a/src/config/DashboardTooltips.ts
+++ b/src/config/DashboardTooltips.ts
@@ -38,6 +38,8 @@ export const TOOLTIP_TEXT = {
           "There are new data entries or validation issues that need to be resolved.",
         MISSING_DATA_FILE:
           "There are no data files for this submission. Please upload the appropriate data files and validate to enable the Submit button.",
+        BATCH_IS_UPLOADING:
+          "There are ongoing batch uploads. Please wait for the upload to complete.",
       },
     },
   },

--- a/src/config/SubmitButtonConfig.ts
+++ b/src/config/SubmitButtonConfig.ts
@@ -45,34 +45,6 @@ export const ORPHANED_FILE_ERROR_TITLE = "Orphaned file found";
  */
 export const SUBMIT_BUTTON_CONDITIONS: SubmitButtonCondition[] = [
   {
-    _identifier: "Validation should not currently be running",
-    check: ({ getSubmission: s }) =>
-      s.metadataValidationStatus !== "Validating" && s.fileValidationStatus !== "Validating",
-    tooltip: TOOLTIP_TEXT.SUBMISSION_ACTIONS.SUBMIT.DISABLED.VALIDATION_RUNNING,
-    required: true,
-  },
-  {
-    _identifier: "There should not be any batches uploading",
-    check: ({ batchStatusList }) =>
-      !batchStatusList?.batches?.some((b) => b.status === "Uploading"),
-    tooltip: TOOLTIP_TEXT.SUBMISSION_ACTIONS.SUBMIT.DISABLED.BATCH_IS_UPLOADING,
-    required: true,
-  },
-  {
-    _identifier: "Metadata and Data File should not have 'New' status",
-    check: ({ getSubmission: s }) =>
-      s.metadataValidationStatus !== "New" && s.fileValidationStatus !== "New",
-    tooltip: TOOLTIP_TEXT.SUBMISSION_ACTIONS.SUBMIT.DISABLED.NEW_DATA_OR_VALIDATION_ERRORS,
-    required: true,
-  },
-  {
-    _identifier: "Submission should not have orphaned files",
-    check: (_, qcResults) =>
-      !qcResults?.some((qc) => qc.errors?.find((err) => err.title === ORPHANED_FILE_ERROR_TITLE)),
-    tooltip: TOOLTIP_TEXT.SUBMISSION_ACTIONS.SUBMIT.DISABLED.NEW_DATA_OR_VALIDATION_ERRORS,
-    required: true,
-  },
-  {
     // NOTE: Might be redundant, currently only 'Metadata Only' dataType is allowed for 'Delete' intention
     _identifier: "Metadata validation should be initialized for 'Delete' intention",
     preConditionCheck: ({ getSubmission: s }) => s.intention === "Delete",
@@ -101,6 +73,34 @@ export const SUBMIT_BUTTON_CONDITIONS: SubmitButtonCondition[] = [
     preConditionCheck: ({ getSubmission: s }) => s.dataType === "Metadata and Data Files",
     check: ({ getSubmission: s }) => !!s.metadataValidationStatus,
     tooltip: TOOLTIP_TEXT.SUBMISSION_ACTIONS.SUBMIT.DISABLED.NEW_DATA_OR_VALIDATION_ERRORS,
+    required: true,
+  },
+  {
+    _identifier: "Metadata and Data File should not have 'New' status",
+    check: ({ getSubmission: s }) =>
+      s.metadataValidationStatus !== "New" && s.fileValidationStatus !== "New",
+    tooltip: TOOLTIP_TEXT.SUBMISSION_ACTIONS.SUBMIT.DISABLED.NEW_DATA_OR_VALIDATION_ERRORS,
+    required: true,
+  },
+  {
+    _identifier: "Submission should not have orphaned files",
+    check: (_, qcResults) =>
+      !qcResults?.some((qc) => qc.errors?.find((err) => err.title === ORPHANED_FILE_ERROR_TITLE)),
+    tooltip: TOOLTIP_TEXT.SUBMISSION_ACTIONS.SUBMIT.DISABLED.NEW_DATA_OR_VALIDATION_ERRORS,
+    required: true,
+  },
+  {
+    _identifier: "Validation should not currently be running",
+    check: ({ getSubmission: s }) =>
+      s.metadataValidationStatus !== "Validating" && s.fileValidationStatus !== "Validating",
+    tooltip: TOOLTIP_TEXT.SUBMISSION_ACTIONS.SUBMIT.DISABLED.VALIDATION_RUNNING,
+    required: true,
+  },
+  {
+    _identifier: "There should not be any batches uploading",
+    check: ({ batchStatusList }) =>
+      !batchStatusList?.batches?.some((b) => b.status === "Uploading"),
+    tooltip: TOOLTIP_TEXT.SUBMISSION_ACTIONS.SUBMIT.DISABLED.BATCH_IS_UPLOADING,
     required: true,
   },
   {

--- a/src/config/SubmitButtonConfig.ts
+++ b/src/config/SubmitButtonConfig.ts
@@ -32,7 +32,7 @@ export type AdminOverrideCondition = Omit<SubmitButtonCondition, "required">;
 /**
  * The title of the error message that represents an orphaned file
  */
-const ORPHANED_FILE_ERROR_TITLE = "Orphaned file found";
+export const ORPHANED_FILE_ERROR_TITLE = "Orphaned file found";
 
 /**
  * Configuration of conditions used to determine whether the submit button

--- a/src/config/SubmitButtonConfig.ts
+++ b/src/config/SubmitButtonConfig.ts
@@ -45,6 +45,20 @@ export const ORPHANED_FILE_ERROR_TITLE = "Orphaned file found";
  */
 export const SUBMIT_BUTTON_CONDITIONS: SubmitButtonCondition[] = [
   {
+    _identifier: "Validation should not currently be running",
+    check: ({ getSubmission: s }) =>
+      s.metadataValidationStatus !== "Validating" && s.fileValidationStatus !== "Validating",
+    tooltip: TOOLTIP_TEXT.SUBMISSION_ACTIONS.SUBMIT.DISABLED.VALIDATION_RUNNING,
+    required: true,
+  },
+  {
+    _identifier: "There should not be any batches uploading",
+    check: ({ batchStatusList }) =>
+      !batchStatusList?.batches?.some((b) => b.status === "Uploading"),
+    tooltip: TOOLTIP_TEXT.SUBMISSION_ACTIONS.SUBMIT.DISABLED.BATCH_IS_UPLOADING,
+    required: true,
+  },
+  {
     // NOTE: Might be redundant, currently only 'Metadata Only' dataType is allowed for 'Delete' intention
     _identifier: "Metadata validation should be initialized for 'Delete' intention",
     preConditionCheck: ({ getSubmission: s }) => s.intention === "Delete",
@@ -87,20 +101,6 @@ export const SUBMIT_BUTTON_CONDITIONS: SubmitButtonCondition[] = [
     check: (_, qcResults) =>
       !qcResults?.some((qc) => qc.errors?.find((err) => err.title === ORPHANED_FILE_ERROR_TITLE)),
     tooltip: TOOLTIP_TEXT.SUBMISSION_ACTIONS.SUBMIT.DISABLED.NEW_DATA_OR_VALIDATION_ERRORS,
-    required: true,
-  },
-  {
-    _identifier: "Validation should not currently be running",
-    check: ({ getSubmission: s }) =>
-      s.metadataValidationStatus !== "Validating" && s.fileValidationStatus !== "Validating",
-    tooltip: TOOLTIP_TEXT.SUBMISSION_ACTIONS.SUBMIT.DISABLED.VALIDATION_RUNNING,
-    required: true,
-  },
-  {
-    _identifier: "There should not be any batches uploading",
-    check: ({ batchStatusList }) =>
-      !batchStatusList?.batches?.some((b) => b.status === "Uploading"),
-    tooltip: TOOLTIP_TEXT.SUBMISSION_ACTIONS.SUBMIT.DISABLED.BATCH_IS_UPLOADING,
     required: true,
   },
   {

--- a/src/content/dataSubmissions/DataSubmission.tsx
+++ b/src/content/dataSubmissions/DataSubmission.tsx
@@ -14,11 +14,6 @@ import QualityControl from "./QualityControl";
 import ValidationStatistics from "../../components/DataSubmissions/ValidationStatistics";
 import ValidationControls from "../../components/DataSubmissions/ValidationControls";
 import { useAuthContext } from "../../components/Contexts/AuthContext";
-import {
-  ReleaseInfo,
-  shouldDisableRelease,
-  shouldEnableSubmit,
-} from "../../utils/dataSubmissionUtils";
 import usePageTitle from "../../hooks/usePageTitle";
 import BackButton from "../../components/DataSubmissions/BackButton";
 import SubmittedData from "./SubmittedData";
@@ -163,7 +158,7 @@ const DataSubmission: FC<Props> = ({ submissionId, tab = URLTabs.UPLOAD_ACTIVITY
   const { user } = useAuthContext();
   const { enqueueSnackbar } = useSnackbar();
   const { lastSearchParams } = useSearchParamsContext();
-  const { data, error, refetch: getSubmission, qcData, qcError } = useSubmissionContext();
+  const { data, error, refetch: getSubmission, qcError } = useSubmissionContext();
 
   const dataSubmissionListPageUrl = `/data-submissions${
     lastSearchParams?.["/data-submissions"] ?? ""
@@ -183,18 +178,6 @@ const DataSubmission: FC<Props> = ({ submissionId, tab = URLTabs.UPLOAD_ACTIVITY
     tab &&
     Object.values(URLTabs).includes(tab) &&
     (tab !== URLTabs.CROSS_VALIDATION_RESULTS || crossValidationVisible);
-
-  const submitInfo: SubmitButtonResult = useMemo(() => {
-    if (!data?.getSubmission?._id || hasUploadingBatches) {
-      return { enabled: false };
-    }
-
-    return shouldEnableSubmit(data.getSubmission, qcData?.submissionQCResults?.results, user);
-  }, [data?.getSubmission, qcData?.submissionQCResults?.results, user, hasUploadingBatches]);
-  const releaseInfo: ReleaseInfo = useMemo(
-    () => shouldDisableRelease(data?.getSubmission),
-    [data?.getSubmission?.crossSubmissionStatus, data?.getSubmission?.otherSubmissions]
-  );
 
   const [submissionAction] = useMutation<SubmissionActionResp>(SUBMISSION_ACTION, {
     context: { clientName: "backend" },
@@ -336,11 +319,8 @@ const DataSubmission: FC<Props> = ({ submissionId, tab = URLTabs.UPLOAD_ACTIVITY
           </StyledCardContent>
           <StyledCardActions>
             <DataSubmissionActions
-              submission={data?.getSubmission}
+              loading={hasUploadingBatches}
               onAction={updateSubmissionAction}
-              submitActionButton={submitInfo}
-              releaseActionButton={releaseInfo}
-              onError={(message: string) => enqueueSnackbar(message, { variant: "error" })}
             />
           </StyledCardActions>
         </StyledCard>

--- a/src/content/dataSubmissions/DataSubmission.tsx
+++ b/src/content/dataSubmissions/DataSubmission.tsx
@@ -164,10 +164,6 @@ const DataSubmission: FC<Props> = ({ submissionId, tab = URLTabs.UPLOAD_ACTIVITY
     lastSearchParams?.["/data-submissions"] ?? ""
   }`;
   const activityRef = useRef<DataActivityRef>(null);
-  const hasUploadingBatches = useMemo<boolean>(
-    () => data?.batchStatusList?.batches?.some((b) => b.status === "Uploading"),
-    [data?.batchStatusList?.batches]
-  );
   const crossValidationVisible: boolean = useMemo<boolean>(
     () =>
       hasPermission(user, "data_submission", "review", data?.getSubmission) &&
@@ -318,10 +314,7 @@ const DataSubmission: FC<Props> = ({ submissionId, tab = URLTabs.UPLOAD_ACTIVITY
             </StyledMainContentArea>
           </StyledCardContent>
           <StyledCardActions>
-            <DataSubmissionActions
-              loading={hasUploadingBatches}
-              onAction={updateSubmissionAction}
-            />
+            <DataSubmissionActions onAction={updateSubmissionAction} />
           </StyledCardActions>
         </StyledCard>
       </StyledBannerContentContainer>

--- a/src/content/dataSubmissions/DataSubmissionActions.stories.tsx
+++ b/src/content/dataSubmissions/DataSubmissionActions.stories.tsx
@@ -321,3 +321,11 @@ export const AdminOverrideSubmissionHasValidationErrors: Story = {
     ],
   },
 };
+
+export const AdminCanPerformRegularSubmitWithAdminSubmitPermissions: Story = {
+  name: "Admin can perform regular submit with 'admin_submit' permissions",
+  args: {
+    role: "Admin",
+    permissions: ["data_submission:view", "data_submission:cancel", "data_submission:admin_submit"],
+  },
+};

--- a/src/content/dataSubmissions/DataSubmissionActions.stories.tsx
+++ b/src/content/dataSubmissions/DataSubmissionActions.stories.tsx
@@ -255,6 +255,13 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
 
+export const UserIsMissingSubmitPermissions: Story = {
+  name: "User is missing 'data_submission:create' and 'data_submission:admin_submit' permissions",
+  args: {
+    permissions: ["data_submission:view", "data_submission:review", "data_submission:cancel"],
+  },
+};
+
 export const MetadataValidationShouldBeInitializedForDeleteIntention: Story = {
   name: "Metadata validation should be initialized for 'Delete' intention",
   args: { intention: "Delete", metadataValidationStatus: null },

--- a/src/content/dataSubmissions/DataSubmissionActions.stories.tsx
+++ b/src/content/dataSubmissions/DataSubmissionActions.stories.tsx
@@ -258,6 +258,7 @@ export const Default: Story = {};
 export const UserIsMissingSubmitPermissions: Story = {
   name: "User is missing 'data_submission:create' and 'data_submission:admin_submit' permissions",
   args: {
+    role: "Admin",
     permissions: ["data_submission:view", "data_submission:review", "data_submission:cancel"],
   },
 };

--- a/src/content/dataSubmissions/DataSubmissionActions.stories.tsx
+++ b/src/content/dataSubmissions/DataSubmissionActions.stories.tsx
@@ -104,6 +104,7 @@ type ContextArgs = {
   dataType: SubmissionDataType;
   intention: SubmissionIntention;
   submissionQCResults: ValidationResult<Pick<QCResult, "errors">> | null;
+  batchStatusList: { batches: Pick<Batch, "_id" | "status">[] } | null;
 };
 
 type ComponentProps = ComponentPropsWithoutRef<typeof DataSubmissionActions>;
@@ -120,6 +121,7 @@ const withProviders: Decorator<StoryArgs> = (Story, context) => {
     dataType,
     intention,
     submissionQCResults,
+    batchStatusList,
   } = context.args;
 
   return (
@@ -149,6 +151,7 @@ const withProviders: Decorator<StoryArgs> = (Story, context) => {
               dataType,
               intention,
             },
+            batchStatusList,
           },
           qcData: {
             submissionQCResults,
@@ -224,6 +227,12 @@ const meta = {
         type: "text",
       },
     },
+    batchStatusList: {
+      name: "batchStatusList",
+      control: {
+        type: "text",
+      },
+    },
   },
   args: {
     role: "Submitter",
@@ -234,7 +243,7 @@ const meta = {
     dataType: "Metadata and Data Files",
     intention: "New/Update",
     submissionQCResults: null,
-    loading: false,
+    batchStatusList: null,
     onAction: fn(),
   },
   tags: ["autodocs"],
@@ -248,7 +257,7 @@ export const Default: Story = {};
 
 export const BatchesShouldNotBeUploading: Story = {
   name: "No Batches should have 'Uploading' status",
-  args: { loading: true },
+  args: { batchStatusList: { batches: [{ _id: "batch-1", status: "Uploading" as BatchStatus }] } },
 };
 
 export const ValidationShouldNotCurrentlyBeRunning: Story = {

--- a/src/content/dataSubmissions/DataSubmissionActions.stories.tsx
+++ b/src/content/dataSubmissions/DataSubmissionActions.stories.tsx
@@ -346,7 +346,7 @@ export const Withdraw: Story = {
 };
 
 export const Release: Story = {
-  name: "User with 'data_submission:review' can Release a submitted submission",
+  name: "User with 'data_submission:review' permission can Release a submitted submission",
   args: {
     role: "Admin",
     permissions: ["data_submission:view", "data_submission:review"],
@@ -355,7 +355,7 @@ export const Release: Story = {
 };
 
 export const Complete: Story = {
-  name: "User with 'data_submission:confirm' can Complete a released submission",
+  name: "User with 'data_submission:confirm' permission can Complete a released submission",
   args: {
     role: "Admin",
     permissions: ["data_submission:view", "data_submission:confirm"],

--- a/src/content/dataSubmissions/DataSubmissionActions.stories.tsx
+++ b/src/content/dataSubmissions/DataSubmissionActions.stories.tsx
@@ -255,14 +255,24 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
 
-export const BatchesShouldNotBeUploading: Story = {
-  name: "No Batches should have 'Uploading' status",
-  args: { batchStatusList: { batches: [{ _id: "batch-1", status: "Uploading" as BatchStatus }] } },
+export const MetadataValidationShouldBeInitializedForDeleteIntention: Story = {
+  name: "Metadata validation should be initialized for 'Delete' intention",
+  args: { intention: "Delete", metadataValidationStatus: null },
 };
 
-export const ValidationShouldNotCurrentlyBeRunning: Story = {
-  name: "Validation should not currently be running",
-  args: { metadataValidationStatus: "Validating", fileValidationStatus: "Validating" },
+export const MetadataValidationShouldBeInitializedForMetadataOnlySubmissions: Story = {
+  name: "Metadata validation should be initialized for 'Metadata Only' submissions",
+  args: { dataType: "Metadata Only", metadataValidationStatus: null },
+};
+
+export const DataFileValidationShouldBeInitializedForMetadataAndDataFileSubmissions: Story = {
+  name: "Data file validation should be initialized for 'Metadata and Data Files' submissions",
+  args: { dataType: "Metadata and Data Files", fileValidationStatus: null },
+};
+
+export const MetadataValidationShouldBeInitializedForMetadataAndDataFilesSubmissions: Story = {
+  name: "Metadata validation should be initialized for 'Metadata and Data Files' submissions",
+  args: { dataType: "Metadata and Data Files", metadataValidationStatus: null },
 };
 
 export const MetadataAndDataFileShouldNotHaveNewStatus: Story = {
@@ -282,24 +292,14 @@ export const SubmissionShouldNotHaveOrphanedFiles: Story = {
   },
 };
 
-export const MetadataValidationShouldBeInitializedForDeleteIntention: Story = {
-  name: "Metadata validation should be initialized for 'Delete' intention",
-  args: { intention: "Delete", metadataValidationStatus: null },
+export const ValidationShouldNotCurrentlyBeRunning: Story = {
+  name: "Validation should not currently be running",
+  args: { metadataValidationStatus: "Validating", fileValidationStatus: "Validating" },
 };
 
-export const MetadataValidationShouldBeInitializedForMetadataOnlySubmissions: Story = {
-  name: "Metadata validation should be initialized for 'Metadata Only' submissions",
-  args: { dataType: "Metadata Only", metadataValidationStatus: null },
-};
-
-export const DataFileValidationShouldBeInitializedForMetadataAndDataFileSubmissions: Story = {
-  name: "Data file validation should be initialized for 'Metadata and Data Files' submissions",
-  args: { dataType: "Metadata and Data Files", fileValidationStatus: null },
-};
-
-export const MetadataValidationShouldBeInitializedForMetadataAndDataFilesSubmissions: Story = {
-  name: "Metadata validation should be initialized for 'Metadata and Data Files' submissions",
-  args: { dataType: "Metadata and Data Files", metadataValidationStatus: null },
+export const BatchesShouldNotBeUploading: Story = {
+  name: "No Batches should have 'Uploading' status",
+  args: { batchStatusList: { batches: [{ _id: "batch-1", status: "Uploading" as BatchStatus }] } },
 };
 
 export const ThereShouldBeNoValidationErrorsForMetadataOrDataFiles: Story = {

--- a/src/content/dataSubmissions/DataSubmissionActions.stories.tsx
+++ b/src/content/dataSubmissions/DataSubmissionActions.stories.tsx
@@ -1,0 +1,289 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { fn } from "@storybook/test";
+import {
+  Context as AuthContext,
+  ContextState as AuthCtxState,
+} from "../../components/Contexts/AuthContext";
+import DataSubmissionActions from "./DataSubmissionActions";
+import { Roles } from "../../config/AuthRoles";
+import {
+  SubmissionContext,
+  SubmissionCtxState,
+  SubmissionCtxStatus,
+} from "../../components/Contexts/SubmissionContext";
+
+const meta: Meta<typeof DataSubmissionActions> = {
+  title: "Data Submissions / Actions",
+  component: DataSubmissionActions,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof DataSubmissionActions>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const baseSubmission: Submission = {
+  _id: "submission-1",
+  name: "",
+  submitterID: "example-user",
+  submitterName: "",
+  organization: undefined,
+  dataCommons: "",
+  dataCommonsDisplayName: "",
+  modelVersion: "",
+  studyID: "",
+  studyAbbreviation: "",
+  dbGaPID: "",
+  bucketName: "",
+  rootPath: "",
+  status: "In Progress",
+  metadataValidationStatus: "New",
+  fileValidationStatus: "New",
+  crossSubmissionStatus: "New",
+  deletingData: false,
+  archived: false,
+  validationStarted: "",
+  validationEnded: "",
+  validationScope: "New",
+  validationType: [],
+  fileErrors: [],
+  history: [],
+  conciergeName: "",
+  conciergeEmail: "",
+  intention: "New/Update",
+  dataType: "Metadata Only",
+  otherSubmissions: "",
+  nodeCount: 0,
+  collaborators: [],
+  dataFileSize: {
+    formatted: "",
+    size: 0,
+  },
+  createdAt: "",
+  updatedAt: "",
+};
+
+const baseSubmissionCtx: SubmissionCtxState = {
+  status: SubmissionCtxStatus.LOADING,
+  data: { getSubmission: baseSubmission, batchStatusList: null, submissionStats: null },
+  error: null,
+  startPolling: fn(),
+  stopPolling: fn(),
+  refetch: fn(),
+  updateQuery: fn(),
+};
+
+const dataSubmissionPermissions: DataSubmissionPermissions[] = [
+  "data_submission:view",
+  "data_submission:create",
+  "data_submission:review",
+  "data_submission:admin_submit",
+  "data_submission:confirm",
+  "data_submission:cancel",
+];
+
+const submissionStatuses: SubmissionStatus[] = [
+  "New",
+  "In Progress",
+  "Canceled",
+  "Submitted",
+  "Withdrawn",
+  "Rejected",
+  "Released",
+  "Completed",
+  "Deleted",
+];
+
+const validationStatuses: (ValidationStatus | null)[] = [
+  null,
+  "Validating",
+  "New",
+  "Error",
+  "Passed",
+  "Warning",
+];
+
+export const Default: Story = {
+  args: {
+    role: "Submitter",
+    permissions: [
+      "data_submission:view",
+      "data_submission:create",
+      "data_submission:review",
+      "data_submission:admin_submit",
+      "data_submission:confirm",
+      "data_submission:cancel",
+    ],
+    submissionStatus: "In Progress",
+    metadataValidationStatus: "Passed",
+    fileValidationStatus: "Passed",
+  },
+  argTypes: {
+    role: {
+      name: "Role",
+      options: Roles,
+      control: {
+        type: "radio",
+      },
+    },
+    permissions: {
+      name: "Permissions",
+      options: dataSubmissionPermissions,
+      control: {
+        type: "check",
+      },
+    },
+    submissionStatus: {
+      name: "Status",
+      options: submissionStatuses,
+      control: {
+        type: "radio",
+      },
+    },
+    metadataValidationStatus: {
+      name: "metadataValidationStatus",
+      options: validationStatuses,
+      control: {
+        type: "radio",
+      },
+    },
+    fileValidationStatus: {
+      name: "fileValidationStatus",
+      options: validationStatuses,
+      control: {
+        type: "radio",
+      },
+    },
+  },
+  decorators: [
+    (Story, context) => (
+      <AuthContext.Provider
+        value={
+          {
+            isLoggedIn: true,
+            user: {
+              _id: "example-user",
+              firstName: "Example",
+              role: context.args.role,
+              permissions: context.args.permissions,
+            } as User,
+          } as AuthCtxState
+        }
+      >
+        <SubmissionContext.Provider
+          value={{
+            ...baseSubmissionCtx,
+            data: {
+              ...baseSubmissionCtx.data,
+              getSubmission: {
+                ...baseSubmissionCtx.data.getSubmission,
+                status: context.args.submissionStatus,
+                dataType: "Metadata and Data Files",
+                metadataValidationStatus: context.args.metadataValidationStatus,
+                fileValidationStatus: context.args.fileValidationStatus,
+              },
+            },
+            qcData: {
+              submissionQCResults: null,
+            },
+          }}
+        >
+          <Story />
+        </SubmissionContext.Provider>
+      </AuthContext.Provider>
+    ),
+  ],
+};
+
+export const ValidationShouldNotCurrentlyBeRunning: Story = {
+  name: "Validation should not currently be running",
+  args: {
+    role: "Submitter" as UserRole,
+    permissions: [
+      "data_submission:view",
+      "data_submission:create",
+      "data_submission:cancel",
+    ] as AuthPermissions[],
+    submissionStatus: "In Progress" as SubmissionStatus,
+    metadataValidationStatus: "Validating" as ValidationStatus,
+    fileValidationStatus: "Validating" as ValidationStatus,
+  },
+  argTypes: {
+    role: {
+      name: "Role",
+      options: Roles,
+      control: {
+        type: "radio",
+      },
+    },
+    permissions: {
+      name: "Permissions",
+      options: dataSubmissionPermissions,
+      control: {
+        type: "check",
+      },
+    },
+    submissionStatus: {
+      name: "Status",
+      options: submissionStatuses,
+      control: {
+        type: "radio",
+      },
+    },
+    metadataValidationStatus: {
+      name: "metadataValidationStatus",
+      options: validationStatuses,
+      control: {
+        type: "radio",
+      },
+    },
+    fileValidationStatus: {
+      name: "fileValidationStatus",
+      options: validationStatuses,
+      control: {
+        type: "radio",
+      },
+    },
+  },
+  decorators: [
+    (Story, context) => (
+      <AuthContext.Provider
+        value={
+          {
+            isLoggedIn: true,
+            user: {
+              _id: "example-user",
+              firstName: "Example",
+              role: context.args.role,
+              permissions: context.args.permissions,
+            } as User,
+          } as AuthCtxState
+        }
+      >
+        <SubmissionContext.Provider
+          value={{
+            ...baseSubmissionCtx,
+            data: {
+              ...baseSubmissionCtx.data,
+              getSubmission: {
+                ...baseSubmissionCtx.data.getSubmission,
+                status: context.args.submissionStatus,
+                dataType: "Metadata and Data Files",
+                metadataValidationStatus: context.args.metadataValidationStatus,
+                fileValidationStatus: context.args.fileValidationStatus,
+              },
+            },
+            qcData: {
+              submissionQCResults: null,
+            },
+          }}
+        >
+          <Story />
+        </SubmissionContext.Provider>
+      </AuthContext.Provider>
+    ),
+  ],
+};

--- a/src/content/dataSubmissions/DataSubmissionActions.stories.tsx
+++ b/src/content/dataSubmissions/DataSubmissionActions.stories.tsx
@@ -255,14 +255,6 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
 
-export const UserIsMissingSubmitPermissions: Story = {
-  name: "User is missing 'data_submission:create' and 'data_submission:admin_submit' permissions",
-  args: {
-    role: "Admin",
-    permissions: ["data_submission:view", "data_submission:review", "data_submission:cancel"],
-  },
-};
-
 export const MetadataValidationShouldBeInitializedForDeleteIntention: Story = {
   name: "Metadata validation should be initialized for 'Delete' intention",
   args: { intention: "Delete", metadataValidationStatus: null },
@@ -335,5 +327,47 @@ export const AdminCanPerformRegularSubmitWithAdminSubmitPermissions: Story = {
   args: {
     role: "Admin",
     permissions: ["data_submission:view", "data_submission:cancel", "data_submission:admin_submit"],
+  },
+};
+
+export const UserIsMissingSubmitPermissions: Story = {
+  name: "User is missing 'data_submission:create' and 'data_submission:admin_submit' permissions",
+  args: {
+    role: "Admin",
+    permissions: ["data_submission:view", "data_submission:review", "data_submission:cancel"],
+  },
+};
+
+export const Withdraw: Story = {
+  name: "User can Withdraw their submitted submission",
+  args: {
+    submissionStatus: "Submitted",
+  },
+};
+
+export const Release: Story = {
+  name: "User with 'data_submission:review' can Release a submitted submission",
+  args: {
+    role: "Admin",
+    permissions: ["data_submission:view", "data_submission:review"],
+    submissionStatus: "Submitted",
+  },
+};
+
+export const Complete: Story = {
+  name: "User with 'data_submission:confirm' can Complete a released submission",
+  args: {
+    role: "Admin",
+    permissions: ["data_submission:view", "data_submission:confirm"],
+    submissionStatus: "Released",
+  },
+};
+
+export const Completed: Story = {
+  name: "No actions are shown once a submission is completed",
+  args: {
+    role: "Admin",
+    permissions: ["data_submission:view", "data_submission:confirm", "data_submission:confirm"],
+    submissionStatus: "Completed",
   },
 };

--- a/src/content/dataSubmissions/DataSubmissionActions.tsx
+++ b/src/content/dataSubmissions/DataSubmissionActions.tsx
@@ -147,11 +147,10 @@ const actionConfig: Record<ActionKey, ActionConfig> = {
 };
 
 type Props = {
-  loading?: boolean;
   onAction: (action: SubmissionAction, reviewComment?: string) => Promise<void>;
 };
 
-const DataSubmissionActions = ({ loading, onAction }: Props) => {
+const DataSubmissionActions = ({ onAction }: Props) => {
   const { user } = useAuthContext();
   const { data, qcData } = useSubmissionContext();
   const { getSubmission: submission } = data || {};
@@ -161,12 +160,12 @@ const DataSubmissionActions = ({ loading, onAction }: Props) => {
   const [reviewComment, setReviewComment] = useState("");
 
   const submitActionButton: SubmitButtonResult = useMemo(() => {
-    if (!data?.getSubmission?._id || loading) {
+    if (!data?.getSubmission?._id) {
       return { enabled: false };
     }
 
-    return shouldEnableSubmit(data.getSubmission, qcData?.submissionQCResults?.results, user);
-  }, [data?.getSubmission, qcData?.submissionQCResults?.results, user, loading]);
+    return shouldEnableSubmit(data, qcData?.submissionQCResults?.results, user);
+  }, [data?.getSubmission, qcData?.submissionQCResults?.results, user]);
 
   const releaseActionButton: ReleaseInfo = useMemo(
     () => shouldDisableRelease(data?.getSubmission),

--- a/src/content/dataSubmissions/DataSubmissionActions.tsx
+++ b/src/content/dataSubmissions/DataSubmissionActions.tsx
@@ -209,8 +209,7 @@ const DataSubmissionActions = ({ onAction }: Props) => {
   return (
     <StyledActionWrapper direction="row" spacing={2}>
       {/* Action Buttons */}
-      {canShowAction("Submit") ||
-      (canShowAction("AdminSubmit") && submitActionButton?.isAdminOverride) ? (
+      {canShowAction("Submit") || canShowAction("AdminSubmit") ? (
         <Tooltip
           placement="top"
           title={submitActionButton?.tooltip}

--- a/src/content/dataSubmissions/DataSubmissionActions.tsx
+++ b/src/content/dataSubmissions/DataSubmissionActions.tsx
@@ -165,7 +165,7 @@ const DataSubmissionActions = ({ onAction }: Props) => {
     }
 
     return shouldEnableSubmit(data, qcData?.submissionQCResults?.results, user);
-  }, [data?.getSubmission, qcData?.submissionQCResults?.results, user]);
+  }, [data, qcData?.submissionQCResults?.results, user]);
 
   const releaseActionButton: ReleaseInfo = useMemo(
     () => shouldDisableRelease(data?.getSubmission),

--- a/src/content/dataSubmissions/DataSubmissionActions.tsx
+++ b/src/content/dataSubmissions/DataSubmissionActions.tsx
@@ -1,13 +1,14 @@
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 import { LoadingButton } from "@mui/lab";
 import { Button, OutlinedInput, Stack, Typography, styled } from "@mui/material";
 import { isEqual } from "lodash";
 import { useAuthContext } from "../../components/Contexts/AuthContext";
 import CustomDialog from "../../components/GenericDialog";
-import { ReleaseInfo } from "../../utils";
+import { ReleaseInfo, shouldDisableRelease, shouldEnableSubmit } from "../../utils";
 import Tooltip from "../../components/Tooltip";
 import { TOOLTIP_TEXT } from "../../config/DashboardTooltips";
 import { hasPermission } from "../../config/AuthPermissions";
+import { useSubmissionContext } from "../../components/Contexts/SubmissionContext";
 
 const StyledActionWrapper = styled(Stack)(() => ({
   justifyContent: "center",
@@ -146,25 +147,31 @@ const actionConfig: Record<ActionKey, ActionConfig> = {
 };
 
 type Props = {
-  submission: Submission;
-  submitActionButton: SubmitButtonResult;
-  releaseActionButton: ReleaseInfo;
+  loading?: boolean;
   onAction: (action: SubmissionAction, reviewComment?: string) => Promise<void>;
-  onError: (message: string) => void;
 };
 
-const DataSubmissionActions = ({
-  submission,
-  submitActionButton,
-  releaseActionButton,
-  onAction,
-  onError,
-}: Props) => {
+const DataSubmissionActions = ({ loading, onAction }: Props) => {
   const { user } = useAuthContext();
+  const { data, qcData } = useSubmissionContext();
+  const { getSubmission: submission } = data || {};
 
   const [currentDialog, setCurrentDialog] = useState<ActiveDialog | null>(null);
   const [action, setAction] = useState<SubmissionAction | null>(null);
   const [reviewComment, setReviewComment] = useState("");
+
+  const submitActionButton: SubmitButtonResult = useMemo(() => {
+    if (!data?.getSubmission?._id || loading) {
+      return { enabled: false };
+    }
+
+    return shouldEnableSubmit(data.getSubmission, qcData?.submissionQCResults?.results, user);
+  }, [data?.getSubmission, qcData?.submissionQCResults?.results, user, loading]);
+
+  const releaseActionButton: ReleaseInfo = useMemo(
+    () => shouldDisableRelease(data?.getSubmission),
+    [data?.getSubmission?.crossSubmissionStatus, data?.getSubmission?.otherSubmissions]
+  );
 
   const handleOnAction = async (action: SubmissionAction) => {
     if (currentDialog) {
@@ -229,7 +236,7 @@ const DataSubmissionActions = ({
           placement="top"
           title={TOOLTIP_TEXT.SUBMISSION_ACTIONS.RELEASE.DISABLED.NO_CROSS_VALIDATION}
           open={undefined} // will use hoverListener to open
-          disableHoverListener={!((action && action !== "Release") || releaseActionButton.disable)}
+          disableHoverListener={!((action && action !== "Release") || releaseActionButton?.disable)}
         >
           <span>
             <StyledLoadingButton
@@ -241,7 +248,7 @@ const DataSubmissionActions = ({
                 )
               }
               loading={action === "Release"}
-              disabled={(action && action !== "Release") || releaseActionButton.disable}
+              disabled={(action && action !== "Release") || releaseActionButton?.disable}
             >
               Release
             </StyledLoadingButton>
@@ -292,7 +299,6 @@ const DataSubmissionActions = ({
           Cancel
         </StyledLoadingButton>
       ) : null}
-
       {/* Submit Dialog */}
       <StyledDialog
         open={currentDialog === "Submit" && !submitActionButton.isAdminOverride}
@@ -320,7 +326,6 @@ const DataSubmissionActions = ({
             : "This action will lock your submission and it will no longer accept updates to the data. Are you sure you want to proceed?"}
         </StyledDialogText>
       </StyledDialog>
-
       {/* Admin Submit Dialog */}
       <StyledDialog
         open={currentDialog === "Submit" && submitActionButton.isAdminOverride}
@@ -355,7 +360,6 @@ const DataSubmissionActions = ({
           required
         />
       </StyledDialog>
-
       {/* Release Dialog (default) */}
       <StyledDialog
         open={currentDialog === "Release"}
@@ -382,7 +386,6 @@ const DataSubmissionActions = ({
           changes to the data. Are you sure you want to proceed?
         </StyledDialogText>
       </StyledDialog>
-
       {/* Release dialog (cross-validation) */}
       <StyledDialog
         open={currentDialog === "ReleaseCrossValidation"}
@@ -409,7 +412,6 @@ const DataSubmissionActions = ({
           want to release this data submission to Data Commons?
         </StyledDialogText>
       </StyledDialog>
-
       {/* Cancel Dialog */}
       <StyledDialog
         open={currentDialog === "Cancel"}
@@ -436,7 +438,6 @@ const DataSubmissionActions = ({
           you want to proceed?
         </StyledDialogText>
       </StyledDialog>
-
       {/* Withdraw Dialog */}
       <StyledDialog
         open={currentDialog === "Withdraw"}
@@ -463,7 +464,6 @@ const DataSubmissionActions = ({
           to update the data within the submission. Are you certain you want to proceed?
         </StyledDialogText>
       </StyledDialog>
-
       {/* Reject Dialog */}
       <StyledDialog
         open={currentDialog === "Reject"}
@@ -499,7 +499,6 @@ const DataSubmissionActions = ({
           required
         />
       </StyledDialog>
-
       {/* Complete Dialog */}
       <StyledDialog
         open={currentDialog === "Complete"}

--- a/src/utils/dataSubmissionUtils.test.ts
+++ b/src/utils/dataSubmissionUtils.test.ts
@@ -67,7 +67,11 @@ describe("General Submit", () => {
       metadataValidationStatus: "Error",
       fileValidationStatus: "Error",
     };
-    const result = utils.shouldEnableSubmit(submission, baseQCResults, baseUser);
+    const result = utils.shouldEnableSubmit(
+      { getSubmission: submission, batchStatusList: null, submissionStats: null },
+      baseQCResults,
+      baseUser
+    );
     expect(result.enabled).toBe(false);
     expect(result.isAdminOverride).toBe(false);
   });
@@ -78,7 +82,11 @@ describe("General Submit", () => {
       metadataValidationStatus: "Passed",
       fileValidationStatus: "Error",
     };
-    const result = utils.shouldEnableSubmit(submission, baseQCResults, baseUser);
+    const result = utils.shouldEnableSubmit(
+      { getSubmission: submission, batchStatusList: null, submissionStats: null },
+      baseQCResults,
+      baseUser
+    );
     expect(result.enabled).toBe(false);
     expect(result.isAdminOverride).toBe(false);
   });
@@ -89,7 +97,11 @@ describe("General Submit", () => {
       metadataValidationStatus: "Error",
       fileValidationStatus: "Passed",
     };
-    const result = utils.shouldEnableSubmit(submission, baseQCResults, baseUser);
+    const result = utils.shouldEnableSubmit(
+      { getSubmission: submission, batchStatusList: null, submissionStats: null },
+      baseQCResults,
+      baseUser
+    );
     expect(result.enabled).toBe(false);
     expect(result.isAdminOverride).toBe(false);
   });
@@ -100,7 +112,11 @@ describe("General Submit", () => {
       metadataValidationStatus: "Warning",
       fileValidationStatus: "Error",
     };
-    const result = utils.shouldEnableSubmit(submission, baseQCResults, baseUser);
+    const result = utils.shouldEnableSubmit(
+      { getSubmission: submission, batchStatusList: null, submissionStats: null },
+      baseQCResults,
+      baseUser
+    );
     expect(result.enabled).toBe(false);
     expect(result.isAdminOverride).toBe(false);
   });
@@ -111,7 +127,11 @@ describe("General Submit", () => {
       metadataValidationStatus: "Error",
       fileValidationStatus: "Warning",
     };
-    const result = utils.shouldEnableSubmit(submission, baseQCResults, baseUser);
+    const result = utils.shouldEnableSubmit(
+      { getSubmission: submission, batchStatusList: null, submissionStats: null },
+      baseQCResults,
+      baseUser
+    );
     expect(result.enabled).toBe(false);
     expect(result.isAdminOverride).toBe(false);
   });
@@ -123,7 +143,11 @@ describe("General Submit", () => {
       metadataValidationStatus: "Passed",
       fileValidationStatus: null,
     };
-    const result = utils.shouldEnableSubmit(submission, baseQCResults, baseUser);
+    const result = utils.shouldEnableSubmit(
+      { getSubmission: submission, batchStatusList: null, submissionStats: null },
+      baseQCResults,
+      baseUser
+    );
     expect(result.enabled).toBe(true);
     expect(result.isAdminOverride).toBe(false);
   });
@@ -134,7 +158,11 @@ describe("General Submit", () => {
       metadataValidationStatus: "Passed",
       fileValidationStatus: "Passed",
     };
-    const result = utils.shouldEnableSubmit(submission, baseQCResults, baseUser);
+    const result = utils.shouldEnableSubmit(
+      { getSubmission: submission, batchStatusList: null, submissionStats: null },
+      baseQCResults,
+      baseUser
+    );
     expect(result.enabled).toBe(true);
     expect(result.isAdminOverride).toBe(false);
   });
@@ -145,7 +173,11 @@ describe("General Submit", () => {
       metadataValidationStatus: null,
       fileValidationStatus: "Passed",
     };
-    const result = utils.shouldEnableSubmit(submission, baseQCResults, baseUser);
+    const result = utils.shouldEnableSubmit(
+      { getSubmission: submission, batchStatusList: null, submissionStats: null },
+      baseQCResults,
+      baseUser
+    );
     expect(result.enabled).toBe(false);
     expect(result.isAdminOverride).toBe(false);
   });
@@ -156,7 +188,11 @@ describe("General Submit", () => {
       metadataValidationStatus: "Passed",
       fileValidationStatus: null,
     };
-    const result = utils.shouldEnableSubmit(submission, baseQCResults, baseUser);
+    const result = utils.shouldEnableSubmit(
+      { getSubmission: submission, batchStatusList: null, submissionStats: null },
+      baseQCResults,
+      baseUser
+    );
     expect(result.enabled).toBe(false);
     expect(result.isAdminOverride).toBe(false);
   });
@@ -169,7 +205,11 @@ describe("General Submit", () => {
       fileValidationStatus: null,
       intention: "Delete",
     };
-    const result = utils.shouldEnableSubmit(submission, baseQCResults, baseUser);
+    const result = utils.shouldEnableSubmit(
+      { getSubmission: submission, batchStatusList: null, submissionStats: null },
+      baseQCResults,
+      baseUser
+    );
     expect(result.enabled).toBe(true);
     expect(result.isAdminOverride).toBe(false);
   });
@@ -181,7 +221,11 @@ describe("General Submit", () => {
       fileValidationStatus: null,
       intention: "New/Update",
     };
-    const result = utils.shouldEnableSubmit(submission, baseQCResults, baseUser);
+    const result = utils.shouldEnableSubmit(
+      { getSubmission: submission, batchStatusList: null, submissionStats: null },
+      baseQCResults,
+      baseUser
+    );
     expect(result.enabled).toBe(false);
     expect(result.isAdminOverride).toBe(false);
   });
@@ -193,7 +237,11 @@ describe("General Submit", () => {
       fileValidationStatus: "Passed",
       intention: "Delete",
     };
-    const result = utils.shouldEnableSubmit(submission, baseQCResults, baseUser);
+    const result = utils.shouldEnableSubmit(
+      { getSubmission: submission, batchStatusList: null, submissionStats: null },
+      baseQCResults,
+      baseUser
+    );
     expect(result.enabled).toBe(false);
     expect(result.isAdminOverride).toBe(false);
   });
@@ -205,7 +253,11 @@ describe("General Submit", () => {
       fileValidationStatus: "Error",
       intention: "Delete",
     };
-    const result = utils.shouldEnableSubmit(submission, baseQCResults, baseUser);
+    const result = utils.shouldEnableSubmit(
+      { getSubmission: submission, batchStatusList: null, submissionStats: null },
+      baseQCResults,
+      baseUser
+    );
     expect(result.enabled).toBe(false);
     expect(result.isAdminOverride).toBe(false);
   });
@@ -216,7 +268,11 @@ describe("General Submit", () => {
       metadataValidationStatus: null,
       fileValidationStatus: null,
     };
-    const result = utils.shouldEnableSubmit(submission, baseQCResults, baseUser);
+    const result = utils.shouldEnableSubmit(
+      { getSubmission: submission, batchStatusList: null, submissionStats: null },
+      baseQCResults,
+      baseUser
+    );
     expect(result.enabled).toBe(false);
     expect(result.isAdminOverride).toBe(false);
   });
@@ -227,7 +283,11 @@ describe("General Submit", () => {
       metadataValidationStatus: "Validating",
       fileValidationStatus: "Validating",
     };
-    const result = utils.shouldEnableSubmit(submission, baseQCResults, baseUser);
+    const result = utils.shouldEnableSubmit(
+      { getSubmission: submission, batchStatusList: null, submissionStats: null },
+      baseQCResults,
+      baseUser
+    );
     expect(result.enabled).toBe(false);
     expect(result.isAdminOverride).toBe(false);
   });
@@ -238,7 +298,11 @@ describe("General Submit", () => {
       metadataValidationStatus: "Validating",
       fileValidationStatus: "Passed",
     };
-    const result = utils.shouldEnableSubmit(submission, baseQCResults, baseUser);
+    const result = utils.shouldEnableSubmit(
+      { getSubmission: submission, batchStatusList: null, submissionStats: null },
+      baseQCResults,
+      baseUser
+    );
     expect(result.enabled).toBe(false);
     expect(result.isAdminOverride).toBe(false);
   });
@@ -249,7 +313,11 @@ describe("General Submit", () => {
       metadataValidationStatus: "Passed",
       fileValidationStatus: "Validating",
     };
-    const result = utils.shouldEnableSubmit(submission, baseQCResults, baseUser);
+    const result = utils.shouldEnableSubmit(
+      { getSubmission: submission, batchStatusList: null, submissionStats: null },
+      baseQCResults,
+      baseUser
+    );
     expect(result.enabled).toBe(false);
     expect(result.isAdminOverride).toBe(false);
   });
@@ -260,7 +328,11 @@ describe("General Submit", () => {
       metadataValidationStatus: "New",
       fileValidationStatus: "New",
     };
-    const result = utils.shouldEnableSubmit(submission, baseQCResults, baseUser);
+    const result = utils.shouldEnableSubmit(
+      { getSubmission: submission, batchStatusList: null, submissionStats: null },
+      baseQCResults,
+      baseUser
+    );
     expect(result.enabled).toBe(false);
     expect(result.isAdminOverride).toBe(false);
   });
@@ -271,7 +343,11 @@ describe("General Submit", () => {
       metadataValidationStatus: "New",
       fileValidationStatus: "Passed",
     };
-    const result = utils.shouldEnableSubmit(submission, baseQCResults, baseUser);
+    const result = utils.shouldEnableSubmit(
+      { getSubmission: submission, batchStatusList: null, submissionStats: null },
+      baseQCResults,
+      baseUser
+    );
     expect(result.enabled).toBe(false);
     expect(result.isAdminOverride).toBe(false);
   });
@@ -282,7 +358,11 @@ describe("General Submit", () => {
       metadataValidationStatus: "Passed",
       fileValidationStatus: "New",
     };
-    const result = utils.shouldEnableSubmit(submission, baseQCResults, baseUser);
+    const result = utils.shouldEnableSubmit(
+      { getSubmission: submission, batchStatusList: null, submissionStats: null },
+      baseQCResults,
+      baseUser
+    );
     expect(result.enabled).toBe(false);
     expect(result.isAdminOverride).toBe(false);
   });
@@ -293,7 +373,11 @@ describe("General Submit", () => {
       metadataValidationStatus: "Warning",
       fileValidationStatus: "Warning",
     };
-    const result = utils.shouldEnableSubmit(submission, baseQCResults, baseUser);
+    const result = utils.shouldEnableSubmit(
+      { getSubmission: submission, batchStatusList: null, submissionStats: null },
+      baseQCResults,
+      baseUser
+    );
     expect(result.enabled).toBe(true);
     expect(result.isAdminOverride).toBe(false);
   });
@@ -304,7 +388,11 @@ describe("General Submit", () => {
       metadataValidationStatus: "Passed",
       fileValidationStatus: "Passed",
     };
-    const result = utils.shouldEnableSubmit(submission, baseQCResults, baseUser);
+    const result = utils.shouldEnableSubmit(
+      { getSubmission: submission, batchStatusList: null, submissionStats: null },
+      baseQCResults,
+      baseUser
+    );
     expect(result.enabled).toBe(true);
     expect(result.isAdminOverride).toBe(false);
   });
@@ -315,7 +403,11 @@ describe("General Submit", () => {
       metadataValidationStatus: "Passed",
       fileValidationStatus: "Warning",
     };
-    const result = utils.shouldEnableSubmit(submission, baseQCResults, baseUser);
+    const result = utils.shouldEnableSubmit(
+      { getSubmission: submission, batchStatusList: null, submissionStats: null },
+      baseQCResults,
+      baseUser
+    );
     expect(result.enabled).toBe(true);
     expect(result.isAdminOverride).toBe(false);
   });
@@ -326,7 +418,11 @@ describe("General Submit", () => {
       metadataValidationStatus: "Warning",
       fileValidationStatus: "Warning",
     };
-    const result = utils.shouldEnableSubmit(submission, baseQCResults, baseUser);
+    const result = utils.shouldEnableSubmit(
+      { getSubmission: submission, batchStatusList: null, submissionStats: null },
+      baseQCResults,
+      baseUser
+    );
     expect(result.enabled).toBe(true);
     expect(result.isAdminOverride).toBe(false);
   });
@@ -350,7 +446,11 @@ describe("Admin Submit", () => {
       role: "Admin",
       permissions: ["data_submission:view", "data_submission:admin_submit"],
     };
-    const result = utils.shouldEnableSubmit(submission, baseQCResults, user);
+    const result = utils.shouldEnableSubmit(
+      { getSubmission: submission, batchStatusList: null, submissionStats: null },
+      baseQCResults,
+      user
+    );
     expect(result.enabled).toBe(true);
     expect(result.isAdminOverride).toBe(true);
   });
@@ -365,7 +465,11 @@ describe("Admin Submit", () => {
       ...baseUser,
       permissions: ["data_submission:view", "data_submission:admin_submit"],
     };
-    const result = utils.shouldEnableSubmit(submission, baseQCResults, user);
+    const result = utils.shouldEnableSubmit(
+      { getSubmission: submission, batchStatusList: null, submissionStats: null },
+      baseQCResults,
+      user
+    );
     expect(result.enabled).toBe(true);
     expect(result.isAdminOverride).toBe(false);
   });
@@ -380,7 +484,11 @@ describe("Admin Submit", () => {
       ...baseUser,
       permissions: ["data_submission:view", "data_submission:admin_submit"],
     };
-    const result = utils.shouldEnableSubmit(submission, baseQCResults, user);
+    const result = utils.shouldEnableSubmit(
+      { getSubmission: submission, batchStatusList: null, submissionStats: null },
+      baseQCResults,
+      user
+    );
     expect(result.enabled).toBe(false);
     expect(result.isAdminOverride).toBe(false);
   });
@@ -395,7 +503,11 @@ describe("Admin Submit", () => {
       ...baseUser,
       permissions: ["data_submission:view", "data_submission:admin_submit"],
     };
-    const result = utils.shouldEnableSubmit(submission, baseQCResults, user);
+    const result = utils.shouldEnableSubmit(
+      { getSubmission: submission, batchStatusList: null, submissionStats: null },
+      baseQCResults,
+      user
+    );
     expect(result.enabled).toBe(false);
   });
 
@@ -412,7 +524,11 @@ describe("Admin Submit", () => {
       role: "Admin",
       permissions: ["data_submission:view", "data_submission:admin_submit"],
     };
-    const result = utils.shouldEnableSubmit(submission, baseQCResults, user);
+    const result = utils.shouldEnableSubmit(
+      { getSubmission: submission, batchStatusList: null, submissionStats: null },
+      baseQCResults,
+      user
+    );
     expect(result.enabled).toBe(true);
     expect(result.isAdminOverride).toBe(true);
   });
@@ -443,7 +559,11 @@ describe("Admin Submit", () => {
       role: "Admin",
       permissions: ["data_submission:view", "data_submission:admin_submit"],
     };
-    const result = utils.shouldEnableSubmit(submission, baseQCResults, user);
+    const result = utils.shouldEnableSubmit(
+      { getSubmission: submission, batchStatusList: null, submissionStats: null },
+      baseQCResults,
+      user
+    );
     expect(result.enabled).toBe(false);
     expect(result.isAdminOverride).toBe(false);
   });
@@ -472,7 +592,11 @@ describe("Admin Submit", () => {
     const qcResults: Pick<QCResult, "errors">[] = [
       { errors: [{ code: null, title: "Orphaned file found", description: "" }] },
     ];
-    const result = utils.shouldEnableSubmit(submission, qcResults, baseUser);
+    const result = utils.shouldEnableSubmit(
+      { getSubmission: submission, batchStatusList: null, submissionStats: null },
+      qcResults,
+      baseUser
+    );
     expect(result._identifier).toBe("Submission should not have orphaned files");
     expect(result.enabled).toBe(false);
     expect(result.isAdminOverride).toBe(false);
@@ -491,7 +615,11 @@ describe("Admin Submit", () => {
       role: "Admin",
       permissions: ["data_submission:view", "data_submission:admin_submit"],
     };
-    const result = utils.shouldEnableSubmit(submission, baseQCResults, user);
+    const result = utils.shouldEnableSubmit(
+      { getSubmission: submission, batchStatusList: null, submissionStats: null },
+      baseQCResults,
+      user
+    );
     expect(result.enabled).toBe(true);
     expect(result.isAdminOverride).toBe(true);
   });
@@ -507,7 +635,11 @@ describe("Admin Submit", () => {
       ...baseUser,
       permissions: ["data_submission:view", "data_submission:admin_submit"],
     };
-    const result = utils.shouldEnableSubmit(submission, baseQCResults, user);
+    const result = utils.shouldEnableSubmit(
+      { getSubmission: submission, batchStatusList: null, submissionStats: null },
+      baseQCResults,
+      user
+    );
     expect(result.enabled).toBe(false);
     expect(result.isAdminOverride).toBe(false);
   });
@@ -521,7 +653,11 @@ describe("Submit > Submission Type/Intention", () => {
       metadataValidationStatus: "Error",
       fileValidationStatus: "Error",
     };
-    const result = utils.shouldEnableSubmit(submission, baseQCResults, baseUser);
+    const result = utils.shouldEnableSubmit(
+      { getSubmission: submission, batchStatusList: null, submissionStats: null },
+      baseQCResults,
+      baseUser
+    );
     expect(result.enabled).toBe(false);
     expect(result.isAdminOverride).toBe(false);
   });
@@ -532,14 +668,14 @@ describe("shouldAllowAdminOverride", () => {
     const customConditions: SubmitButtonCondition[] = [
       {
         _identifier: "test-identifier-1",
-        preConditionCheck: (s) => s._id === "test-id-1",
-        check: (s) => s.name === "test-name-1",
+        preConditionCheck: ({ getSubmission: s }) => s._id === "test-id-1",
+        check: ({ getSubmission: s }) => s.name === "test-name-1",
         required: true,
       },
       {
         _identifier: "test-identifier-2",
-        preConditionCheck: (s) => s._id === "test-id-2",
-        check: (s) => s.name === "test-name-2",
+        preConditionCheck: ({ getSubmission: s }) => s._id === "test-id-2",
+        check: ({ getSubmission: s }) => s.name === "test-name-2",
         required: true,
       },
     ];
@@ -572,7 +708,10 @@ describe("shouldAllowAdminOverride", () => {
       metadataValidationStatus: "Error",
       fileValidationStatus: null,
     };
-    const result = utils.shouldAllowAdminOverride(submission, baseQCResults);
+    const result = utils.shouldAllowAdminOverride(
+      { getSubmission: submission, batchStatusList: null, submissionStats: null },
+      baseQCResults
+    );
     expect(result._identifier).toBe("Admin Override - Submission has validation errors");
     expect(result.enabled).toBe(true);
     expect(result.isAdminOverride).toBe(true);
@@ -585,7 +724,10 @@ describe("shouldAllowAdminOverride", () => {
       metadataValidationStatus: "Passed",
       fileValidationStatus: null,
     };
-    const result = utils.shouldAllowAdminOverride(submission, baseQCResults);
+    const result = utils.shouldAllowAdminOverride(
+      { getSubmission: submission, batchStatusList: null, submissionStats: null },
+      baseQCResults
+    );
     expect(result._identifier).toBe(undefined);
     expect(result.enabled).toBe(false);
     expect(result.isAdminOverride).toBe(false);
@@ -598,7 +740,10 @@ describe("shouldAllowAdminOverride", () => {
       metadataValidationStatus: "Passed",
       fileValidationStatus: "Validating",
     };
-    const result = utils.shouldAllowAdminOverride(submission, baseQCResults);
+    const result = utils.shouldAllowAdminOverride(
+      { getSubmission: submission, batchStatusList: null, submissionStats: null },
+      baseQCResults
+    );
     expect(result._identifier).toBe("Validation should not currently be running");
     expect(result.enabled).toBe(false);
     expect(result.isAdminOverride).toBe(false);
@@ -614,7 +759,10 @@ describe("shouldAllowAdminOverride", () => {
       fileValidationStatus: "Passed",
     };
 
-    const result = utils.shouldAllowAdminOverride(submission, baseQCResults);
+    const result = utils.shouldAllowAdminOverride(
+      { getSubmission: submission, batchStatusList: null, submissionStats: null },
+      baseQCResults
+    );
     expect(result._identifier).toBe("test-identifier-1");
     expect(result.enabled).toBe(false);
     expect(result.isAdminOverride).toBe(false);


### PR DESCRIPTION
### Overview

Added Storybook support for all of the Data Submission submit button reasons for being disabled. Also, updated the button to show regular submit when user has admin submit permission.

### Change Details (Specifics)

- Added storybook support for all scenarios regarding the DS Submit button, including disabled conditions, admin submit conditions, and admin performing regular submit
- Added basic storybook support for all additional DS action buttons
- Reordered submit button conditions in terms of criticality, so that the most critical conditions show their tooltip first
- Updated documentation slightly to include regular submit scenario and added a note about order
- Updated DataSubmissionActions to prefer using submission context instead of prop drilling
- Moved check for uploading batch to within the submit button config to better keep everything in one place
- Added additional tooltips for submit button disabled states

### Related Ticket(s)

[CRDCDH-2673](https://tracker.nci.nih.gov/browse/CRDCDH-2673) (US)
[CRDCDH-2698](https://tracker.nci.nih.gov/browse/CRDCDH-2698) (Task)
