### PR TITLE
CRDCDH-2867 Bug: Fix select dropdown menu sizes and tooltip sizes

### DIFF
--- a/src/components/AdminPortal/Studies/ApprovedStudyFilters.tsx
+++ b/src/components/AdminPortal/Studies/ApprovedStudyFilters.tsx
@@ -3,7 +3,7 @@ import { debounce, sortBy } from "lodash";
 import { Box, FormControl, MenuItem, Stack, styled } from "@mui/material";
 import { Controller, useForm } from "react-hook-form";
 import StyledOutlinedInput from "../../StyledFormComponents/StyledOutlinedInput";
-import BaseSelect from "../../StyledFormComponents/StyledSelect";
+import StyledSelect from "../../StyledFormComponents/StyledSelect";
 import { useSearchParamsContext } from "../../Contexts/SearchParamsContext";
 import { Status, useOrganizationListContext } from "../../Contexts/OrganizationListContext";
 import SuspenseLoader from "../../SuspenseLoader";
@@ -25,12 +25,6 @@ const StyledFormControl = styled(FormControl)({
   marginRight: 0,
   minWidth: "250px",
   maxWidth: "250px",
-});
-
-const StyledSelect = styled(BaseSelect)({
-  "& .MuiPaper-root": {
-    width: "250px",
-  },
 });
 
 const initialTouchedFields: TouchedState = {
@@ -70,6 +64,7 @@ const ApprovedStudyFilters = ({ onChange }: Props) => {
     "dbGaPID",
     "accessType",
   ]);
+  const [selectMinWidth, setSelectMinWidth] = useState<number | null>(null);
   const [touchedFilters, setTouchedFilters] = useState<TouchedState>(initialTouchedFields);
   const debouncedOnChangeRef = useRef(
     debounce((form: FilterForm) => onChange?.(form), 500)
@@ -224,7 +219,13 @@ const ApprovedStudyFilters = ({ onChange }: Props) => {
               <StyledSelect
                 {...field}
                 value={field.value}
-                MenuProps={{ disablePortal: true }}
+                onOpen={(event) =>
+                  setSelectMinWidth((event.currentTarget as HTMLElement)?.offsetWidth || null)
+                }
+                MenuProps={{
+                  disablePortal: true,
+                  sx: { width: selectMinWidth ? `${selectMinWidth}px` : "auto" },
+                }}
                 inputProps={{ id: "programID-filter" }}
                 data-testid="programID-select"
                 onChange={(e) => {

--- a/src/components/CopyTextButton/index.tsx
+++ b/src/components/CopyTextButton/index.tsx
@@ -1,6 +1,6 @@
 import { forwardRef, memo } from "react";
 import { IconButton, IconButtonProps, styled, TooltipProps } from "@mui/material";
-import Tooltip from "../Tooltip";
+import StyledTooltip from "../StyledFormComponents/StyledTooltip";
 import { ReactComponent as CopyIconSvg } from "../../assets/icons/copy_icon_2.svg";
 
 const StyledCopyIDButton = styled(IconButton)(({ theme }) => ({
@@ -65,16 +65,17 @@ const CopyTextButton = ({
   };
 
   return title && !disabled ? (
-    <Tooltip
+    <StyledTooltip
       placement="top"
       title={title}
       open={undefined}
       disableHoverListener={!title}
       arrow
+      dynamic
       {...tooltipProps}
     >
       <CopyButton onClick={handleCopyText} disabled={disabled} {...rest} />
-    </Tooltip>
+    </StyledTooltip>
   ) : (
     <CopyButton onClick={handleCopyText} disabled={disabled} {...rest} />
   );

--- a/src/components/DataSubmissions/CreateDataSubmissionDialog.tsx
+++ b/src/components/DataSubmissions/CreateDataSubmissionDialog.tsx
@@ -223,6 +223,7 @@ const CreateDataSubmissionDialog: FC<Props> = ({ onCreate }) => {
   const [error, setError] = useState<boolean>(false);
   const [isDbGapRequired, setIsDbGapRequired] = useState<boolean>(false);
   const [dbGaPID, setDbGaPID] = useState<string>("");
+  const [selectMinWidth, setSelectMinWidth] = useState<number | null>(null);
 
   const shouldFetchAllStudies = useMemo<boolean>(
     () =>
@@ -470,7 +471,13 @@ const CreateDataSubmissionDialog: FC<Props> = ({ onCreate }) => {
                   <StyledSelect
                     {...field}
                     value={field.value || ""}
-                    MenuProps={{ disablePortal: true }}
+                    onOpen={(event) =>
+                      setSelectMinWidth((event.currentTarget as HTMLElement)?.offsetWidth || null)
+                    }
+                    MenuProps={{
+                      disablePortal: true,
+                      sx: { width: selectMinWidth ? `${selectMinWidth}px` : "auto" },
+                    }}
                     aria-describedby="submission-study-abbreviation-helper-text"
                     inputProps={{ "aria-labelledby": "study" }}
                     data-testid="create-data-submission-dialog-study-id-input"

--- a/src/components/DataSubmissions/DataSubmissionListFilters.tsx
+++ b/src/components/DataSubmissions/DataSubmissionListFilters.tsx
@@ -148,6 +148,7 @@ const DataSubmissionListFilters = ({
   ] = watch(["status", "organization", "dataCommons", "name", "dbGaPID", "submitterName"]);
 
   const [touchedFilters, setTouchedFilters] = useState<TouchedState>(initialTouchedFields);
+  const [selectMinWidth, setSelectMinWidth] = useState<number | null>(null);
 
   const debounceAfter3CharsInputs: FilterFormKey[] = ["name", "dbGaPID"];
   const debouncedOnChangeRef = useRef(
@@ -367,7 +368,13 @@ const DataSubmissionListFilters = ({
                         ? field.value
                         : "All"
                     }
-                    MenuProps={{ disablePortal: true }}
+                    onOpen={(event) =>
+                      setSelectMinWidth((event.currentTarget as HTMLElement)?.offsetWidth || null)
+                    }
+                    MenuProps={{
+                      disablePortal: true,
+                      sx: { width: selectMinWidth ? `${selectMinWidth}px` : "auto" },
+                    }}
                     inputProps={{
                       id: "organization-filter",
                       "data-testid": "organization-select-input",
@@ -528,7 +535,13 @@ const DataSubmissionListFilters = ({
                   <StyledSelect
                     {...field}
                     value={submitterNames?.includes(field.value) ? field.value : "All"}
-                    MenuProps={{ disablePortal: true }}
+                    onOpen={(event) => {
+                      setSelectMinWidth((event.currentTarget as HTMLElement)?.offsetWidth || null);
+                    }}
+                    MenuProps={{
+                      disablePortal: true,
+                      sx: { width: selectMinWidth ? `${selectMinWidth}px` : "auto" },
+                    }}
                     inputProps={{
                       id: "submitter-name-filter",
                       "data-testid": "submitter-name-select-input",

--- a/src/components/StyledFormComponents/StyledTooltip.tsx
+++ b/src/components/StyledFormComponents/StyledTooltip.tsx
@@ -1,10 +1,23 @@
 import { Tooltip as MuiToolTip, TooltipProps, styled } from "@mui/material";
 
-const StyledTooltip = styled((props: TooltipProps) => (
-  <MuiToolTip classes={{ popper: props.className }} {...props} />
-))(() => ({
+type TooltipPropsWithDynamic = TooltipProps & {
+  /**
+   * Indicates when text content within tooltip is dynamic. This
+   * increases the maxWidth of the tooltip.
+   *
+   * NOTE: It is is false by default
+   */
+  dynamic?: boolean;
+};
+
+const StyledTooltip = styled(
+  ({ dynamic, ...tooltipProps }: TooltipPropsWithDynamic) => (
+    <MuiToolTip classes={{ popper: tooltipProps.className }} {...tooltipProps} />
+  ),
+  { shouldForwardProp: (prop) => prop !== "dynamic" }
+)(({ dynamic = false }) => ({
   "& .MuiTooltip-tooltip": {
-    maxWidth: "412px",
+    maxWidth: dynamic ? "1000px" : "412px",
     minHeight: "43px",
     color: "#2B528B",
     border: "1px solid #2B528B",

--- a/src/components/SummaryList/index.tsx
+++ b/src/components/SummaryList/index.tsx
@@ -1,7 +1,7 @@
 import { memo, ReactNode, useMemo } from "react";
 import { isEqual } from "lodash";
 import { styled, Typography } from "@mui/material";
-import Tooltip from "../Tooltip";
+import StyledTooltip from "../StyledFormComponents/StyledTooltip";
 
 const StyledContainerTypography = styled(Typography)<{ component: React.ElementType }>({
   wordWrap: "break-word",
@@ -76,17 +76,18 @@ const SummaryList = <T,>({
       {data.length > 1 && (
         <>
           {" and "}
-          <Tooltip
+          <StyledTooltip
             title={tooltipContent}
             placement="top"
             open={undefined}
             disableHoverListener={false}
             arrow
+            dynamic
           >
             <StyledTypography component="span" data-testid="study-list-other-count">
               other {data.length - 1}
             </StyledTypography>
-          </Tooltip>
+          </StyledTooltip>
         </>
       )}
     </StyledContainerTypography>

--- a/src/components/TruncatedText/index.tsx
+++ b/src/components/TruncatedText/index.tsx
@@ -105,6 +105,7 @@ const TruncatedText: FC<Props> = ({
       disableInteractive={disableInteractiveTooltip}
       data-testid="truncated-text-tooltip"
       arrow={arrow}
+      dynamic
     >
       <StyledTextWrapper
         truncated={isTruncated}

--- a/src/content/dataSubmissions/CrossValidation.tsx
+++ b/src/content/dataSubmissions/CrossValidation.tsx
@@ -82,7 +82,7 @@ const columns: Column<CrossValidationResult>[] = [
     label: "Conflicting Submission",
     renderValue: ({ conflictingSubmission: _id }) => (
       <span key={_id} data-testid={`conflicting-submission-${_id}`}>
-        <StyledFormTooltip title={_id}>
+        <StyledFormTooltip title={_id} dynamic>
           <Link
             to={`/data-submission/${_id}`}
             target="_blank"

--- a/src/content/organizations/OrganizationView.tsx
+++ b/src/content/organizations/OrganizationView.tsx
@@ -6,7 +6,6 @@ import {
   Box,
   Container,
   MenuItem,
-  Popper,
   Stack,
   TextField,
   Typography,
@@ -133,10 +132,6 @@ const StyledPaper = styled(BasePaper)({
   "& .MuiAutocomplete-option": { whiteSpace: "nowrap" },
 });
 
-const StyledPopper = styled(Popper)({
-  width: "463px !important",
-});
-
 const StyledTag = styled("div")({
   position: "absolute",
   paddingLeft: "12px",
@@ -226,6 +221,8 @@ const OrganizationView: FC<Props> = ({ _id }: Props) => {
     control,
   } = useForm<FormInput>();
   const studiesField = watch("studies");
+
+  const [autocompleteMinWidth, setAutocompleteMinWidth] = useState<number | null>(null);
 
   const { data: activeDCPs } = useQuery<ListActiveDCPsResp>(LIST_ACTIVE_DCPS, {
     context: { clientName: "backend" },
@@ -595,12 +592,25 @@ const OrganizationView: FC<Props> = ({ _id }: Props) => {
 
                         return <StyledTag>{value?.length} studies selected</StyledTag>;
                       }}
+                      onOpen={(event) => {
+                        setAutocompleteMinWidth(
+                          (event.currentTarget as HTMLElement)?.offsetWidth || null
+                        );
+                      }}
+                      slotProps={{
+                        popper: {
+                          sx: {
+                            width: autocompleteMinWidth
+                              ? `${autocompleteMinWidth}px !important`
+                              : "auto !important",
+                          },
+                        },
+                      }}
                       options={studyOptions}
                       getOptionLabel={(option: string) => formattedStudyMap[option]}
                       onChange={(_, data: string[]) => field.onChange(data)}
                       loading={approvedStudiesLoading}
                       PaperComponent={StyledPaper}
-                      PopperComponent={StyledPopper}
                       disableCloseOnSelect
                       multiple
                     />


### PR DESCRIPTION
### Overview

Provided a way to specify when the text inside of tooltips is dynamic (text is not provided by us). When this is enabled, the max width of the tooltip is increased by ~2x. Also, looked around the site and fixed any select/autocomplete that is causing the dropdown menu to have mismatched width with their inputs.

### Change Details (Specifics)

- Added a prop to StyledTooltip, dynamic, to be used when the text inside of tooltips is not static. When it is dynamic, the max width of the tooltip is increased to support the potential size of the text. 
  - The reason I did this instead of just increasing max width for all, is because all of the static hard-coded tooltips that looked weird after the increase, and would have all of the text in a single super long line.
- Fixed select/autocomplete inputs which have a dropdown menu that is too large or too small. Updated it to dynamically detect the right size, only when the dropdown opens.

> [!NOTE]
> The select/autocomplete dropdown menu solution is kinda hacky, but seems to work well. Open to alternative suggestions. Maybe in the future we can just apply a fix in one location instead of having to add it in each usage, but I didn't want to modify the styled component since we try to leave those pretty bare-bones.

### Related Ticket(s)

[CRDCDH-2867](https://tracker.nci.nih.gov/browse/CRDCDH-2867) (Bug)
