### PR TITLE
HOTFIX: Coerce new value before evaluating

### DIFF
--- a/src/components/NodeComparison/ComparisonTable.test.tsx
+++ b/src/components/NodeComparison/ComparisonTable.test.tsx
@@ -448,6 +448,48 @@ describe("Implementation Requirements", () => {
       ...unchangedStyle,
     });
   });
+
+  it("should gray out columns where the NEW value is NULL", () => {
+    const { getByTestId } = render(
+      <ComparisonTable
+        newNode={{
+          ...baseNode,
+          props: JSON.stringify({ emptyVal: null, xyzEmpty: null, emptySame: null }),
+        }}
+        existingNode={{
+          ...baseNode,
+          props: JSON.stringify({ emptyVal: "wont", xyzEmpty: "be", emptySame: "changed" }),
+        }}
+        loading={false}
+      />
+    );
+
+    const unchangedStyle: React.CSSProperties = {
+      fontWeight: "400",
+      color: "#083A50",
+      backgroundColor: "#F2F6FA",
+    };
+
+    // No data changes anywhere
+    expect(getByTestId("node-comparison-table-existing-emptyVal")).toHaveStyle({
+      ...unchangedStyle,
+    });
+    expect(getByTestId("node-comparison-table-new-emptyVal")).toHaveStyle({
+      ...unchangedStyle,
+    });
+    expect(getByTestId("node-comparison-table-existing-xyzEmpty")).toHaveStyle({
+      ...unchangedStyle,
+    });
+    expect(getByTestId("node-comparison-table-new-xyzEmpty")).toHaveStyle({
+      ...unchangedStyle,
+    });
+    expect(getByTestId("node-comparison-table-existing-emptySame")).toHaveStyle({
+      ...unchangedStyle,
+    });
+    expect(getByTestId("node-comparison-table-new-emptySame")).toHaveStyle({
+      ...unchangedStyle,
+    });
+  });
 });
 
 describe("Snapshots", () => {

--- a/src/components/NodeComparison/ComparisonTable.tsx
+++ b/src/components/NodeComparison/ComparisonTable.tsx
@@ -124,7 +124,7 @@ const ComparisonTable: FC<ComparisonTableProps> = ({ newNode, existingNode, load
       allPropertyNames.filter((property) => {
         const [newVal, oldVal] = [newProps?.[property], existingProps?.[property]];
 
-        return (!isEqual(newVal, oldVal) && newVal !== "") || newVal === DELETE_DATA_SYMBOL;
+        return (!isEqual(newVal, oldVal) && !!newVal) || newVal === DELETE_DATA_SYMBOL;
       }),
     [newProps, existingProps, allPropertyNames]
   );


### PR DESCRIPTION
### Overview

PR to fix an integration issue where backend is using `null` to represent "empty" values, rather than an empty string.

### Change Details (Specifics)

N/A

### Related Ticket(s)

CRDCDH-2681
