### PR TITLE
CRDCDH-2707 Study Name field not reflecting error state

### DIFF
--- a/src/content/studies/StudyView.tsx
+++ b/src/content/studies/StudyView.tsx
@@ -484,6 +484,7 @@ const StudyView: FC<Props> = ({ _id }: Props) => {
                   required
                   disabled={retrievingStudy}
                   readOnly={saving}
+                  error={!!errors.studyName}
                   inputProps={{
                     "aria-labelledby": "studyNameLabel",
                     "data-testid": "studyName-input",
@@ -497,6 +498,7 @@ const StudyView: FC<Props> = ({ _id }: Props) => {
                   size="small"
                   disabled={retrievingStudy}
                   readOnly={saving}
+                  error={!!errors.studyAbbreviation}
                   inputProps={{
                     "aria-labelledby": "studyAbbreviationLabel",
                     "data-testid": "studyAbbreviation-input",


### PR DESCRIPTION
### Overview

Fix the Study Management -> Study Name/Abbreviation field not visually reflecting validation errors.

### Change Details (Specifics)

N/A

### Related Ticket(s)

CRDCDH-2707
