### PR TITLE
CRDCDH-2763 Add warning when assigning study to multiple programs

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -15,3 +15,4 @@ export * from "./envUtils";
 export * from "./logger";
 export * from "./fetchUtils";
 export * from "./dashboardUtils";
+export * from "./studyUtils";

--- a/src/utils/studyUtils.test.ts
+++ b/src/utils/studyUtils.test.ts
@@ -1,50 +1,167 @@
-import { formatAccessTypes } from "./studyUtils";
+import * as utils from "./studyUtils";
 
 describe("formatAccessTypes", () => {
   it('should return "Controlled, Open" when both controlledAccess and openAccess are true', () => {
-    const result = formatAccessTypes(true, true);
+    const result = utils.formatAccessTypes(true, true);
     expect(result).toBe("Controlled, Open");
   });
 
   it('should return "Controlled" when only controlledAccess is true', () => {
-    const result = formatAccessTypes(true, false);
+    const result = utils.formatAccessTypes(true, false);
     expect(result).toBe("Controlled");
   });
 
   it('should return "Open" when only openAccess is true', () => {
-    const result = formatAccessTypes(false, true);
+    const result = utils.formatAccessTypes(false, true);
     expect(result).toBe("Open");
   });
 
   it("should return an empty string when both controlledAccess and openAccess are false", () => {
-    const result = formatAccessTypes(false, false);
+    const result = utils.formatAccessTypes(false, false);
     expect(result).toBe("");
   });
 
   it("should handle controlledAccess as true and openAccess as undefined", () => {
-    const result = formatAccessTypes(true, undefined);
+    const result = utils.formatAccessTypes(true, undefined);
     expect(result).toBe("Controlled");
   });
 
   it("should handle openAccess as true and controlledAccess as undefined", () => {
-    const result = formatAccessTypes(undefined, true);
+    const result = utils.formatAccessTypes(undefined, true);
     expect(result).toBe("Open");
   });
 
   it("should handle both controlledAccess and openAccess as undefined", () => {
-    const result = formatAccessTypes(undefined, undefined);
+    const result = utils.formatAccessTypes(undefined, undefined);
     expect(result).toBe("");
   });
 
   it("should ignore non-boolean truthy values for controlledAccess and openAccess", () => {
     // @ts-expect-error Testing with non-boolean input
-    const result = formatAccessTypes(1, "true");
+    const result = utils.formatAccessTypes(1, "true");
     expect(result).toBe("");
   });
 
   it("should handle non-boolean falsy values for controlledAccess and openAccess", () => {
     // @ts-expect-error Testing with non-boolean input
-    const result = formatAccessTypes(0, "");
+    const result = utils.formatAccessTypes(0, "");
     expect(result).toBe("");
+  });
+});
+
+describe("hasStudyWithMultiplePrograms", () => {
+  const baseStudy = (
+    programs: Pick<ApprovedStudy["programs"][number], "_id" | "name">[] = []
+  ): ApprovedStudy => ({
+    _id: "study1",
+    programs: programs?.map((p) => ({
+      ...p,
+      abbreviation: "",
+      description: "",
+      status: "Active",
+      conciergeID: "",
+      conciergeName: "",
+      conciergeEmail: "",
+      studies: [],
+      readOnly: false,
+      createdAt: "",
+      updateAt: "",
+    })),
+    originalOrg: "",
+    studyName: "",
+    studyAbbreviation: "",
+    dbGaPID: "",
+    controlledAccess: false,
+    openAccess: false,
+    PI: "",
+    ORCID: "",
+    primaryContact: {
+      _id: "",
+      firstName: "",
+      lastName: "",
+      role: "User",
+      email: "",
+      dataCommons: [],
+      dataCommonsDisplayNames: [],
+      studies: [],
+      institution: undefined,
+      IDP: "nih",
+      userStatus: "Active",
+      permissions: [],
+      notifications: [],
+      updateAt: "",
+      createdAt: "",
+    },
+    useProgramPC: false,
+    createdAt: "",
+  });
+
+  it("returns false when studies array is empty", () => {
+    expect(utils.hasStudyWithMultiplePrograms([], "prog1")).toBe(false);
+  });
+
+  it("returns false when newProgramId is an empty string", () => {
+    const studies = [baseStudy([{ _id: "a", name: "Test" }])];
+    expect(utils.hasStudyWithMultiplePrograms(studies, "")).toBe(false);
+  });
+
+  it("ignores 'NA' program and returns false when adding a new program results in a single entry", () => {
+    const studies = [baseStudy([{ _id: "na1", name: "NA" }])];
+    expect(utils.hasStudyWithMultiplePrograms(studies, "prog1")).toBe(false);
+  });
+
+  it("ignores 'NA' program and returns true when study is assigned to multiple programs", () => {
+    const studies = [
+      baseStudy([
+        { _id: "na1", name: "NA" },
+        { _id: "prog1", name: "Alpha" },
+      ]),
+    ];
+    expect(utils.hasStudyWithMultiplePrograms(studies, "prog2")).toBe(true);
+  });
+
+  it("returns false when the only existing program matches the newProgramId and is the only program", () => {
+    const studies = [baseStudy([{ _id: "prog1", name: "Alpha" }])];
+    expect(utils.hasStudyWithMultiplePrograms(studies, "prog1")).toBe(false);
+  });
+
+  it("returns true when a study has one other program and the newProgramId is different", () => {
+    const studies = [baseStudy([{ _id: "prog2", name: "Beta" }])];
+    expect(utils.hasStudyWithMultiplePrograms(studies, "prog1")).toBe(true);
+  });
+
+  it("returns false when study has null programs", () => {
+    const studies = [baseStudy(null)];
+    expect(utils.hasStudyWithMultiplePrograms(studies, "prog1")).toBe(false);
+  });
+
+  it("returns true when a study has multiple programs even before adding the new one", () => {
+    const studies = [
+      baseStudy([
+        { _id: "prog2", name: "Beta" },
+        { _id: "prog3", name: "Gamma" },
+      ]),
+    ];
+    expect(utils.hasStudyWithMultiplePrograms(studies, "prog1")).toBe(true);
+  });
+
+  it("returns true if at least one study in the list would become multi-program", () => {
+    const studies = [
+      baseStudy([{ _id: "na1", name: "NA" }]), // stays single
+      baseStudy([{ _id: "X", name: "X" }]), // becomes multi
+      baseStudy([
+        { _id: "Y", name: "Y" },
+        { _id: "na2", name: "NA" },
+      ]), // also multi
+    ];
+    expect(utils.hasStudyWithMultiplePrograms(studies, "prog1")).toBe(true);
+  });
+
+  it("returns false when none of the studies would become multi-program", () => {
+    const studies = [
+      baseStudy([{ _id: "na1", name: "NA" }]),
+      baseStudy([{ _id: "prog1", name: "Existing" }]),
+    ];
+    expect(utils.hasStudyWithMultiplePrograms(studies, "prog1")).toBe(false);
   });
 });

--- a/src/utils/studyUtils.ts
+++ b/src/utils/studyUtils.ts
@@ -20,3 +20,28 @@ export const formatAccessTypes = (controlledAccess: boolean, openAccess: boolean
 
   return properties.join(", ");
 };
+
+/**
+ * Determines whether any of the given studies would end up belonging to more than one program
+ * after assigning them to the specified program.  System-managed `"NA"` programs are ignored.
+ *
+ * @param {ApprovedStudy[]} studies - Array of approved studies.
+ * @param {string} newProgramId - The ID of the program under which each study is about to be saved.
+ * @returns `true` if at least one study would have more than one program (excluding `"NA"`);
+ *          otherwise `false`.
+ */
+export const hasStudyWithMultiplePrograms = (
+  studies: ApprovedStudy[],
+  newProgramId: string
+): boolean => {
+  if (!studies?.length || !newProgramId) {
+    return false;
+  }
+
+  return studies.some((study) => {
+    const validPrograms = study.programs?.filter((p) => p.name !== "NA") || [];
+    const distinctProgramIds = new Set<string>([...validPrograms.map((p) => p._id), newProgramId]);
+
+    return distinctProgramIds.size > 1;
+  });
+};


### PR DESCRIPTION
### Overview

Within the Edit Program page, when a study is assigned to multiple programs, a warning dialog will show.

> [!NOTE]
> ~There is a BE error that shows up when assigning a study to a program when the study belongs to the "NA" program.~ Edit: It was fixed. 

### Change Details (Specifics)

- Added warning dialog when a study is being assigned to multiple programs
- Added utility function to check for multiple programs with tests

### Related Ticket(s)

[CRDCDH-2763](https://tracker.nci.nih.gov/browse/CRDCDH-2763) (Task)
[CRDCDH-2585](https://tracker.nci.nih.gov/browse/CRDCDH-2585) (US)
