### PR TITLE
CRDCDH-2695 Update stats to "new" when model version changes

### DIFF
--- a/src/components/ModelSelection/index.tsx
+++ b/src/components/ModelSelection/index.tsx
@@ -106,6 +106,15 @@ const ModelSelection: FC<Props> = ({ disabled, ...rest }: Props) => {
             fileValidationStatus: "New",
             modelVersion: d.updateSubmissionModelVersion.modelVersion,
           },
+          submissionStats: {
+            stats: prev.submissionStats?.stats?.map((stat) => ({
+              ...stat,
+              new: stat?.total || 0,
+              error: 0,
+              passed: 0,
+              warning: 0,
+            })),
+          },
         }));
       } catch (err) {
         Logger.error("ModelSelection: API error received", err);


### PR DESCRIPTION
### Overview

When the validation status is reset after a model version change, the stats still remain as they were before. This can be misleading. Therefore, I updated all of the stats to "New" after the model version change.

### Change Details (Specifics)

N/A

### Related Ticket(s)

[CRDCDH-2695](https://tracker.nci.nih.gov/browse/CRDCDH-2695)
