### PR TITLE
CRDCDH-2905: Fix misaligned tooltip

### DIFF
--- a/src/components/AccessRequest/index.tsx
+++ b/src/components/AccessRequest/index.tsx
@@ -1,4 +1,4 @@
-import { Button, styled } from "@mui/material";
+import { Box, Button, styled } from "@mui/material";
 import { FC, memo, useState } from "react";
 
 import { hasPermission } from "../../config/AuthPermissions";
@@ -8,9 +8,13 @@ import StyledTooltip from "../StyledFormComponents/StyledTooltip";
 
 import FormDialog from "./FormDialog";
 
-const StyledButton = styled(Button)({
+const StyledBox = styled(Box)({
   marginLeft: "42px",
   marginBottom: "1px",
+});
+
+const StyledButton = styled(Button)({
+  margin: 0,
   color: "#0B7F99",
   textTransform: "uppercase",
   fontSize: "13px",
@@ -50,23 +54,25 @@ const AccessRequest: FC = (): React.ReactNode => {
 
   return (
     <>
-      <StyledTooltip
-        title="Request role change, study access, or institution update."
-        placement="top"
-        arrow
-      >
-        <span>
-          <StyledButton
-            variant="text"
-            onClick={handleClick}
-            data-testid="request-access-button"
-            disableFocusRipple
-            disableRipple
-          >
-            Request Access
-          </StyledButton>
-        </span>
-      </StyledTooltip>
+      <StyledBox>
+        <StyledTooltip
+          title="Request role change, study access, or institution update."
+          placement="top"
+          arrow
+        >
+          <span>
+            <StyledButton
+              variant="text"
+              onClick={handleClick}
+              data-testid="request-access-button"
+              disableFocusRipple
+              disableRipple
+            >
+              Request Access
+            </StyledButton>
+          </span>
+        </StyledTooltip>
+      </StyledBox>
       {dialogOpen && (
         <MemoizedProvider filterInactive>
           <FormDialog open onClose={handleClose} />


### PR DESCRIPTION
### Overview

The tooltip is shifted to the left due to margin. Moved margin to outside the button and into a wrapper instead.

### Change Details (Specifics)

N/A

### Related Ticket(s)

[CRDCDH-2905](https://tracker.nci.nih.gov/browse/CRDCDH-2905) (Task)
[CRDCDH-2846](https://tracker.nci.nih.gov/browse/CRDCDH-2846) (US)
