### PR TITLE
CRDCDH-2990 Manage Collaborators with 'No Access'

### DIFF
--- a/src/components/Collaborators/CollaboratorsDialog.stories.tsx
+++ b/src/components/Collaborators/CollaboratorsDialog.stories.tsx
@@ -1,0 +1,207 @@
+import { MockedResponse } from "@apollo/client/testing";
+import type { Meta, StoryObj } from "@storybook/react";
+import { userEvent, screen, expect, waitFor } from "@storybook/test";
+import React, { ComponentPropsWithoutRef } from "react";
+
+import { authCtxStateFactory } from "@/factories/auth/AuthCtxStateFactory";
+import { userFactory } from "@/factories/auth/UserFactory";
+import { collaboratorFactory } from "@/factories/submission/CollaboratorFactory";
+import { submissionAttributesFactory } from "@/factories/submission/SubmissionAttributesFactory";
+import { submissionCtxStateFactory } from "@/factories/submission/SubmissionContextFactory";
+import { submissionFactory } from "@/factories/submission/SubmissionFactory";
+
+import { TOOLTIP_TEXT } from "../../config/DashboardTooltips";
+import {
+  LIST_POTENTIAL_COLLABORATORS,
+  ListPotentialCollaboratorsInput,
+  ListPotentialCollaboratorsResp,
+} from "../../graphql";
+import { Context as AuthContext, ContextState as AuthCtxState } from "../Contexts/AuthContext";
+import { CollaboratorsProvider } from "../Contexts/CollaboratorsContext";
+import { SubmissionContext, SubmissionCtxState } from "../Contexts/SubmissionContext";
+
+import CollaboratorsDialog from "./CollaboratorsDialog";
+
+const NUM_COLLABORATORS = 5;
+
+const listPotentialCollaboratorsMock: MockedResponse<
+  ListPotentialCollaboratorsResp,
+  ListPotentialCollaboratorsInput
+> = {
+  request: {
+    query: LIST_POTENTIAL_COLLABORATORS,
+  },
+  variableMatcher: () => true,
+  result: {
+    data: {
+      listPotentialCollaborators: userFactory
+        .pick(["_id", "firstName", "lastName"])
+        .build(NUM_COLLABORATORS, (index) => ({
+          _id: `user-${index + 1}`,
+          firstName: `${index + 1} Jane`,
+          lastName: "Smith",
+        })),
+    },
+  },
+};
+
+type ContextArgs = {
+  isEdit: boolean;
+  userRole: UserRole;
+  submissionStatus: SubmissionStatus;
+  collaboratorsCount: number;
+};
+
+type ComponentProps = ComponentPropsWithoutRef<typeof CollaboratorsDialog>;
+
+type StoryArgs = ContextArgs & ComponentProps;
+
+const meta: Meta<StoryArgs> = {
+  title: "Data Submissions / Collaborators Dialog",
+  component: CollaboratorsDialog,
+  parameters: {
+    layout: "fullscreen",
+    apolloClient: { mocks: [listPotentialCollaboratorsMock] },
+  },
+  argTypes: {
+    isEdit: { name: "Edit mode", control: "boolean" },
+    userRole: {
+      name: "User Role",
+      control: "select",
+      options: [
+        "User",
+        "Submitter",
+        "Admin",
+        "Data Commons Personnel",
+        "Federal Lead",
+      ] as UserRole[],
+      defaultValue: "Submitter",
+    },
+    submissionStatus: {
+      name: "Submission Status",
+      control: "select",
+      options: [
+        "New",
+        "In Progress",
+        "Canceled",
+        "Withdrawn",
+        "Released",
+        "Rejected",
+        "Completed",
+        "Deleted",
+      ] as SubmissionStatus[],
+      defaultValue: "In Progress",
+    },
+    collaboratorsCount: {
+      name: "Collaborators Count",
+      control: { type: "number", min: 0, max: NUM_COLLABORATORS },
+      defaultValue: 1,
+    },
+  },
+  args: {
+    isEdit: false,
+    userRole: "Submitter",
+    submissionStatus: "In Progress",
+    collaboratorsCount: 1,
+    open: true,
+  },
+  decorators: [
+    (Story, ctx) => {
+      const { isEdit, userRole, submissionStatus, collaboratorsCount } = ctx.args;
+      const authState: AuthCtxState = authCtxStateFactory.build({
+        user: userFactory.build({
+          _id: "user-1",
+          firstName: "Example",
+          role: userRole,
+          permissions: ["data_submission:create"],
+        }),
+      });
+
+      const submissionState: SubmissionCtxState = submissionCtxStateFactory.build({
+        data: {
+          getSubmission: submissionFactory.build({
+            _id: "submission-1",
+            submitterID: isEdit ? "user-1" : "other-user",
+            collaborators: collaboratorFactory.build(collaboratorsCount, (i) => ({
+              collaboratorID: `user-${i + 2}`,
+              collaboratorName: `Smith, ${i + 2} Jane`,
+              permission: "Can Edit",
+            })),
+            status: submissionStatus,
+          }),
+          submissionStats: { stats: [] },
+          getSubmissionAttributes: {
+            submissionAttributes: submissionAttributesFactory
+              .pick(["hasOrphanError", "isBatchUploading"])
+              .build({
+                hasOrphanError: false,
+                isBatchUploading: false,
+              }),
+          },
+        },
+      });
+
+      return (
+        <AuthContext.Provider value={authState}>
+          <SubmissionContext.Provider value={submissionState}>
+            <CollaboratorsProvider>
+              <Story />
+            </CollaboratorsProvider>
+          </SubmissionContext.Provider>
+        </AuthContext.Provider>
+      );
+    },
+  ],
+} satisfies Meta<StoryArgs>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Editable: Story = {
+  args: { isEdit: true, open: true },
+  play: async () => {
+    await expect(await screen.findByTestId("collaborators-dialog")).toBeInTheDocument();
+    await expect(await screen.findByTestId("collaborators-dialog-header")).toBeInTheDocument();
+
+    const saveBtn = await screen.findByTestId("collaborators-dialog-save-button");
+    await expect(saveBtn).not.toBeDisabled();
+
+    const addBtn = await screen.findByTestId("add-collaborator-button");
+    await userEvent.click(addBtn);
+
+    const rows = await screen.findAllByTestId(/collaborator-row-/);
+    expect(rows.length).toBe(2);
+  },
+};
+
+export const ViewOnly: Story = {
+  args: { isEdit: false, open: true },
+  play: async () => {
+    await expect(await screen.findByTestId("collaborators-dialog")).toBeInTheDocument();
+    expect(screen.queryByTestId("collaborators-dialog-save-button")).toBeNull();
+
+    await expect(
+      await screen.findByTestId("collaborators-dialog-close-button")
+    ).toBeInTheDocument();
+  },
+};
+
+export const MaxReached: Story = {
+  args: { isEdit: true, open: true },
+  play: async () => {
+    await expect(await screen.findByTestId("collaborators-dialog")).toBeInTheDocument();
+
+    const addBtn = await screen.findByTestId("add-collaborator-button");
+    new Array(NUM_COLLABORATORS - 1).fill(null).forEach(() => {
+      userEvent.click(addBtn);
+    });
+
+    await waitFor(() => expect(addBtn).toBeDisabled());
+
+    await userEvent.hover(addBtn);
+    const tooltip = await screen.findByText(
+      TOOLTIP_TEXT.COLLABORATORS_DIALOG.ACTIONS.ADD_COLLABORATOR_DISABLED
+    );
+    expect(tooltip).toBeInTheDocument();
+  },
+};

--- a/src/components/Collaborators/CollaboratorsTable.stories.tsx
+++ b/src/components/Collaborators/CollaboratorsTable.stories.tsx
@@ -1,0 +1,164 @@
+import { MockedResponse } from "@apollo/client/testing";
+import type { Meta, StoryObj } from "@storybook/react";
+import { userEvent, within, screen, expect, waitFor } from "@storybook/test";
+import React, { useEffect } from "react";
+
+import { authCtxStateFactory } from "@/factories/auth/AuthCtxStateFactory";
+import { userFactory } from "@/factories/auth/UserFactory";
+import { collaboratorFactory } from "@/factories/submission/CollaboratorFactory";
+import { submissionAttributesFactory } from "@/factories/submission/SubmissionAttributesFactory";
+import { submissionCtxStateFactory } from "@/factories/submission/SubmissionContextFactory";
+import { submissionFactory } from "@/factories/submission/SubmissionFactory";
+
+import { TOOLTIP_TEXT } from "../../config/DashboardTooltips";
+import {
+  LIST_POTENTIAL_COLLABORATORS,
+  ListPotentialCollaboratorsInput,
+  ListPotentialCollaboratorsResp,
+} from "../../graphql";
+import { Context as AuthContext, ContextState as AuthCtxState } from "../Contexts/AuthContext";
+import { CollaboratorsProvider, useCollaboratorsContext } from "../Contexts/CollaboratorsContext";
+import { SubmissionContext, SubmissionCtxState } from "../Contexts/SubmissionContext";
+
+import CollaboratorsTable from "./CollaboratorsTable";
+
+const NUM_COLLABORATORS = 5;
+
+const listPotentialCollaboratorsMock: MockedResponse<
+  ListPotentialCollaboratorsResp,
+  ListPotentialCollaboratorsInput
+> = {
+  request: {
+    query: LIST_POTENTIAL_COLLABORATORS,
+  },
+  variableMatcher: () => true,
+  result: {
+    data: {
+      listPotentialCollaborators: userFactory
+        .pick(["_id", "firstName", "lastName"])
+        .build(NUM_COLLABORATORS, (index) => ({
+          _id: `user-${index + 1}`,
+          firstName: `${index + 1} Jane`,
+          lastName: "Smith",
+        })),
+    },
+  },
+};
+
+const TableWithAutoLoad: React.FC<{ isEdit: boolean }> = ({ isEdit }) => {
+  const { loadPotentialCollaborators } = useCollaboratorsContext();
+  useEffect(() => loadPotentialCollaborators(), [loadPotentialCollaborators]);
+  return <CollaboratorsTable isEdit={isEdit} />;
+};
+
+const meta: Meta<typeof CollaboratorsTable> = {
+  title: "Data Submissions / Collaborators Table",
+  component: CollaboratorsTable,
+  parameters: {
+    layout: "fullscreen",
+    apolloClient: { mocks: [listPotentialCollaboratorsMock] },
+  },
+  argTypes: {
+    isEdit: { name: "Edit mode", control: "boolean" },
+  },
+  args: {
+    isEdit: false,
+  },
+  decorators: [
+    (Story) => {
+      const authState: AuthCtxState = authCtxStateFactory.build({
+        user: userFactory.build({
+          _id: "user-1",
+          firstName: "Example",
+          role: "Submitter",
+          permissions: ["data_submission:create"],
+        }),
+      });
+
+      const submissionState: SubmissionCtxState = submissionCtxStateFactory.build({
+        data: {
+          getSubmission: submissionFactory.build({
+            _id: "submission-1",
+            submitterID: "user-1",
+            collaborators: collaboratorFactory.build(1, {
+              collaboratorID: "user-2",
+              collaboratorName: "Smith, 2 Jane",
+              permission: "Can Edit",
+            }),
+          }),
+          submissionStats: {
+            stats: [],
+          },
+          getSubmissionAttributes: {
+            submissionAttributes: submissionAttributesFactory
+              .pick(["hasOrphanError", "isBatchUploading"])
+              .build({
+                hasOrphanError: false,
+                isBatchUploading: false,
+              }),
+          },
+        },
+      });
+
+      return (
+        <AuthContext.Provider value={authState}>
+          <SubmissionContext.Provider value={submissionState}>
+            <CollaboratorsProvider>
+              <Story />
+            </CollaboratorsProvider>
+          </SubmissionContext.Provider>
+        </AuthContext.Provider>
+      );
+    },
+  ],
+} satisfies Meta<typeof CollaboratorsTable>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Editable: Story = {
+  args: { role: "Submitter", isEdit: true },
+  render: (args) => <TableWithAutoLoad isEdit={args.isEdit} />,
+  play: async ({ canvasElement }) => {
+    const c = within(canvasElement);
+
+    const addBtn = await c.findByTestId("add-collaborator-button");
+    await expect(addBtn).not.toBeDisabled();
+
+    await userEvent.click(addBtn);
+    const rows = await c.findAllByTestId(/collaborator-row-/);
+    expect(rows.length).toBe(2);
+  },
+};
+
+export const ViewOnly: Story = {
+  args: { role: "Data Curator", isEdit: false },
+  render: (args) => <TableWithAutoLoad isEdit={args.isEdit} />,
+  play: async ({ canvasElement }) => {
+    const c = within(canvasElement);
+    expect(c.queryByTestId("remove-collaborator-button-0")).toBeNull();
+  },
+};
+
+export const MaxReached: Story = {
+  args: { role: "Submitter", isEdit: true },
+  render: (args) => <TableWithAutoLoad isEdit={args.isEdit} />,
+  play: async ({ canvasElement }) => {
+    const c = within(canvasElement);
+
+    const addBtn = await c.findByTestId("add-collaborator-button");
+    await expect(addBtn).not.toBeDisabled();
+
+    new Array(NUM_COLLABORATORS - 1).fill(null).forEach(() => {
+      userEvent.click(addBtn);
+    });
+
+    await waitFor(() => expect(addBtn).toBeDisabled());
+
+    await userEvent.hover(addBtn);
+    const tooltip = await screen.findByText(
+      TOOLTIP_TEXT.COLLABORATORS_DIALOG.ACTIONS.ADD_COLLABORATOR_DISABLED
+    );
+    expect(tooltip).toBeInTheDocument();
+  },
+};

--- a/src/components/Collaborators/CollaboratorsTable.tsx
+++ b/src/components/Collaborators/CollaboratorsTable.tsx
@@ -31,6 +31,11 @@ const StyledTableContainer = styled(TableContainer)(() => ({
   marginBottom: "15px",
 }));
 
+const FixedTable = styled(Table)({
+  tableLayout: "fixed",
+  width: "100%",
+});
+
 const StyledTableHeaderRow = styled(TableRow)(() => ({
   "&.MuiTableRow-root": {
     height: "38px",
@@ -197,7 +202,13 @@ const CollaboratorsTable = ({ isEdit }: Props) => {
   return (
     <>
       <StyledTableContainer data-testid="collaborators-table-container">
-        <Table>
+        <FixedTable>
+          <colgroup>
+            <col style={{ width: isEdit ? "47%" : "50%" }} />
+            <col style={{ width: isEdit ? "40%" : "50%" }} />
+            {isEdit && <col style={{ width: "13%" }} />}
+          </colgroup>
+
           <TableHead>
             <StyledTableHeaderRow data-testid="table-header-row">
               <StyledTableHeaderCell id="header-collaborator" data-testid="header-collaborator">
@@ -229,7 +240,7 @@ const CollaboratorsTable = ({ isEdit }: Props) => {
                 key={`collaborator_${idx}_${collaborator.collaboratorID}`}
                 data-testid={`collaborator-row-${idx}`}
               >
-                <StyledNameCell width="45%">
+                <StyledNameCell>
                   <StyledSelect
                     value={collaborator.collaboratorID || ""}
                     onChange={(e) =>
@@ -269,7 +280,7 @@ const CollaboratorsTable = ({ isEdit }: Props) => {
                   </StyledSelect>
                 </StyledNameCell>
 
-                <StyledTableCell width="40%" data-testid={`collaborator-access-${idx}`}>
+                <StyledTableCell data-testid={`collaborator-access-${idx}`}>
                   <Stack direction="row" justifyContent="center" alignItems="center">
                     <StyledRadioGroup
                       value={collaborator?.permission || ""}
@@ -311,7 +322,7 @@ const CollaboratorsTable = ({ isEdit }: Props) => {
                 </StyledTableCell>
 
                 {isEdit && (
-                  <StyledTableCell width="15%">
+                  <StyledTableCell>
                     <Stack direction="row" justifyContent="center" alignItems="center">
                       <StyledRemoveButton
                         onClick={() => handleRemoveCollaborator(idx)}
@@ -327,7 +338,7 @@ const CollaboratorsTable = ({ isEdit }: Props) => {
               </StyledTableRow>
             ))}
           </TableBody>
-        </Table>
+        </FixedTable>
       </StyledTableContainer>
 
       <AddRemoveButton

--- a/src/components/Collaborators/CollaboratorsTable.tsx
+++ b/src/components/Collaborators/CollaboratorsTable.tsx
@@ -248,8 +248,7 @@ const CollaboratorsTable = ({ isEdit }: Props) => {
                     }}
                     renderValue={() => (
                       <TruncatedText
-                        text="AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
-                        // text={collaborator.collaboratorName ?? " "}
+                        text={collaborator.collaboratorName ?? " "}
                         maxCharacters={20}
                         underline={false}
                         ellipsis

--- a/src/components/Collaborators/CollaboratorsTable.tsx
+++ b/src/components/Collaborators/CollaboratorsTable.tsx
@@ -1,7 +1,9 @@
 import AddCircleIcon from "@mui/icons-material/AddCircle";
 import {
+  FormControlLabel,
   IconButton,
   MenuItem,
+  RadioGroup,
   Stack,
   styled,
   Table,
@@ -18,6 +20,7 @@ import RemoveIconSvg from "../../assets/icons/remove_icon.svg?react";
 import { TOOLTIP_TEXT } from "../../config/DashboardTooltips";
 import AddRemoveButton from "../AddRemoveButton";
 import { useCollaboratorsContext } from "../Contexts/CollaboratorsContext";
+import StyledFormRadioButton from "../Questionnaire/StyledRadioButton";
 import StyledFormSelect from "../StyledFormComponents/StyledSelect";
 import TruncatedText from "../TruncatedText";
 
@@ -96,6 +99,47 @@ const StyledNameCell = styled(StyledTableCell)({
   },
 });
 
+const StyledRadioControl = styled(FormControlLabel)({
+  fontFamily: "Nunito",
+  fontSize: "16px",
+  fontWeight: "500",
+  lineHeight: "20px",
+  textAlign: "left",
+  color: "#083A50",
+  "&:last-child": {
+    marginRight: "0px",
+    minWidth: "unset",
+  },
+});
+
+const StyledRadioGroup = styled(RadioGroup)({
+  width: "100%",
+  justifyContent: "center",
+  alignItems: "center",
+  gap: "14px",
+  "& .MuiFormControlLabel-root": {
+    margin: 0,
+    "&.Mui-disabled": {
+      cursor: "not-allowed",
+    },
+  },
+  "& .MuiFormControlLabel-asterisk": {
+    display: "none",
+  },
+  "& .MuiSelect-select .notranslate": {
+    display: "inline-block",
+    minHeight: "38px",
+  },
+  "& .MuiRadio-root.Mui-disabled .radio-icon": {
+    background: "#FFF !important",
+    opacity: 0.4,
+  },
+});
+
+const StyledRadioButton = styled(StyledFormRadioButton)({
+  padding: "0 7px 0 0",
+});
+
 const StyledRemoveButton = styled(IconButton)(({ theme }) => ({
   color: "#C05239",
   padding: "5px",
@@ -159,6 +203,14 @@ const CollaboratorsTable = ({ isEdit }: Props) => {
               <StyledTableHeaderCell id="header-collaborator" data-testid="header-collaborator">
                 Collaborator
               </StyledTableHeaderCell>
+              <StyledTableHeaderCell
+                id="header-access"
+                sx={{ textAlign: "center" }}
+                data-testid="header-access"
+              >
+                Access
+              </StyledTableHeaderCell>
+
               {isEdit && (
                 <StyledTableHeaderCell
                   id="header-remove"
@@ -177,7 +229,7 @@ const CollaboratorsTable = ({ isEdit }: Props) => {
                 key={`collaborator_${idx}_${collaborator.collaboratorID}`}
                 data-testid={`collaborator-row-${idx}`}
               >
-                <StyledNameCell width="100%">
+                <StyledNameCell width="45%">
                   <StyledSelect
                     value={collaborator.collaboratorID || ""}
                     onChange={(e) =>
@@ -196,8 +248,9 @@ const CollaboratorsTable = ({ isEdit }: Props) => {
                     }}
                     renderValue={() => (
                       <TruncatedText
-                        text={collaborator.collaboratorName ?? " "}
-                        maxCharacters={35}
+                        text="AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+                        // text={collaborator.collaboratorName ?? " "}
+                        maxCharacters={20}
                         underline={false}
                         ellipsis
                       />
@@ -216,8 +269,50 @@ const CollaboratorsTable = ({ isEdit }: Props) => {
                       ))}
                   </StyledSelect>
                 </StyledNameCell>
+
+                <StyledTableCell width="40%" data-testid={`collaborator-access-${idx}`}>
+                  <Stack direction="row" justifyContent="center" alignItems="center">
+                    <StyledRadioGroup
+                      value={collaborator?.permission || ""}
+                      onChange={(e, val: CollaboratorPermissions) =>
+                        handleUpdateCollaborator(idx, {
+                          collaboratorID: collaborator?.collaboratorID,
+                          permission: val,
+                        })
+                      }
+                      data-testid={`collaborator-permissions-${idx}`}
+                      aria-labelledby="header-access"
+                      row
+                    >
+                      <StyledRadioControl
+                        value="Can Edit"
+                        control={
+                          <StyledRadioButton
+                            readOnly={loading || !isEdit}
+                            disabled={loading || !isEdit}
+                            required
+                          />
+                        }
+                        label="Can Edit"
+                      />
+
+                      <StyledRadioControl
+                        value="No Access"
+                        control={
+                          <StyledRadioButton
+                            readOnly={loading || !isEdit}
+                            disabled={loading || !isEdit}
+                            required
+                          />
+                        }
+                        label="No Access"
+                      />
+                    </StyledRadioGroup>
+                  </Stack>
+                </StyledTableCell>
+
                 {isEdit && (
-                  <StyledTableCell>
+                  <StyledTableCell width="15%">
                     <Stack direction="row" justifyContent="center" alignItems="center">
                       <StyledRemoveButton
                         onClick={() => handleRemoveCollaborator(idx)}

--- a/src/components/Contexts/CollaboratorsContext.tsx
+++ b/src/components/Contexts/CollaboratorsContext.tsx
@@ -77,7 +77,7 @@ type ProviderProps = {
 /**
  * CollaboratorsProvider component to provide collaborators context
  *
- * @see {@link useSubmissionContext} The context hook
+ * @see {@link useCollaboratorsContext} The context hook
  * @returns {JSX.Element}
  */
 export const CollaboratorsProvider: FC<ProviderProps> = ({ children }) => {

--- a/src/components/Contexts/CollaboratorsContext.tsx
+++ b/src/components/Contexts/CollaboratorsContext.tsx
@@ -229,7 +229,10 @@ export const CollaboratorsProvider: FC<ProviderProps> = ({ children }) => {
     collaboratorIdx: number,
     newCollaborator: CollaboratorInput
   ): void => {
-    if (isNaN(collaboratorIdx) || !newCollaborator?.collaboratorID) {
+    if (
+      isNaN(collaboratorIdx) ||
+      (!newCollaborator?.collaboratorID && !newCollaborator?.permission)
+    ) {
       return;
     }
 
@@ -267,8 +270,8 @@ export const CollaboratorsProvider: FC<ProviderProps> = ({ children }) => {
    */
   const saveCollaborators = useCallback(async (): Promise<Collaborator[]> => {
     const collaboratorsToSave: CollaboratorInput[] = currentCollaborators
-      .filter((c) => !!c.collaboratorID)
-      .map((c) => ({ collaboratorID: c.collaboratorID, permission: "Can Edit" }));
+      .filter((c) => !!c.collaboratorID && !!c.permission)
+      .map((c) => ({ collaboratorID: c.collaboratorID, permission: c.permission }));
 
     try {
       const { data, errors } = await editSubmissionCollaborators({

--- a/src/types/Submissions.d.ts
+++ b/src/types/Submissions.d.ts
@@ -411,7 +411,7 @@ type SubmitButtonResult = {
 /**
  * Represents the permissions a collaborator can have in a submission
  */
-type CollaboratorPermissions = "Can Edit";
+type CollaboratorPermissions = "Can Edit" | "No Access";
 
 /**
  * Represents a submitter that can view and edit another submitter's submission


### PR DESCRIPTION
### Overview

Update the manage collaborators table to re-add the "Access" column. 

### Change Details (Specifics)

- Re-added the "Access' column within the manage collaborators table
- Kept the option "Can Edit", and added "No Access"
- Added test and storybook coverage

### Related Ticket(s)

[CRDCDH-2990](https://tracker.nci.nih.gov/browse/CRDCDH-2990) (Task)
[CRDCDH-2693](https://tracker.nci.nih.gov/browse/CRDCDH-2693) (US)
