### PR TITLE
CRDCDH-2938 Submission Request - Conditional Approval 

### DIFF
--- a/src/components/CancelApplicationButton/index.stories.tsx
+++ b/src/components/CancelApplicationButton/index.stories.tsx
@@ -74,6 +74,7 @@ const meta: Meta<typeof Button> = {
             studyAbbreviation: "MOCK-STUDY",
             conditional: false,
             pendingConditions: [],
+            pendingModelChange: false,
             programName: "",
             programAbbreviation: "",
             programDescription: "",

--- a/src/components/CancelApplicationButton/index.test.tsx
+++ b/src/components/CancelApplicationButton/index.test.tsx
@@ -62,6 +62,7 @@ const baseApp: Application = {
   studyAbbreviation: "",
   conditional: false,
   pendingConditions: [],
+  pendingModelChange: false,
   programName: "",
   programAbbreviation: "",
   programDescription: "",

--- a/src/components/Contexts/FormContext.test.tsx
+++ b/src/components/Contexts/FormContext.test.tsx
@@ -40,6 +40,7 @@ const baseApplication: Omit<Application, "questionnaireData"> = {
   studyAbbreviation: "",
   conditional: false,
   pendingConditions: [],
+  pendingModelChange: false,
   programAbbreviation: "",
   programDescription: "",
   version: "",
@@ -455,7 +456,10 @@ describe("approveForm Tests", () => {
     });
 
     await act(async () => {
-      const approveResp = await result.current.approveForm("mock approval comment", true);
+      const approveResp = await result.current.approveForm(
+        { reviewComment: "mock approval comment", pendingModelChange: false },
+        true
+      );
       expect(approveResp).toEqual({
         status: "success",
         id: appId,
@@ -540,7 +544,10 @@ describe("approveForm Tests", () => {
     });
 
     await act(async () => {
-      const approveResp = await result.current.approveForm("", true);
+      const approveResp = await result.current.approveForm(
+        { reviewComment: "", pendingModelChange: false },
+        true
+      );
       expect(approveResp).toEqual({
         status: "success",
         id: appId,
@@ -584,7 +591,10 @@ describe("approveForm Tests", () => {
     });
 
     await act(async () => {
-      const approveResp = await result.current.approveForm("", true);
+      const approveResp = await result.current.approveForm(
+        { reviewComment: "", pendingModelChange: false },
+        true
+      );
       expect(approveResp).toEqual({
         status: "failed",
         errorMessage: "Test GraphQL error",
@@ -615,7 +625,10 @@ describe("approveForm Tests", () => {
     });
 
     await act(async () => {
-      const approveResp = await result.current.approveForm("", true);
+      const approveResp = await result.current.approveForm(
+        { reviewComment: "", pendingModelChange: false },
+        true
+      );
       expect(approveResp).toEqual({
         status: "failed",
         errorMessage: "Test network error",

--- a/src/components/Contexts/FormContext.tsx
+++ b/src/components/Contexts/FormContext.tsx
@@ -24,6 +24,7 @@ import {
   SaveAppInput,
 } from "../../graphql";
 import { Logger } from "../../utils";
+import { FormInput as ApproveFormInput } from "../Questionnaire/ApproveFormDialog";
 
 export type SetDataReturnType =
   | { status: "success"; id: string }
@@ -34,7 +35,7 @@ export type ContextState = {
   data: Application;
   submitData?: () => Promise<string | boolean>;
   reopenForm?: () => Promise<string | boolean>;
-  approveForm?: (comment: string, wholeProgram: boolean) => Promise<SetDataReturnType>;
+  approveForm?: (data: ApproveFormInput, wholeProgram: boolean) => Promise<SetDataReturnType>;
   inquireForm?: (comment: string) => Promise<string | boolean>;
   rejectForm?: (comment: string) => Promise<string | boolean>;
   setData?: (Application) => Promise<SetDataReturnType>;
@@ -231,7 +232,7 @@ export const FormProvider: FC<ProviderProps> = ({ children, id }: ProviderProps)
 
   // Here we approve the form to the API with a comment and wholeProgram
   const approveForm = async (
-    comment: string,
+    data: ApproveFormInput,
     wholeProgram: boolean
   ): Promise<SetDataReturnType> => {
     setState((prevState) => ({ ...prevState, status: Status.SUBMITTING }));
@@ -245,9 +246,10 @@ export const FormProvider: FC<ProviderProps> = ({ children, id }: ProviderProps)
     const { data: res, errors } = await approveApp({
       variables: {
         id: state?.data?._id,
-        comment,
+        comment: data?.reviewComment,
         wholeProgram,
         institutions,
+        pendingModelChange: data?.pendingModelChange,
       },
     }).catch((e) => ({ data: null, errors: [e] }));
 

--- a/src/components/Questionnaire/ApproveFormDialog.test.tsx
+++ b/src/components/Questionnaire/ApproveFormDialog.test.tsx
@@ -12,12 +12,6 @@ describe("Accessibility", () => {
     expect(await axe(container)).toHaveNoViolations();
   });
 
-  it("should have no violations (disabled actions)", async () => {
-    const { container } = render(<ReviewDialog open disableActions />);
-
-    expect(await axe(container)).toHaveNoViolations();
-  });
-
   it("should have no violations (loading)", async () => {
     const { container } = render(<ReviewDialog open loading />);
 
@@ -36,13 +30,6 @@ describe("Basic Functionality", () => {
     const { getByTestId } = render(<ReviewDialog open />);
 
     expect(getByTestId("review-comment")).toBeInTheDocument();
-  });
-
-  it("should disable all actions when `disableActions` is true", () => {
-    const { getByRole } = render(<ReviewDialog open disableActions />);
-
-    expect(getByRole("button", { name: /Cancel/i })).toBeDisabled();
-    expect(getByRole("button", { name: /Confirm to Approve/i })).toBeDisabled();
   });
 
   it("should disable the confirm button when `loading` is true", () => {

--- a/src/components/Questionnaire/ApproveFormDialog.tsx
+++ b/src/components/Questionnaire/ApproveFormDialog.tsx
@@ -153,7 +153,11 @@ const ApproveFormDialog: FC<Props> = ({ open, loading, onCancel, onSubmit, onClo
         render={({ field }) => (
           <StyledOutlinedInput
             {...field}
-            inputProps={{ maxLength: 500, style: { height: "auto !important" } }}
+            inputProps={{
+              maxLength: 500,
+              style: { height: "auto !important" },
+              "aria-label": "Review comment input",
+            }}
             name="reviewComment"
             placeholder="500 characters allowed"
             minRows={5}

--- a/src/components/Questionnaire/ApproveFormDialog.tsx
+++ b/src/components/Questionnaire/ApproveFormDialog.tsx
@@ -1,11 +1,42 @@
 import { LoadingButton } from "@mui/lab";
-import { Button, DialogProps, styled } from "@mui/material";
+import {
+  Button,
+  Checkbox,
+  CheckboxProps,
+  DialogProps,
+  FormControlLabel,
+  OutlinedInputProps,
+  styled,
+} from "@mui/material";
 import { isEqual } from "lodash";
-import { FC, memo, useState } from "react";
+import { FC, memo } from "react";
+import { Controller, useForm } from "react-hook-form";
 
+import CheckboxCheckedIconSvg from "../../assets/icons/checkbox_checked.svg?url";
 import Dialog from "../GenericDialog";
+import StyledHelperText from "../StyledFormComponents/StyledHelperText";
+import BaseOutlinedInput from "../StyledFormComponents/StyledOutlinedInput";
 
-import TextInput from "./TextInput";
+const UncheckedIcon = styled("div")<{ readOnly?: boolean }>(({ readOnly }) => ({
+  outline: "2px solid #1D91AB",
+  outlineOffset: -2,
+  width: "24px",
+  height: "24px",
+  backgroundColor: readOnly ? "#E5EEF4" : "initial",
+  color: "#083A50",
+  cursor: readOnly ? "not-allowed" : "pointer",
+}));
+
+const CheckedIcon = styled("div")<{ readOnly?: boolean }>(({ readOnly }) => ({
+  backgroundImage: `url("${CheckboxCheckedIconSvg}")`,
+  backgroundSize: "auto",
+  backgroundRepeat: "no-repeat",
+  width: "24px",
+  height: "24px",
+  backgroundColor: readOnly ? "#E5EEF4" : "initial",
+  color: "#1D91AB",
+  cursor: readOnly ? "not-allowed" : "pointer",
+}));
 
 const StyledDialog = styled(Dialog)({
   "& .MuiDialog-paper": {
@@ -15,32 +46,74 @@ const StyledDialog = styled(Dialog)({
   },
 });
 
+const StyledCheckbox = styled(Checkbox)({
+  "&.MuiCheckbox-root": {
+    padding: "10px",
+  },
+  "& .MuiSvgIcon-root": {
+    fontSize: "24px",
+  },
+  "&.Mui-disabled": {
+    cursor: "not-allowed",
+  },
+});
+
+const StyledOutlinedInput = styled(BaseOutlinedInput, {
+  shouldForwardProp: (prop) => prop !== "resize" && prop !== "rowHeight",
+})<OutlinedInputProps & { resize: boolean; rowHeight?: number }>(
+  ({ resize, rowHeight = 25, rows, minRows, maxRows }) => ({
+    "&.MuiInputBase-multiline": {
+      padding: "12px",
+    },
+    "& .MuiInputBase-inputMultiline": {
+      resize: resize ? "vertical" : "none",
+      minHeight: resize && rowHeight ? `${(+rows || +minRows || 1) * rowHeight}px` : 0,
+      maxHeight: resize && maxRows && rowHeight ? `${+maxRows * rowHeight}px` : "none",
+      overflow: "auto",
+    },
+    "&.MuiInputBase-multiline .MuiInputBase-input": {
+      lineHeight: `${rowHeight}px`,
+      padding: 0,
+    },
+  })
+);
+
+export type FormInput = {
+  pendingModelChange: boolean;
+  reviewComment: string;
+};
+
 type Props = {
-  disableActions?: boolean;
   loading?: boolean;
   onCancel?: () => void;
-  onSubmit?: (reviewComment: string) => void;
+  onSubmit?: (data: FormInput) => void;
 } & DialogProps;
 
-const ApproveFormDialog: FC<Props> = ({
-  open,
-  disableActions,
-  loading,
-  onCancel,
-  onSubmit,
-  onClose,
-  ...rest
-}) => {
-  const [reviewComment, setReviewComment] = useState("");
+const ApproveFormDialog: FC<Props> = ({ open, loading, onCancel, onSubmit, onClose, ...rest }) => {
+  const {
+    handleSubmit,
+    watch,
+    control,
+    reset,
+    formState: { errors },
+  } = useForm<FormInput>({
+    mode: "onSubmit",
+    reValidateMode: "onSubmit",
+    defaultValues: {
+      pendingModelChange: false,
+      reviewComment: "",
+    },
+  });
+  const reviewComment = watch("reviewComment");
 
-  const handleCommentChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const val = (event?.target?.value || "").trim().substring(0, 500);
-    setReviewComment(val);
+  const handleOnSubmit = (data: FormInput) => {
+    onSubmit?.(data);
+    reset();
   };
 
   const handleOnCancel = () => {
+    reset();
     onCancel?.();
-    setReviewComment("");
   };
 
   return (
@@ -51,13 +124,13 @@ const ApproveFormDialog: FC<Props> = ({
       title="Approve Submission Request"
       actions={
         <>
-          <Button onClick={handleOnCancel} disabled={disableActions}>
+          <Button onClick={handleOnCancel} disabled={loading}>
             Cancel
           </Button>
           <LoadingButton
-            onClick={() => onSubmit(reviewComment)}
+            onClick={handleSubmit(handleOnSubmit)}
             loading={loading}
-            disabled={!reviewComment || disableActions}
+            disabled={!reviewComment || loading}
             autoFocus
           >
             Confirm to Approve
@@ -66,20 +139,58 @@ const ApproveFormDialog: FC<Props> = ({
       }
       {...rest}
     >
-      <TextInput
+      <Controller
         name="reviewComment"
-        value={reviewComment}
-        onChange={handleCommentChange}
-        maxLength={500}
-        placeholder="500 characters allowed"
-        minRows={5}
-        maxRows={15}
-        data-testid="review-comment"
-        sx={{ paddingY: "16px" }}
-        required
-        multiline
-        resize
+        control={control}
+        rules={{
+          validate: {
+            required: (v: string) => v.trim() !== "" || "This field is required",
+            maxLength: (v: string) => v.trim().length <= 500 || "Maximum of 500 characters allowed",
+          },
+        }}
+        render={({ field }) => (
+          <StyledOutlinedInput
+            {...field}
+            inputProps={{ maxLength: 500, style: { height: "auto !important" } }}
+            name="reviewComment"
+            placeholder="500 characters allowed"
+            minRows={5}
+            maxRows={15}
+            data-testid="review-comment"
+            sx={{ paddingY: "16px" }}
+            required
+            multiline
+            resize
+          />
+        )}
       />
+      <StyledHelperText data-testid="pending-model-change-dialog-error">
+        {errors?.reviewComment?.message}
+      </StyledHelperText>
+
+      <Controller
+        name="pendingModelChange"
+        control={control}
+        render={({ field }) => (
+          <FormControlLabel
+            control={
+              <StyledCheckbox
+                {...field}
+                checkedIcon={<CheckedIcon readOnly={loading} />}
+                icon={<UncheckedIcon readOnly={loading} />}
+                disabled={loading}
+                inputProps={
+                  { "data-testid": "pendingModelChange-checkbox" } as CheckboxProps["inputProps"]
+                }
+              />
+            }
+            label="Require Data Model changes"
+          />
+        )}
+      />
+      <StyledHelperText data-testid="pending-model-change-dialog-error">
+        {errors?.pendingModelChange?.message}
+      </StyledHelperText>
     </StyledDialog>
   );
 };

--- a/src/components/Questionnaire/ApproveFormDialog.tsx
+++ b/src/components/Questionnaire/ApproveFormDialog.tsx
@@ -122,6 +122,7 @@ const ApproveFormDialog: FC<Props> = ({ open, loading, onCancel, onSubmit, onClo
       onClose={onClose}
       scroll="body"
       title="Approve Submission Request"
+      data-testid="approve-form-dialog"
       actions={
         <>
           <Button onClick={handleOnCancel} disabled={loading}>
@@ -132,6 +133,7 @@ const ApproveFormDialog: FC<Props> = ({ open, loading, onCancel, onSubmit, onClo
             loading={loading}
             disabled={!reviewComment || loading}
             autoFocus
+            data-testid="confirm-to-approve-button"
           >
             Confirm to Approve
           </LoadingButton>

--- a/src/components/ToggleApplicationButton/index.test.tsx
+++ b/src/components/ToggleApplicationButton/index.test.tsx
@@ -64,6 +64,7 @@ const baseApp: Omit<Application, "questionnaireData"> = {
   studyAbbreviation: "",
   conditional: false,
   pendingConditions: [],
+  pendingModelChange: false,
   programName: "",
   programAbbreviation: "",
   programDescription: "",

--- a/src/config/AuthPermissions.test.ts
+++ b/src/config/AuthPermissions.test.ts
@@ -21,6 +21,7 @@ const baseApplication: Application = {
   studyAbbreviation: "",
   conditional: false,
   pendingConditions: [],
+  pendingModelChange: false,
   programAbbreviation: "",
   programDescription: "",
   version: "",

--- a/src/config/InitialValues.ts
+++ b/src/config/InitialValues.ts
@@ -14,6 +14,7 @@ export const InitialApplication: Omit<Application, "questionnaireData"> = {
   PI: "",
   conditional: false,
   pendingConditions: [],
+  pendingModelChange: false,
   programAbbreviation: "",
   programDescription: "",
   version: "",

--- a/src/content/questionnaire/FormView.tsx
+++ b/src/content/questionnaire/FormView.tsx
@@ -18,7 +18,9 @@ import { Status as AuthStatus, useAuthContext } from "../../components/Contexts/
 import { Status as FormStatus, useFormContext } from "../../components/Contexts/FormContext";
 import PageBanner from "../../components/PageBanner";
 import ProgressBar from "../../components/ProgressBar/ProgressBar";
-import ApproveFormDialog from "../../components/Questionnaire/ApproveFormDialog";
+import ApproveFormDialog, {
+  FormInput as ApproveFormInput,
+} from "../../components/Questionnaire/ApproveFormDialog";
 import InquireFormDialog from "../../components/Questionnaire/InquireFormDialog";
 import RejectFormDialog from "../../components/Questionnaire/RejectFormDialog";
 import SubmitFormDialog from "../../components/Questionnaire/SubmitFormDialog";
@@ -247,7 +249,7 @@ const FormView: FC<Props> = ({ section }: Props) => {
    *
    * @returns {Promise<boolean>} true if the approval submission was successful, false otherwise
    */
-  const submitApproveForm = async (reviewComment): Promise<string | boolean> => {
+  const submitApproveForm = async (data: ApproveFormInput): Promise<string | boolean> => {
     if (formMode !== "Review") {
       return false;
     }
@@ -257,19 +259,19 @@ const FormView: FC<Props> = ({ section }: Props) => {
       return false;
     }
 
-    const res = await approveForm(reviewComment, true);
+    const res = await approveForm(data, true);
     setOpenApproveDialog(false);
     if (res?.status === "success") {
       navigate("/submission-requests");
     } else {
       enqueueSnackbar(
-        res.errorMessage || "An error occurred while approving the form. Please try again.",
+        res?.errorMessage || "An error occurred while approving the form. Please try again.",
         {
           variant: "error",
         }
       );
     }
-    return res.status === "success";
+    return res?.status === "success";
   };
 
   /**
@@ -784,7 +786,8 @@ const FormView: FC<Props> = ({ section }: Props) => {
       <ApproveFormDialog
         open={openApproveDialog}
         onCancel={handleCloseApproveFormDialog}
-        onSubmit={(reviewComment) => submitApproveForm(reviewComment)}
+        onSubmit={(data) => submitApproveForm(data)}
+        loading={status === FormStatus.SUBMITTING}
       />
       <InquireFormDialog
         open={openInquireDialog}

--- a/src/graphql/approveApplication.ts
+++ b/src/graphql/approveApplication.ts
@@ -6,12 +6,14 @@ export const mutation = gql`
     $comment: String
     $wholeProgram: Boolean
     $institutions: [String]
+    $pendingModelChange: Boolean
   ) {
     approveApplication(
       _id: $id
       wholeProgram: $wholeProgram
       comment: $comment
       institutions: $institutions
+      pendingModelChange: $pendingModelChange
     ) {
       _id
     }
@@ -23,6 +25,7 @@ export type Input = {
   comment: string;
   wholeProgram: boolean;
   institutions: string[];
+  pendingModelChange: boolean;
 };
 
 export type Response = {

--- a/src/types/Application.d.ts
+++ b/src/types/Application.d.ts
@@ -40,6 +40,10 @@ type Application = {
    * The current form version
    */
   version: string;
+  /**
+   * Indicates the application is awaiting required data model updates.
+   */
+  pendingModelChange: boolean;
 };
 
 type QuestionnaireData = {


### PR DESCRIPTION
### Overview

When a Submission Request reviewer is approving a form, within the dialog, it will now have a checkbox for "Requiring Data Model changes" to support conditional approvals while waiting for the changes to be made.

> [!NOTE]
> The BE is not yet merged, so this will fail, but it is modeled after existing BE PR. 

### Change Details (Specifics)

- Updated the Approve Form dialog to include a checkbox to be used when data model changes are pending. When enabled, this will flag the application as a conditional approval
- Added `pendingModelChange` to `approveApplication` mutation, and added the property to the Application type. This property will be added to additional queries in other tickets
- Updated form to accept new `pendingModelChange` property when attempting to approve the form
- Added/fixed tests

### Related Ticket(s)

[CRDCDH-2938](https://tracker.nci.nih.gov/browse/CRDCDH-2938) (Task)
[CRDCDH-2935](https://tracker.nci.nih.gov/browse/CRDCDH-2935) (US)
