### PR TITLE
CRDCDH-2906 Include `type` column in TSV export

### DIFF
--- a/src/components/DataSubmissions/ExportNodeDataButton.tsx
+++ b/src/components/DataSubmissions/ExportNodeDataButton.tsx
@@ -106,6 +106,7 @@ export const ExportNodeDataButton: React.FC<Props> = ({
       const filteredName = filterAlphaNumeric(submission.name?.trim()?.replaceAll(" ", "-"), "-");
       const filename = `${filteredName}_${nodeType}_${dayjs().format("YYYYMMDDHHmm")}.tsv`;
       const csvArray = d.getSubmissionNodes.nodes.map((node) => ({
+        type: nodeType,
         ...JSON.parse(node.props),
         status: node.status,
       }));


### PR DESCRIPTION
### Overview

Trivial PR to add the `type` (node type) column to the TSV export of Data Submission Data View tab.

### Change Details (Specifics)

N/A

### Related Ticket(s)

CRDCDH-2906 (Task)