### PR TITLE
CRDCDH-2831 Bug: Fix broken storybook stats

### DIFF
--- a/src/components/DataSubmissions/ValidationStatistics.stories.tsx
+++ b/src/components/DataSubmissions/ValidationStatistics.stories.tsx
@@ -1,21 +1,60 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
+import { GetSubmissionResp } from "../../graphql";
+import { SubmissionContext, SubmissionCtxStatus } from "../Contexts/SubmissionContext";
+
 import ValidationStatistics from "./ValidationStatistics";
 
-type CustomStoryProps = React.ComponentProps<typeof ValidationStatistics>;
+type CustomStoryProps = React.ComponentProps<typeof ValidationStatistics> & {
+  submission: GetSubmissionResp["getSubmission"];
+  status: SubmissionCtxStatus;
+  statistics: SubmissionStatistic[];
+};
 
 const meta: Meta<CustomStoryProps> = {
   title: "Data Submissions / Validation Statistics",
   component: ValidationStatistics,
   tags: ["autodocs"],
   argTypes: {
-    dataSubmission: {
-      control: false,
-    },
-    statistics: {
-      control: false,
+    submission: { control: false },
+    statistics: { control: false },
+    status: {
+      options: [
+        SubmissionCtxStatus.LOADED,
+        SubmissionCtxStatus.LOADING,
+        SubmissionCtxStatus.POLLING,
+        SubmissionCtxStatus.ERROR,
+      ],
+      control: {
+        type: "radio",
+      },
     },
   },
+  args: {
+    status: SubmissionCtxStatus.LOADED,
+  },
+  decorators: [
+    (Story, context) => (
+      <SubmissionContext.Provider
+        value={{
+          data: {
+            getSubmission: context.args.submission,
+            submissionStats: { stats: context.args.statistics },
+            getSubmissionAttributes: {
+              submissionAttributes: {
+                hasOrphanError: false,
+                isBatchUploading: false,
+              },
+            },
+          } as GetSubmissionResp,
+          status: context.args.status,
+          error: null,
+        }}
+      >
+        <Story />
+      </SubmissionContext.Provider>
+    ),
+  ],
 } satisfies Meta<CustomStoryProps>;
 
 type Story = StoryObj<CustomStoryProps>;
@@ -73,7 +112,7 @@ const mockData: SubmissionStatistic[] = [
 
 export const Default: Story = {
   args: {
-    dataSubmission: {
+    submission: {
       _id: "mock id",
     } as Submission,
     statistics: [...mockData],
@@ -82,7 +121,7 @@ export const Default: Story = {
 
 export const NoData: Story = {
   args: {
-    dataSubmission: {
+    submission: {
       _id: "mock id",
     } as Submission,
     statistics: [],
@@ -90,7 +129,9 @@ export const NoData: Story = {
 };
 
 export const Loading: Story = {
-  args: {},
+  args: {
+    status: SubmissionCtxStatus.LOADING,
+  },
 };
 
 export default meta;

--- a/src/components/DataSubmissions/ValidationStatistics.stories.tsx
+++ b/src/components/DataSubmissions/ValidationStatistics.stories.tsx
@@ -130,6 +130,8 @@ export const NoData: Story = {
 
 export const Loading: Story = {
   args: {
+    submission: null,
+    statistics: null,
     status: SubmissionCtxStatus.LOADING,
   },
 };


### PR DESCRIPTION
### Overview

The validation statistics were updated to use submission context, but the storybook was not updated with the provider. Issue was introduced in https://github.com/CBIIT/crdc-datahub-ui/pull/747. 

### Change Details (Specifics)

- Added the submission context provider to the validation statistics storybook
- Added control for submission context status
- Kept everything else the same. The "default" option looks weird on full-screen, but likely just a container issue, not a component issue. Out of scope for now, will address in future.

### Related Ticket(s)

[CRDCDH-2831](https://tracker.nci.nih.gov/browse/CRDCDH-2831) (Task)
[CRDCDH-2767](https://tracker.nci.nih.gov/browse/CRDCDH-2767) (US)
