### PR TITLE
CRDCDH-2697 Update 'Uploading' font weight

### DIFF
--- a/src/content/dataSubmissions/DataActivity.tsx
+++ b/src/content/dataSubmissions/DataActivity.tsx
@@ -64,7 +64,7 @@ const StyledErrorDetailsButton = styled(Button)({
 const batchStatusStyles: Record<BatchStatus, SxProps> = {
   Uploading: {
     color: "#3800F0",
-    fontWeight: 600,
+    fontWeight: 800,
   },
   Failed: {
     color: "#B54717",


### PR DESCRIPTION
### Overview

Increased font weight for an 'Uploading' Batch.

### Change Details (Specifics)

![Screenshot 2025-05-22 at 5 13 48 PM](https://github.com/user-attachments/assets/a6a8ea96-fe20-482e-b832-1a8d4f8affe2)


### Related Ticket(s)

[CRDCDH-2697](https://tracker.nci.nih.gov/browse/CRDCDH-2697) (Task)
[CRDCDH-2612](https://tracker.nci.nih.gov/browse/CRDCDH-2612) (US)
