### PR TITLE
CRDCDH-2899 Display pending conditions in a bullet list within tooltip

### DIFF
--- a/src/components/StatusBar/components/HistorySection.tsx
+++ b/src/components/StatusBar/components/HistorySection.tsx
@@ -7,6 +7,7 @@ import { TOOLTIP_TEXT } from "../../../config/QuestionnaireTooltips";
 import { FormatDate } from "../../../utils";
 import { useFormContext } from "../../Contexts/FormContext";
 import HistoryDialog from "../../HistoryDialog";
+import TooltipList from "../../SummaryList/TooltipList";
 import Tooltip from "../../Tooltip";
 
 import { HistoryIconMap } from "./SubmissionRequestIconMap";
@@ -84,14 +85,19 @@ const HistorySection: FC = () => {
       if ((conditional || pendingConditions?.length > 0) && status === "Approved") {
         return ({ children }) => (
           <Tooltip
-            title={pendingConditions?.join(" ")}
+            title={<TooltipList data={pendingConditions} />}
             placement="top"
             open={undefined}
             disableHoverListener={false}
             disableInteractive
             arrow
           >
-            <Stack direction="row" alignItems="center" data-testid="status-bar-pending-conditions">
+            <Stack
+              direction="row"
+              alignItems="center"
+              data-testid="status-bar-pending-conditions"
+              sx={{ cursor: "pointer" }}
+            >
               {children}
               <StyledBellIcon />
             </Stack>

--- a/src/components/SummaryList/TooltipList.stories.tsx
+++ b/src/components/SummaryList/TooltipList.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import TooltipList, { Props } from "./TooltipList";
+
+const meta: Meta<typeof TooltipList> = {
+  title: "Miscellaneous / TooltipList",
+  component: TooltipList,
+  tags: ["autodocs"],
+} satisfies Meta<typeof TooltipList>;
+
+export default meta;
+type Story = StoryObj<Props<{ _id: string; name: string; abbreviation?: string }>>;
+
+/**
+ * A scenario in which only one item is provided.
+ */
+export const Single: Story = {
+  args: {
+    data: [{ _id: "item-1", name: "Item One" }],
+    getItemKey: (item) => item._id,
+    renderTooltipItem: (item) => item.name,
+  },
+};
+
+/**
+ * A scenario in which multiple items are provided.
+ */
+export const Multiple: Story = {
+  args: {
+    data: [
+      { _id: "item-1", name: "Item One" },
+      { _id: "item-2", name: "Item Two", abbreviation: "IT2-ABBR" },
+      { _id: "item-3", name: "Item Three" },
+    ],
+    getItemKey: (item) => item._id,
+    renderTooltipItem: (item) => item.name,
+  },
+};
+
+/**
+ * No items are provided.
+ */
+export const None: Story = {
+  args: {
+    data: [],
+    getItemKey: (item) => item._id,
+    renderTooltipItem: (item) => item.name,
+  },
+};

--- a/src/components/SummaryList/TooltipList.test.tsx
+++ b/src/components/SummaryList/TooltipList.test.tsx
@@ -1,0 +1,120 @@
+import { render } from "@testing-library/react";
+import { axe } from "vitest-axe";
+
+import TooltipList from "./TooltipList";
+
+describe("Accessibility", () => {
+  it("has no accessibility violations with items", async () => {
+    const { container } = render(
+      <TooltipList
+        data={[
+          { _id: "item-1", name: "Item One" },
+          { _id: "item-2", name: "Item Two" },
+        ]}
+        getItemKey={(item) => item._id}
+        renderTooltipItem={(item) => item.name}
+      />
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it("has no accessibility violations with empty data", async () => {
+    const { container } = render(
+      <TooltipList
+        data={[]}
+        getItemKey={(item) => item._id}
+        renderTooltipItem={(item) => item.name}
+      />
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});
+
+describe("TooltipList", () => {
+  const data = [
+    { _id: "item-1", name: "Item One" },
+    { _id: "item-2", name: "Item Two" },
+  ];
+
+  it("renders nothing when data is undefined", () => {
+    const { container } = render(<TooltipList data={undefined} />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing when data is null", () => {
+    const { container } = render(<TooltipList data={null} />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing when data is an empty array", () => {
+    const { container } = render(<TooltipList data={[]} />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders a list with one item", () => {
+    const { getByTestId } = render(
+      <TooltipList
+        data={[data[0]]}
+        getItemKey={(item) => item._id}
+        renderTooltipItem={(item) => item.name}
+      />
+    );
+
+    expect(getByTestId("item-1")).toHaveTextContent("Item One");
+  });
+
+  it("renders a list with multiple items", () => {
+    const { getByTestId } = render(
+      <TooltipList
+        data={data}
+        getItemKey={(item) => item._id}
+        renderTooltipItem={(item) => item.name}
+      />
+    );
+
+    expect(getByTestId("item-1")).toHaveTextContent("Item One");
+    expect(getByTestId("item-2")).toHaveTextContent("Item Two");
+  });
+
+  it("uses getItemKey to generate unique keys", () => {
+    const { getByTestId } = render(
+      <TooltipList
+        data={data}
+        getItemKey={(item) => `custom-${item._id}`}
+        renderTooltipItem={(item) => item.name}
+      />
+    );
+    expect(getByTestId("custom-item-1")).toBeInTheDocument();
+    expect(getByTestId("custom-item-2")).toBeInTheDocument();
+  });
+
+  it("falls back to String(item) as key when getItemKey is not provided", () => {
+    const primitiveData = ["a", "b"];
+    const { getByTestId } = render(<TooltipList data={primitiveData} />);
+
+    expect(getByTestId("a")).toBeInTheDocument();
+    expect(getByTestId("b")).toBeInTheDocument();
+  });
+
+  it("uses renderTooltipItem to render each item", () => {
+    const { getByTestId } = render(
+      <TooltipList
+        data={data}
+        getItemKey={(item) => item._id}
+        renderTooltipItem={(item) => <span>Rendered: {item.name}</span>}
+      />
+    );
+
+    expect(getByTestId("item-1")).toHaveTextContent("Rendered: Item One");
+  });
+
+  it("falls back to String(item) as content when renderTooltipItem is not provided", () => {
+    const primitiveData = [123, 456];
+    const { getByTestId } = render(<TooltipList data={primitiveData} />);
+    expect(getByTestId("123")).toHaveTextContent("123");
+    expect(getByTestId("456")).toHaveTextContent("456");
+  });
+});

--- a/src/components/SummaryList/TooltipList.tsx
+++ b/src/components/SummaryList/TooltipList.tsx
@@ -1,0 +1,52 @@
+import { styled } from "@mui/material";
+import { isEqual } from "lodash";
+import { memo, ReactNode } from "react";
+
+const StyledList = styled("ul")({
+  paddingInlineStart: 16,
+  marginBlockStart: 6,
+  marginBlockEnd: 6,
+});
+
+const StyledListItem = styled("li")({
+  "&:not(:last-child)": {
+    marginBottom: 8,
+  },
+  fontSize: 14,
+});
+
+export type Props<T> = {
+  data: T[];
+  getItemKey?: (item: T) => string;
+  renderTooltipItem?: (item: T) => string | ReactNode;
+};
+
+/**
+ * TooltipList is a generic component that renders a styled list of items,
+ * typically used for displaying a list within a tooltip.
+ *
+ * @template T - Type of data items.
+ * @param {Props} props
+ * @returns {JSX.Element} JSX.Element or null if data is empty.
+ */
+const TooltipList = <T,>({ data, getItemKey, renderTooltipItem }: Props<T>): JSX.Element => {
+  if (!Array.isArray(data) || !data?.length) {
+    return null;
+  }
+
+  return (
+    <StyledList>
+      {data?.map((item: T) => {
+        const itemKey = getItemKey?.(item) ?? String(item);
+
+        return (
+          <StyledListItem key={itemKey} data-testid={itemKey}>
+            {renderTooltipItem?.(item) ?? String(item)}
+          </StyledListItem>
+        );
+      })}
+    </StyledList>
+  );
+};
+
+export default memo(TooltipList, isEqual) as <T>(props: Props<T>) => JSX.Element;

--- a/src/components/SummaryList/index.tsx
+++ b/src/components/SummaryList/index.tsx
@@ -1,26 +1,15 @@
 import { styled, Typography } from "@mui/material";
 import { isEqual } from "lodash";
-import { memo, ReactNode, useMemo } from "react";
+import { memo, ReactNode } from "react";
 
 import StyledTooltip from "../StyledFormComponents/StyledTooltip";
+
+import TooltipList from "./TooltipList";
 
 const StyledContainerTypography = styled(Typography)<{ component: React.ElementType }>({
   wordWrap: "break-word",
   maxWidth: "100%",
   fontSize: "inherit",
-});
-
-const StyledList = styled("ul")({
-  paddingInlineStart: 16,
-  marginBlockStart: 6,
-  marginBlockEnd: 6,
-});
-
-const StyledListItem = styled("li")({
-  "&:not(:last-child)": {
-    marginBottom: 8,
-  },
-  fontSize: 14,
 });
 
 const StyledTypography = styled(Typography)<{ component: React.ElementType }>(() => ({
@@ -50,23 +39,6 @@ const SummaryList = <T,>({
   renderItem,
   renderTooltipItem,
 }: Props<T>): JSX.Element => {
-  const tooltipContent = useMemo<React.ReactNode>(
-    () => (
-      <StyledList>
-        {data?.map((item) => {
-          const itemKey = getItemKey(item);
-
-          return (
-            <StyledListItem key={itemKey} data-testid={itemKey}>
-              {renderTooltipItem(item)}
-            </StyledListItem>
-          );
-        })}
-      </StyledList>
-    ),
-    [data]
-  );
-
   if (!data || !Array.isArray(data) || data.length === 0) {
     return <span>{emptyText}</span>;
   }
@@ -78,7 +50,13 @@ const SummaryList = <T,>({
         <>
           {" and "}
           <StyledTooltip
-            title={tooltipContent}
+            title={
+              <TooltipList
+                data={data}
+                getItemKey={getItemKey}
+                renderTooltipItem={renderTooltipItem}
+              />
+            }
             placement="top"
             open={undefined}
             disableHoverListener={false}

--- a/src/content/questionnaire/ListView.tsx
+++ b/src/content/questionnaire/ListView.tsx
@@ -11,6 +11,7 @@ import CreateApplicationButton from "../../components/CreateApplicationButton";
 import GenericTable, { Column } from "../../components/GenericTable";
 import PageBanner from "../../components/PageBanner";
 import StyledTooltip from "../../components/StyledFormComponents/StyledTooltip";
+import TooltipList from "../../components/SummaryList/TooltipList";
 import ToggleApplicationButton from "../../components/ToggleApplicationButton";
 import Tooltip from "../../components/Tooltip";
 import TruncatedText from "../../components/TruncatedText";
@@ -98,6 +99,7 @@ const StyledDateTooltip = styled(StyledTooltip)(() => ({
 const StyledSpecialStatus = styled(Stack)({
   color: "#C94313",
   fontWeight: 600,
+  cursor: "pointer",
 });
 
 const StyledBellIcon = styled(BellIcon)({
@@ -134,7 +136,7 @@ const columns: Column<T>[] = [
 
       return (
         <Tooltip
-          title={pendingConditions?.join(" ")}
+          title={<TooltipList data={pendingConditions} />}
           placement="top"
           open={undefined}
           disableHoverListener={false}


### PR DESCRIPTION
### Overview

Display pending conditions in a bullet list within the tooltip.

### Change Details (Specifics)

- Created reusable `TooltipList` to list out items in a bullet list
- Updated History dialog alert tooltip and SR List status alert tooltip to use `TooltipList`
- Added storybook and test support

### Related Ticket(s)

[CRDCDH-2899](https://tracker.nci.nih.gov/browse/CRDCDH-2899) (Task)
[CRDCDH-2860](https://tracker.nci.nih.gov/browse/CRDCDH-2860) (US)
