### PR TITLE
CRDCDH-2993 Add 'User' filter to Manage Users list page

### DIFF
--- a/src/components/GenericTable/index.tsx
+++ b/src/components/GenericTable/index.tsx
@@ -475,7 +475,9 @@ const GenericTable = <T,>(
 
   return (
     <StyledTableContainer {...containerProps}>
-      {(!paramsInitialized || showDelayedLoading) && <SuspenseLoader fullscreen={false} />}
+      {(!paramsInitialized || showDelayedLoading) && (
+        <SuspenseLoader fullscreen={false} data-testid="generic-table-suspense-loader" />
+      )}
       {(position === "top" || position === "both") && (
         <Pagination verticalPlacement="top" disabled={!data || loading || !paramsInitialized} />
       )}
@@ -517,10 +519,10 @@ const GenericTable = <T,>(
               </TableRow>
             </TableHeadComponent>
           )}
-          <TableBody>
+          <TableBody data-testid="generic-table-body">
             {(!paramsInitialized || showDelayedLoading) && (total === 0 || !data?.length)
               ? Array.from(Array(numRowsNoContent).keys())?.map((_, idx) => (
-                  <StyledTableRow key={`loading_row_${idx}`}>
+                  <StyledTableRow key={`loading_row_${idx}`} data-testid="loading-row">
                     <TableCell colSpan={columns?.length} />
                   </StyledTableRow>
                 ))
@@ -528,7 +530,7 @@ const GenericTable = <T,>(
                   // eslint-disable-next-line @typescript-eslint/dot-notation
                   const itemKey = setItemKey ? setItemKey(d, idx) : d["_id"];
                   return (
-                    <TableRow tabIndex={-1} hover key={itemKey}>
+                    <TableRow tabIndex={-1} hover key={itemKey} data-testid="generic-table-row">
                       {columns?.map((col: Column<T>) => (
                         <TableBodyCellComponent
                           key={`${itemKey}_${col.label}`}

--- a/src/content/users/ListView.test.tsx
+++ b/src/content/users/ListView.test.tsx
@@ -1,0 +1,273 @@
+import { MockedProvider, MockedResponse } from "@apollo/client/testing";
+import { fireEvent, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { FC, useMemo } from "react";
+import { MemoryRouter, MemoryRouterProps } from "react-router-dom";
+import { axe } from "vitest-axe";
+
+import {
+  Context as AuthContext,
+  ContextState as AuthContextState,
+} from "@/components/Contexts/AuthContext";
+import { SearchParamsProvider } from "@/components/Contexts/SearchParamsContext";
+import { authCtxStateFactory } from "@/factories/auth/AuthCtxStateFactory";
+import { userFactory } from "@/factories/auth/UserFactory";
+import { LIST_USERS, ListUsersResp } from "@/graphql";
+import { act, render, waitFor } from "@/test-utils";
+
+import ListView from "./ListView";
+
+const listUsersMock: MockedResponse<ListUsersResp> = {
+  request: {
+    query: LIST_USERS,
+  },
+  variableMatcher: () => true,
+  result: {
+    data: {
+      listUsers: userFactory.build(100, (index) => ({
+        _id: `user-${index + 1}`,
+        name: `User ${index + 1}`,
+        firstName: `First ${index + 1}`,
+        lastName: `Last ${index + 1}`,
+        email: `user${index + 1}@example.com`,
+        role: index === 10 ? "Federal Lead" : "Submitter",
+      })),
+    },
+  },
+  maxUsageCount: Infinity,
+};
+
+type ParentProps = {
+  mocks?: MockedResponse[];
+  user?: Partial<User>;
+  initialEntries?: MemoryRouterProps["initialEntries"];
+  children: React.ReactNode;
+};
+
+const TestParent: FC<ParentProps> = ({
+  mocks = [listUsersMock],
+  user = {},
+  initialEntries = ["/"],
+  children,
+}: ParentProps) => {
+  const authCtx: AuthContextState = useMemo<AuthContextState>(
+    () =>
+      authCtxStateFactory.build({
+        user: userFactory.build({ _id: "user-1", permissions: ["user:manage"], ...user }),
+      }),
+    [user]
+  );
+
+  return (
+    <MockedProvider mocks={mocks} addTypename={false}>
+      <MemoryRouter initialEntries={initialEntries}>
+        <AuthContext.Provider value={authCtx}>
+          <SearchParamsProvider>{children}</SearchParamsProvider>
+        </AuthContext.Provider>
+      </MemoryRouter>
+    </MockedProvider>
+  );
+};
+
+describe("Accessibility", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("should have no violations", async () => {
+    const { container, queryByTestId } = render(
+      <TestParent>
+        <ListView />
+      </TestParent>
+    );
+    await waitFor(() => {
+      expect(queryByTestId("generic-table-suspense-loader")).not.toBeInTheDocument();
+    });
+
+    await act(async () => {
+      expect(await axe(container)).toHaveNoViolations();
+    });
+  });
+});
+
+describe("Basic Functionality", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("renders without crashing", async () => {
+    const { getByTestId } = render(
+      <TestParent>
+        <ListView />
+      </TestParent>
+    );
+
+    await waitFor(() => {
+      expect(getByTestId("list-view-container")).toBeInTheDocument();
+    });
+  });
+});
+
+describe("Implementation Requirements", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("should render all filters", () => {
+    const { getByLabelText, getByPlaceholderText } = render(
+      <TestParent>
+        <ListView />
+      </TestParent>
+    );
+    expect(getByLabelText("User")).toBeInTheDocument();
+    expect(getByPlaceholderText("Enter User Name or Email")).toBeInTheDocument();
+    expect(getByLabelText("Role")).toBeInTheDocument();
+    expect(getByLabelText("Status")).toBeInTheDocument();
+  });
+
+  it("should not filter until at least 3 characters are entered", async () => {
+    const { getByPlaceholderText, queryByTestId, getByTestId } = render(
+      <TestParent>
+        <ListView />
+      </TestParent>
+    );
+    await waitFor(() => {
+      expect(queryByTestId("generic-table-suspense-loader")).not.toBeInTheDocument();
+    });
+
+    const input = getByPlaceholderText("Enter User Name or Email");
+    userEvent.type(input, "Us");
+
+    expect(
+      within(getByTestId("generic-table-body")).getAllByTestId("generic-table-row").length
+    ).toBeGreaterThan(0);
+  });
+
+  it("should filter users by partial, case-insensitive match on firstName, lastName, email, and name formats", async () => {
+    const { getByPlaceholderText, queryByTestId, getByTestId } = render(
+      <TestParent>
+        <ListView />
+      </TestParent>
+    );
+    await waitFor(() => {
+      expect(queryByTestId("generic-table-suspense-loader")).not.toBeInTheDocument();
+    });
+
+    const input = getByPlaceholderText("Enter User Name or Email");
+
+    // Match by email
+    userEvent.clear(input);
+    userEvent.type(input, "user1@example.com");
+    expect(
+      within(getByTestId("generic-table-body")).getAllByTestId("generic-table-row").length
+    ).toBeGreaterThan(0);
+
+    // Match by firstName
+    userEvent.clear(input);
+    userEvent.type(input, "First 1");
+    expect(
+      within(getByTestId("generic-table-body")).getAllByTestId("generic-table-row").length
+    ).toBeGreaterThan(0);
+
+    // Match by lastName
+    userEvent.clear(input);
+    userEvent.type(input, "Last 1");
+    expect(
+      within(getByTestId("generic-table-body")).getAllByTestId("generic-table-row").length
+    ).toBeGreaterThan(0);
+
+    // Match by "lastName, firstName"
+    userEvent.clear(input);
+    userEvent.type(input, "Last 1, First 1");
+    expect(
+      within(getByTestId("generic-table-body")).getAllByTestId("generic-table-row").length
+    ).toBeGreaterThan(0);
+
+    // Match by "firstName lastName"
+    userEvent.clear(input);
+    userEvent.type(input, "First 1 Last 1");
+    expect(
+      within(getByTestId("generic-table-body")).getAllByTestId("generic-table-row").length
+    ).toBeGreaterThan(0);
+
+    // Match by "lastName firstName"
+    userEvent.clear(input);
+    userEvent.type(input, "Last 1 First 1");
+    expect(
+      within(getByTestId("generic-table-body")).getAllByTestId("generic-table-row").length
+    ).toBeGreaterThan(0);
+
+    // Case-insensitive match
+    userEvent.clear(input);
+    userEvent.type(input, "first 1");
+    expect(
+      within(getByTestId("generic-table-body")).getAllByTestId("generic-table-row").length
+    ).toBeGreaterThan(0);
+  });
+
+  it("should show empty state when no users match", async () => {
+    const { getByPlaceholderText, findByText, queryByTestId } = render(
+      <TestParent>
+        <ListView />
+      </TestParent>
+    );
+    await waitFor(() => {
+      expect(queryByTestId("generic-table-suspense-loader")).not.toBeInTheDocument();
+    });
+
+    const input = getByPlaceholderText("Enter User Name or Email");
+    userEvent.clear(input);
+    userEvent.type(input, "notarealuser@example.com");
+    expect(await findByText("No users found matching your search criteria.")).toBeInTheDocument();
+  });
+
+  it("should update results in real-time as user types", async () => {
+    const { getByPlaceholderText, queryByTestId, getByTestId, findByText } = render(
+      <TestParent>
+        <ListView />
+      </TestParent>
+    );
+    await waitFor(() => {
+      expect(queryByTestId("generic-table-suspense-loader")).not.toBeInTheDocument();
+    });
+
+    const input = getByPlaceholderText("Enter User Name or Email");
+    userEvent.clear(input);
+    userEvent.type(input, "user1@example.com");
+    expect(
+      within(getByTestId("generic-table-body")).getAllByTestId("generic-table-row").length
+    ).toBeGreaterThan(0);
+
+    userEvent.clear(input);
+    userEvent.type(input, "notarealuser@example.com");
+    expect(await findByText("No users found matching your search criteria.")).toBeInTheDocument();
+  });
+
+  it("should combine User filter with Role and Status filters", async () => {
+    const { getByPlaceholderText, getByLabelText, getByTestId, queryByTestId } = render(
+      <TestParent>
+        <ListView />
+      </TestParent>
+    );
+    await waitFor(() => {
+      expect(queryByTestId("generic-table-suspense-loader")).not.toBeInTheDocument();
+    });
+
+    const input = getByPlaceholderText("Enter User Name or Email");
+    const roleSelect = getByLabelText("Role");
+    const statusSelect = getByLabelText("Status");
+
+    userEvent.clear(input);
+    userEvent.type(input, "user");
+
+    fireEvent.change(roleSelect, { target: { value: "Federal Lead" } });
+    fireEvent.change(statusSelect, { target: { value: "Active" } });
+
+    expect(
+      within(getByTestId("generic-table-body")).getAllByTestId("generic-table-row").length
+    ).toBe(1);
+  });
+});

--- a/src/content/users/ListView.test.tsx
+++ b/src/content/users/ListView.test.tsx
@@ -149,7 +149,7 @@ describe("Implementation Requirements", () => {
     ).toBeGreaterThan(0);
   });
 
-  it("should filter users by partial, case-insensitive match on firstName, lastName, email, and name formats", async () => {
+  it("should filter users by email (case-insensitive, partial)", async () => {
     const { getByPlaceholderText, queryByTestId, getByTestId } = render(
       <TestParent>
         <ListView />
@@ -160,52 +160,104 @@ describe("Implementation Requirements", () => {
     });
 
     const input = getByPlaceholderText("Enter User Name or Email");
-
-    // Match by email
     userEvent.clear(input);
     userEvent.type(input, "user1@example.com");
+
     expect(
       within(getByTestId("generic-table-body")).getAllByTestId("generic-table-row").length
     ).toBeGreaterThan(0);
+  });
 
-    // Match by firstName
-    userEvent.clear(input);
-    userEvent.type(input, "First 1");
-    expect(
-      within(getByTestId("generic-table-body")).getAllByTestId("generic-table-row").length
-    ).toBeGreaterThan(0);
+  it("should filter users by firstName (case-insensitive, partial)", async () => {
+    const { getByPlaceholderText, queryByTestId, getByTestId } = render(
+      <TestParent>
+        <ListView />
+      </TestParent>
+    );
+    await waitFor(() => {
+      expect(queryByTestId("generic-table-suspense-loader")).not.toBeInTheDocument();
+    });
 
-    // Match by lastName
-    userEvent.clear(input);
-    userEvent.type(input, "Last 1");
-    expect(
-      within(getByTestId("generic-table-body")).getAllByTestId("generic-table-row").length
-    ).toBeGreaterThan(0);
-
-    // Match by "lastName, firstName"
-    userEvent.clear(input);
-    userEvent.type(input, "Last 1, First 1");
-    expect(
-      within(getByTestId("generic-table-body")).getAllByTestId("generic-table-row").length
-    ).toBeGreaterThan(0);
-
-    // Match by "firstName lastName"
-    userEvent.clear(input);
-    userEvent.type(input, "First 1 Last 1");
-    expect(
-      within(getByTestId("generic-table-body")).getAllByTestId("generic-table-row").length
-    ).toBeGreaterThan(0);
-
-    // Match by "lastName firstName"
-    userEvent.clear(input);
-    userEvent.type(input, "Last 1 First 1");
-    expect(
-      within(getByTestId("generic-table-body")).getAllByTestId("generic-table-row").length
-    ).toBeGreaterThan(0);
-
-    // Case-insensitive match
+    const input = getByPlaceholderText("Enter User Name or Email");
     userEvent.clear(input);
     userEvent.type(input, "first 1");
+
+    expect(
+      within(getByTestId("generic-table-body")).getAllByTestId("generic-table-row").length
+    ).toBeGreaterThan(0);
+  });
+
+  it("should filter users by lastName (case-insensitive, partial)", async () => {
+    const { getByPlaceholderText, queryByTestId, getByTestId } = render(
+      <TestParent>
+        <ListView />
+      </TestParent>
+    );
+    await waitFor(() => {
+      expect(queryByTestId("generic-table-suspense-loader")).not.toBeInTheDocument();
+    });
+
+    const input = getByPlaceholderText("Enter User Name or Email");
+    userEvent.clear(input);
+    userEvent.type(input, "Last 1");
+
+    expect(
+      within(getByTestId("generic-table-body")).getAllByTestId("generic-table-row").length
+    ).toBeGreaterThan(0);
+  });
+
+  it('should filter users by "lastName, firstName" format', async () => {
+    const { getByPlaceholderText, queryByTestId, getByTestId } = render(
+      <TestParent>
+        <ListView />
+      </TestParent>
+    );
+    await waitFor(() => {
+      expect(queryByTestId("generic-table-suspense-loader")).not.toBeInTheDocument();
+    });
+
+    const input = getByPlaceholderText("Enter User Name or Email");
+    userEvent.clear(input);
+    userEvent.type(input, "Last 1, First 1");
+
+    expect(
+      within(getByTestId("generic-table-body")).getAllByTestId("generic-table-row").length
+    ).toBeGreaterThan(0);
+  });
+
+  it('should filter users by "firstName lastName" format', async () => {
+    const { getByPlaceholderText, queryByTestId, getByTestId } = render(
+      <TestParent>
+        <ListView />
+      </TestParent>
+    );
+    await waitFor(() => {
+      expect(queryByTestId("generic-table-suspense-loader")).not.toBeInTheDocument();
+    });
+
+    const input = getByPlaceholderText("Enter User Name or Email");
+    userEvent.clear(input);
+    userEvent.type(input, "First 1 Last 1");
+
+    expect(
+      within(getByTestId("generic-table-body")).getAllByTestId("generic-table-row").length
+    ).toBeGreaterThan(0);
+  });
+
+  it('should filter users by "lastName firstName" format', async () => {
+    const { getByPlaceholderText, queryByTestId, getByTestId } = render(
+      <TestParent>
+        <ListView />
+      </TestParent>
+    );
+    await waitFor(() => {
+      expect(queryByTestId("generic-table-suspense-loader")).not.toBeInTheDocument();
+    });
+
+    const input = getByPlaceholderText("Enter User Name or Email");
+    userEvent.clear(input);
+    userEvent.type(input, "Last 1 First 1");
+
     expect(
       within(getByTestId("generic-table-body")).getAllByTestId("generic-table-row").length
     ).toBeGreaterThan(0);
@@ -224,6 +276,7 @@ describe("Implementation Requirements", () => {
     const input = getByPlaceholderText("Enter User Name or Email");
     userEvent.clear(input);
     userEvent.type(input, "notarealuser@example.com");
+
     expect(await findByText("No users found matching your search criteria.")).toBeInTheDocument();
   });
 
@@ -240,12 +293,14 @@ describe("Implementation Requirements", () => {
     const input = getByPlaceholderText("Enter User Name or Email");
     userEvent.clear(input);
     userEvent.type(input, "user1@example.com");
+
     expect(
       within(getByTestId("generic-table-body")).getAllByTestId("generic-table-row").length
     ).toBeGreaterThan(0);
 
     userEvent.clear(input);
     userEvent.type(input, "notarealuser@example.com");
+
     expect(await findByText("No users found matching your search criteria.")).toBeInTheDocument();
   });
 

--- a/src/content/users/ListView.tsx
+++ b/src/content/users/ListView.tsx
@@ -269,7 +269,7 @@ const ListingView: FC = () => {
     }
 
     setTablePage(0);
-  }, [searchParams?.toString()]);
+  }, [searchParams?.get("user"), searchParams?.get("role"), searchParams?.get("status")]);
 
   useEffect(() => {
     if (Object.values(touchedFilters).every((filter) => !filter)) {

--- a/src/content/users/ListView.tsx
+++ b/src/content/users/ListView.tsx
@@ -254,7 +254,7 @@ const ListingView: FC = () => {
     ["All", "Inactive", "Active"].includes(status);
 
   useEffect(() => {
-    const user = searchParams.get("user");
+    const user = searchParams.get("user") || "";
     const role = searchParams.get("role");
     const status = searchParams.get("status");
 
@@ -313,6 +313,12 @@ const ListingView: FC = () => {
   const handleFilterChange = (field: keyof FilterForm) => {
     setTouchedFilters((prev) => ({ ...prev, [field]: true }));
   };
+
+  useEffect(() => {
+    if (userFilter?.length === 0) {
+      setTablePage(0);
+    }
+  }, [userFilter]);
 
   return (
     <>

--- a/src/content/users/ListView.tsx
+++ b/src/content/users/ListView.tsx
@@ -318,7 +318,7 @@ const ListingView: FC = () => {
     <>
       <PageBanner title="Manage Users" subTitle="" padding="38px 0 0 25px" />
 
-      <StyledContainer maxWidth="xl">
+      <StyledContainer maxWidth="xl" data-testid="list-view-container">
         {(state?.error || error) && (
           <Alert sx={{ mb: 3, p: 2 }} severity="error">
             {state?.error || "An error occurred while loading the data."}

--- a/src/content/users/ListView.tsx
+++ b/src/content/users/ListView.tsx
@@ -25,7 +25,13 @@ import StyledSelect from "../../components/StyledFormComponents/StyledSelect";
 import { Roles } from "../../config/AuthRoles";
 import { LIST_USERS, ListUsersResp } from "../../graphql";
 import usePageTitle from "../../hooks/usePageTitle";
-import { compareStrings, isUserMatch, formatIDP, sortData } from "../../utils";
+import {
+  compareStrings,
+  isUserMatch,
+  formatIDP,
+  sortData,
+  isStringLengthBetween,
+} from "../../utils";
 
 type T = ListUsersResp["listUsers"][number];
 
@@ -272,7 +278,7 @@ const ListingView: FC = () => {
 
     const newSearchParams = new URLSearchParams(searchParams);
 
-    if (userFilter) {
+    if (userFilter?.trim()?.length >= 3) {
       newSearchParams.set("user", userFilter);
     } else {
       newSearchParams.delete("user");
@@ -335,6 +341,9 @@ const ListingView: FC = () => {
                     field.onChange(e);
                     handleFilterChange("user");
                   }}
+                  onBlur={(e) =>
+                    isStringLengthBetween(e?.target?.value, 0, 3) && setValue("user", "")
+                  }
                 />
               )}
             />
@@ -402,6 +411,7 @@ const ListingView: FC = () => {
           defaultRowsPerPage={20}
           defaultOrder="asc"
           setItemKey={(item, idx) => `${idx}_${item._id}`}
+          noContentText="No users found matching your search criteria."
           onFetchData={handleFetchData}
           containerProps={{ sx: { marginBottom: "8px", borderColor: "#083A50" } }}
           CustomTableHead={StyledTableHead}

--- a/src/content/users/ListView.tsx
+++ b/src/content/users/ListView.tsx
@@ -254,12 +254,12 @@ const ListingView: FC = () => {
     ["All", "Inactive", "Active"].includes(status);
 
   useEffect(() => {
-    const user = searchParams.get("user") || "";
+    const userParam = searchParams.get("user") || "";
     const role = searchParams.get("role");
     const status = searchParams.get("status");
 
-    if (user && user !== userFilter) {
-      setValue("user", user);
+    if (userParam && userParam !== userFilter) {
+      setValue("user", userParam);
     }
     if (isRoleFilterOption(role) && role !== roleFilter) {
       setValue("role", role);
@@ -269,7 +269,7 @@ const ListingView: FC = () => {
     }
 
     setTablePage(0);
-  }, [searchParams.get("user"), searchParams.get("role"), searchParams.get("status")]);
+  }, [searchParams?.toString()]);
 
   useEffect(() => {
     if (Object.values(touchedFilters).every((filter) => !filter)) {
@@ -314,12 +314,6 @@ const ListingView: FC = () => {
     setTouchedFilters((prev) => ({ ...prev, [field]: true }));
   };
 
-  useEffect(() => {
-    if (userFilter?.length === 0) {
-      setTablePage(0);
-    }
-  }, [userFilter]);
-
   return (
     <>
       <PageBanner title="Manage Users" subTitle="" padding="38px 0 0 25px" />
@@ -347,9 +341,11 @@ const ListingView: FC = () => {
                     field.onChange(e);
                     handleFilterChange("user");
                   }}
-                  onBlur={(e) =>
-                    isStringLengthBetween(e?.target?.value, 0, 3) && setValue("user", "")
-                  }
+                  onBlur={(e) => {
+                    if (isStringLengthBetween(e?.target?.value, 0, 3)) {
+                      setValue("user", "");
+                    }
+                  }}
                 />
               )}
             />

--- a/src/test-utils/factories/auth/AuthCtxStateFactory.ts
+++ b/src/test-utils/factories/auth/AuthCtxStateFactory.ts
@@ -8,7 +8,7 @@ import { userFactory } from "./UserFactory";
  */
 export const baseAuthCtxState: AuthCtxState = {
   status: Status.LOADED,
-  isLoggedIn: false,
+  isLoggedIn: true,
   user: userFactory.build(),
 };
 

--- a/src/utils/profileUtils.test.ts
+++ b/src/utils/profileUtils.test.ts
@@ -1,4 +1,5 @@
 import { pbacDefaultFactory } from "@/factories/auth/PBACDefaultFactory";
+import { userFactory } from "@/factories/auth/UserFactory";
 
 import * as utils from "./profileUtils";
 
@@ -429,5 +430,59 @@ describe("getUserPermissionExtensions", () => {
     const permission = "entity:action:one:two:three:four:five" as AuthPermissions;
 
     expect(utils.getUserPermissionExtensions(permission, -2)).toEqual([["four"], ["five"]]);
+  });
+});
+
+describe("isUserMatch cases", () => {
+  const baseUser = userFactory.build({
+    firstName: "Jane",
+    lastName: "Smith",
+    email: "jane.smith@example.com",
+  });
+
+  it("should return false when user is null or undefined", () => {
+    expect(utils.isUserMatch(null, "john")).toBe(false);
+    expect(utils.isUserMatch(undefined, "john")).toBe(false);
+  });
+
+  it("should return true when filter is null, undefined, empty or whitespace", () => {
+    expect(utils.isUserMatch(baseUser, null)).toBe(true);
+    expect(utils.isUserMatch(baseUser, undefined)).toBe(true);
+    expect(utils.isUserMatch(baseUser, "")).toBe(true);
+    expect(utils.isUserMatch(baseUser, "   ")).toBe(true);
+  });
+
+  it("should match by first name (partial, case-insensitive)", () => {
+    expect(utils.isUserMatch(baseUser, "jan")).toBe(true);
+  });
+
+  it("should match by last name (partial, case-insensitive)", () => {
+    expect(utils.isUserMatch(baseUser, "smi")).toBe(true);
+  });
+
+  it("should match by email  (partial, case-insensitive)", () => {
+    expect(utils.isUserMatch(baseUser, "smith@exa")).toBe(true);
+  });
+
+  it("should match by 'last, first' format (partial, case-insensitive)", () => {
+    expect(utils.isUserMatch(baseUser, "smith, j")).toBe(true);
+    expect(utils.isUserMatch(baseUser, "smith, jane")).toBe(true);
+  });
+
+  it("should match by 'first last' format (partial, case-insensitive)", () => {
+    expect(utils.isUserMatch(baseUser, "jane s")).toBe(true);
+    expect(utils.isUserMatch(baseUser, "jane smith")).toBe(true);
+  });
+
+  it("should match by 'last first' format (partial, case-insensitive)", () => {
+    expect(utils.isUserMatch(baseUser, "smith j")).toBe(true);
+    expect(utils.isUserMatch(baseUser, "smith jane")).toBe(true);
+  });
+
+  it("should return false when query does not match any user field", () => {
+    expect(utils.isUserMatch(baseUser, "nonexistent")).toBe(false);
+    expect(utils.isUserMatch(baseUser, "john smith")).toBe(false);
+    expect(utils.isUserMatch(baseUser, "smith john")).toBe(false);
+    expect(utils.isUserMatch(baseUser, "smith, john")).toBe(false);
   });
 });

--- a/src/utils/profileUtils.test.ts
+++ b/src/utils/profileUtils.test.ts
@@ -469,6 +469,19 @@ describe("isUserMatch cases", () => {
     expect(utils.isUserMatch(baseUser, "smith, jane")).toBe(true);
   });
 
+  it("should not match by ',' when first name and last name are missing or empty space", () => {
+    expect(utils.isUserMatch(userFactory.build({ firstName: "", lastName: "" }), ",")).toBe(false);
+    expect(utils.isUserMatch(userFactory.build({ firstName: "   ", lastName: "   " }), ",")).toBe(
+      false
+    );
+    expect(utils.isUserMatch(userFactory.build({ firstName: null, lastName: null }), ",")).toBe(
+      false
+    );
+    expect(
+      utils.isUserMatch(userFactory.build({ firstName: undefined, lastName: undefined }), ",")
+    ).toBe(false);
+  });
+
   it("should match by 'first last' format (partial, case-insensitive)", () => {
     expect(utils.isUserMatch(baseUser, "jane s")).toBe(true);
     expect(utils.isUserMatch(baseUser, "jane smith")).toBe(true);

--- a/src/utils/profileUtils.ts
+++ b/src/utils/profileUtils.ts
@@ -198,3 +198,38 @@ export const getUserPermissionExtensions = (
 
   return rawExtensions.slice(startAt)?.map((p) => p.split("+"));
 };
+
+/**
+ * Determines whether a user matches a given search query.
+ *
+ * @param {Partial<User>} user - The user object to filter.
+ * @param {string} filter - The search query string.
+ * @returns {boolean} True if the user matches the filter, false otherwise.
+ */
+export const isUserMatch = (user: Partial<User>, filter: string): boolean => {
+  if (!user) {
+    return false;
+  }
+
+  const query = filter?.trim()?.toLowerCase() || "";
+  if (!query) {
+    return true;
+  }
+
+  const first = user.firstName?.trim()?.toLowerCase() || "";
+  const last = user.lastName?.trim()?.toLowerCase() || "";
+  const email = user.email?.trim()?.toLowerCase() || "";
+
+  const fullComma = `${last}, ${first}`.trim();
+  const fullSpace = `${first} ${last}`.trim();
+  const fullSpaceReverse = `${last} ${first}`.trim();
+
+  return (
+    email.includes(query) ||
+    first.includes(query) ||
+    last.includes(query) ||
+    fullComma.includes(query) ||
+    fullSpace.includes(query) ||
+    fullSpaceReverse.includes(query)
+  );
+};

--- a/src/utils/profileUtils.ts
+++ b/src/utils/profileUtils.ts
@@ -220,9 +220,9 @@ export const isUserMatch = (user: Partial<User>, filter: string): boolean => {
   const last = user.lastName?.trim()?.toLowerCase() || "";
   const email = user.email?.trim()?.toLowerCase() || "";
 
-  const fullComma = `${last}, ${first}`.trim();
-  const fullSpace = `${first} ${last}`.trim();
-  const fullSpaceReverse = `${last} ${first}`.trim();
+  const fullComma = [last, first].filter(Boolean).join(", ").trim();
+  const fullSpace = [first, last].filter(Boolean).join(" ").trim();
+  const fullSpaceReverse = [last, first].filter(Boolean).join(" ").trim();
 
   return (
     email.includes(query) ||

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,6 +28,7 @@
     "jsx": "react-jsx",
     "paths": {
       "@/factories/*": ["./src/test-utils/factories/*"],
+      "@/components/*": ["./src/components/*"],
       "@/*": ["./src/*"],
     }
   },


### PR DESCRIPTION
### Overview

Added a "User" filter within the Manage Users list page.

### Change Details (Specifics)

- Added new filter "User" within Manage Users list page to filter by:
  - `firstName`
  - `lastName`
  - `email`
  - `lastname, firstName` (How "name" appears on the table)
  - `firstName lastName`
  - `lastName firstName`
- Only apply search when "User" filter has more than 3 characters typed in
- Added user filter to search params
- Updated default message when table yields no results
- Added test coverage

### Related Ticket(s)

[CRDCDH-2993](https://tracker.nci.nih.gov/browse/CRDCDH-2993) (Task)
[CRDCDH-2965](https://tracker.nci.nih.gov/browse/CRDCDH-2965) (US)
