### PR TITLE
CRDCDH-2886 Conditional Approval - Data Submission Creation

### DIFF
--- a/src/components/DataSubmissions/CreateDataSubmissionDialog.test.tsx
+++ b/src/components/DataSubmissions/CreateDataSubmissionDialog.test.tsx
@@ -45,6 +45,7 @@ const baseStudies: GetMyUserResp["getMyUser"]["studies"] = [
     studyAbbreviation: "SN",
     dbGaPID: "phsTEST",
     controlledAccess: null,
+    pendingModelChange: false,
   },
   {
     _id: "study2",
@@ -52,6 +53,7 @@ const baseStudies: GetMyUserResp["getMyUser"]["studies"] = [
     studyAbbreviation: "CS",
     dbGaPID: "phsTEST",
     controlledAccess: true,
+    pendingModelChange: false,
   },
   {
     _id: "no-dbGaP-ID",
@@ -59,6 +61,7 @@ const baseStudies: GetMyUserResp["getMyUser"]["studies"] = [
     studyAbbreviation: "DB",
     dbGaPID: null,
     controlledAccess: true,
+    pendingModelChange: false,
   },
 ];
 
@@ -761,6 +764,7 @@ describe("Implementation Requirements", () => {
         studyAbbreviation: "CS",
         dbGaPID: null,
         controlledAccess: true,
+        pendingModelChange: false,
       },
     ];
 
@@ -813,6 +817,7 @@ describe("Implementation Requirements", () => {
         studyAbbreviation: "CS",
         dbGaPID: null,
         controlledAccess: true,
+        pendingModelChange: false,
       },
     ];
 
@@ -876,6 +881,7 @@ describe("Implementation Requirements", () => {
         studyAbbreviation: "CS",
         dbGaPID: "phsTEST",
         controlledAccess: true,
+        pendingModelChange: false,
       },
       {
         _id: "non-controlled",
@@ -883,6 +889,7 @@ describe("Implementation Requirements", () => {
         studyAbbreviation: "NCS",
         dbGaPID: null,
         controlledAccess: false,
+        pendingModelChange: false,
       },
     ];
 
@@ -949,6 +956,7 @@ describe("Implementation Requirements", () => {
         studyAbbreviation: "CS",
         dbGaPID: null,
         controlledAccess: true,
+        pendingModelChange: false,
       },
     ];
 

--- a/src/components/DataSubmissions/CreateDataSubmissionDialog.tsx
+++ b/src/components/DataSubmissions/CreateDataSubmissionDialog.tsx
@@ -250,7 +250,7 @@ const CreateDataSubmissionDialog: FC<Props> = ({ onCreate }) => {
     {
       variables: { first: -1, orderBy: "studyAbbreviation", sortDirection: "asc" },
       context: { clientName: "backend" },
-      fetchPolicy: "cache-first",
+      fetchPolicy: "cache-and-network",
       skip: !shouldFetchAllStudies,
     }
   );

--- a/src/components/DataSubmissions/CreateDataSubmissionDialog.tsx
+++ b/src/components/DataSubmissions/CreateDataSubmissionDialog.tsx
@@ -34,6 +34,7 @@ import BaseStyledHelperText from "../StyledFormComponents/StyledHelperText";
 import StyledLabel from "../StyledFormComponents/StyledLabel";
 import StyledOutlinedInput from "../StyledFormComponents/StyledOutlinedInput";
 import StyledSelect from "../StyledFormComponents/StyledSelect";
+import StyledTooltip from "../StyledFormComponents/StyledTooltip";
 import Tooltip from "../Tooltip";
 
 import RadioInput, { RadioOption } from "./RadioInput";
@@ -226,6 +227,7 @@ const CreateDataSubmissionDialog: FC<Props> = ({ onCreate }) => {
   const [isDbGapRequired, setIsDbGapRequired] = useState<boolean>(false);
   const [dbGaPID, setDbGaPID] = useState<string>("");
   const [selectMinWidth, setSelectMinWidth] = useState<number | null>(null);
+  const [intention, studyID] = watch(["intention", "studyID"]);
 
   const shouldFetchAllStudies = useMemo<boolean>(
     () =>
@@ -263,7 +265,15 @@ const CreateDataSubmissionDialog: FC<Props> = ({ onCreate }) => {
     );
   }, [shouldFetchAllStudies, allStudies, user?.studies]);
 
-  const intention = watch("intention");
+  const studyHasPendingConditions = useMemo<boolean>(() => {
+    if (!studyID) {
+      return false;
+    }
+
+    const mappedStudy = studies?.find((s) => s?._id === studyID);
+    return mappedStudy?.pendingModelChange || false;
+  }, [studyID, studies]);
+
   const submissionTypeOptions: RadioOption[] = [
     {
       label: "New/Update",
@@ -310,6 +320,10 @@ const CreateDataSubmissionDialog: FC<Props> = ({ onCreate }) => {
   };
 
   const onSubmit: SubmitHandler<CreateSubmissionInput> = async (input) => {
+    if (studyHasPendingConditions) {
+      return;
+    }
+
     const { data, errors } = await createDataSubmission({
       variables: { ...input },
     }).catch((e) => {
@@ -568,15 +582,27 @@ const CreateDataSubmissionDialog: FC<Props> = ({ onCreate }) => {
           </StyledFormStack>
         </StyledDialogContent>
         <StyledDialogActions>
-          <StyledDialogButton
-            type="submit"
-            tabIndex={0}
-            data-testid="create-data-submission-dialog-create-button"
-            form="create-submission-dialog-form"
-            disabled={(isDbGapRequired && !dbGaPID) || isSubmitting}
+          <StyledTooltip
+            title="The CRDC team is reviewing the data requirements of this study for potential data model changes. Data submissions cannot be created until any required model updates are released."
+            placement="top"
+            open={undefined}
+            disableHoverListener={!studyHasPendingConditions}
+            arrow
           >
-            Create
-          </StyledDialogButton>
+            <span>
+              <StyledDialogButton
+                type="submit"
+                tabIndex={0}
+                data-testid="create-data-submission-dialog-create-button"
+                form="create-submission-dialog-form"
+                disabled={
+                  (isDbGapRequired && !dbGaPID) || studyHasPendingConditions || isSubmitting
+                }
+              >
+                Create
+              </StyledDialogButton>
+            </span>
+          </StyledTooltip>
           {error && (
             <StyledDialogError variant="body1">
               Unable to create this data submission. If the problem persists please contact

--- a/src/graphql/getMyUser.ts
+++ b/src/graphql/getMyUser.ts
@@ -19,6 +19,7 @@ export const query: TypedDocumentNode<Response> = gql`
         studyAbbreviation
         dbGaPID
         controlledAccess
+        pendingModelChange
       }
       institution {
         _id
@@ -36,7 +37,12 @@ export type Response = {
   getMyUser: User & {
     studies: Pick<
       ApprovedStudy,
-      "_id" | "studyName" | "studyAbbreviation" | "dbGaPID" | "controlledAccess"
+      | "_id"
+      | "studyName"
+      | "studyAbbreviation"
+      | "dbGaPID"
+      | "controlledAccess"
+      | "pendingModelChange"
     >[];
   };
 };


### PR DESCRIPTION
### Overview

Prevent a user from creating a Data Submission when they select a study that is pending a model change.

### Change Details (Specifics)

- Updated Create a DS dialog to disable "Create" button when the study selected has `pendingModelChange` set to true. Also, included a tooltip for justification as to why the button is disabled
- Updated getMyUser query to include `pendingModelChange` property (listApprovedStudies already includes it)
- Added storybook support for pending changes scenario, as well as a test 

### Related Ticket(s)

[CRDCDH-2901](https://tracker.nci.nih.gov/browse/CRDCDH-2901) (Task)
[CRDCDH-2886](https://tracker.nci.nih.gov/browse/CRDCDH-2886) (US)
