### PR TITLE
CRDCDH-2904 Renaming Data Submission List and Submission Request List page titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,7 +95,7 @@ This production patch includes a critical fix to resolve a timeout and crash iss
 
 - Added Submission Request Version Support to ensure backward compatibility.
 - Released Submission Request Form 3.0 with added question and UI improvements
-- Provided filtering capability on the Submission Request List Page.
+- Provided filtering capability on the Submission Requests Page.
 - Users can now cancel and restore Submission Requests.
 - Added support for conditionally approved studies.
 - Study Primary Contacts and PIs will now receive Submission Request email notifications for their study

--- a/src/components/PageBanner/index.stories.tsx
+++ b/src/components/PageBanner/index.stories.tsx
@@ -41,7 +41,7 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
-    title: "Submission Request List",
+    title: "Submission Requests",
     subTitle:
       "Below is a list of submission requests that are associated with your account. Please click on any of the submission requests to review or continue work.",
     bannerSrc: bannerPng,
@@ -50,7 +50,7 @@ export const Default: Story = {
 
 export const WithBody: Story = {
   args: {
-    title: "Submission Request List",
+    title: "Submission Requests",
     subTitle:
       "Below is a list of submission requests that are associated with your account. Please click on any of the submission requests to review or continue work.",
     bannerSrc: bannerPng,

--- a/src/content/dataSubmissions/DataSubmission.tsx
+++ b/src/content/dataSubmissions/DataSubmission.tsx
@@ -318,7 +318,7 @@ const DataSubmission: FC<Props> = ({ submissionId, tab = URLTabs.UPLOAD_ACTIVITY
               )}
               {tab === URLTabs.SUBMITTED_DATA && <SubmittedData />}
 
-              {/* Return to Data Submission List Button */}
+              {/* Return to Data Submissions Button */}
               <BackButton
                 navigateTo={dataSubmissionListPageUrl}
                 text="Back to Data Submissions List"

--- a/src/content/dataSubmissions/DataSubmission.tsx
+++ b/src/content/dataSubmissions/DataSubmission.tsx
@@ -319,10 +319,7 @@ const DataSubmission: FC<Props> = ({ submissionId, tab = URLTabs.UPLOAD_ACTIVITY
               {tab === URLTabs.SUBMITTED_DATA && <SubmittedData />}
 
               {/* Return to Data Submissions Button */}
-              <BackButton
-                navigateTo={dataSubmissionListPageUrl}
-                text="Back to Data Submissions List"
-              />
+              <BackButton navigateTo={dataSubmissionListPageUrl} text="Back to Data Submissions" />
             </StyledMainContentArea>
           </StyledCardContent>
           <StyledCardActions>

--- a/src/content/dataSubmissions/DataSubmissionsListView.tsx
+++ b/src/content/dataSubmissions/DataSubmissionsListView.tsx
@@ -234,7 +234,7 @@ const columns: Column<T>[] = [
  * @returns {JSX.Element}
  */
 const ListingView: FC = () => {
-  usePageTitle("Data Submission List");
+  usePageTitle("Data Submissions");
 
   const { state } = useLocation();
   const { status: authStatus } = useAuthContext();
@@ -302,7 +302,7 @@ const ListingView: FC = () => {
         fetchPolicy: "no-cache",
       });
       if (error || !d?.listSubmissions) {
-        throw new Error("Unable to retrieve Data Submission List results.");
+        throw new Error("Unable to retrieve Data Submission results.");
       }
 
       setData(d.listSubmissions.submissions);
@@ -318,7 +318,7 @@ const ListingView: FC = () => {
       );
       setTotalData(d.listSubmissions.total);
     } catch (err) {
-      Logger.error("Error while fetching Data Submission list", err);
+      Logger.error("Error while fetching Data Submissions", err);
       setError(true);
     } finally {
       setLoading(false);
@@ -335,7 +335,7 @@ const ListingView: FC = () => {
 
       const { data: d } = await refetch();
       if (error || !d?.listSubmissions) {
-        throw new Error("Unable to retrieve Data Submission List results.");
+        throw new Error("Unable to retrieve Data Submission results.");
       }
       setData(d.listSubmissions.submissions);
       setOrganizations(
@@ -350,7 +350,7 @@ const ListingView: FC = () => {
       );
       setTotalData(d.listSubmissions.total);
     } catch (err) {
-      Logger.error("Error updating the Data Submission list", err);
+      Logger.error("Error updating the Data Submissions", err);
       setError(true);
     } finally {
       setLoading(false);
@@ -373,7 +373,7 @@ const ListingView: FC = () => {
   return (
     <>
       <PageBanner
-        title="Data Submission List"
+        title="Data Submissions"
         subTitle="Below is a list of data submissions that are associated with your account. Please click on any of the data submissions to review or continue work."
         padding="57px 0 0 25px"
         body={

--- a/src/content/questionnaire/ListView.test.tsx
+++ b/src/content/questionnaire/ListView.test.tsx
@@ -116,7 +116,7 @@ describe("Accessibility", () => {
     );
 
     await waitFor(() => {
-      expect(getByText("Submission Request List")).toBeInTheDocument();
+      expect(getByText("Submission Requests")).toBeInTheDocument();
     });
 
     await act(async () => {

--- a/src/content/questionnaire/ListView.test.tsx
+++ b/src/content/questionnaire/ListView.test.tsx
@@ -137,7 +137,7 @@ describe("ListView Component", () => {
         <ListView />
       </TestParent>
     );
-    expect(getByText("Submission Request List")).toBeInTheDocument();
+    expect(getByText("Submission Requests")).toBeInTheDocument();
   });
 
   it("sets the page title correctly", () => {
@@ -146,7 +146,7 @@ describe("ListView Component", () => {
         <ListView />
       </TestParent>
     );
-    expect(mockUsePageTitle).toHaveBeenCalledWith("Submission Request List");
+    expect(mockUsePageTitle).toHaveBeenCalledWith("Submission Requests");
   });
 
   it("shows the 'Start a Submission Request' button for users with the required permissions", () => {

--- a/src/content/questionnaire/ListView.tsx
+++ b/src/content/questionnaire/ListView.tsx
@@ -263,7 +263,7 @@ const columns: Column<T>[] = [
  * @returns {JSX.Element}
  */
 const ListingView: FC = () => {
-  usePageTitle("Submission Request List");
+  usePageTitle("Submission Requests");
 
   const navigate = useNavigate();
   const { state } = useLocation();
@@ -329,12 +329,12 @@ const ListingView: FC = () => {
         fetchPolicy: "no-cache",
       });
       if (error || !d?.listApplications) {
-        throw new Error("Unable to retrieve Data Submission List results.");
+        throw new Error("Unable to retrieve Submission Requests results.");
       }
 
       setData(d.listApplications);
     } catch (err) {
-      Logger.error(`ListView: Unable to retrieve Data Submission List results`, err);
+      Logger.error(`ListView: Unable to retrieve Submission Requests results`, err);
       setError(true);
     } finally {
       setLoading(false);
@@ -396,7 +396,7 @@ const ListingView: FC = () => {
   return (
     <>
       <PageBanner
-        title="Submission Request List"
+        title="Submission Requests"
         subTitle="Below is a list of submission requests that are associated with your account. Please click on any of the submission requests to review or continue work."
         padding="57px 25px 0 25px"
         body={


### PR DESCRIPTION
### Overview

Renamed the "Data Submission(s) List" page to "Data Submissions". Also, renamed "Submission Request(s) List" to "Data Submissions". Updated across all found instances.

### Change Details (Specifics)

N/A

### Related Ticket(s)

[CRDCDH-2904](https://tracker.nci.nih.gov/browse/CRDCDH-2904) (Task)
[CRDCDH-2861](https://tracker.nci.nih.gov/browse/CRDCDH-2861) (US)
