### PR TITLE
CRDCDH-3016 Replace Institution select with an autocomplete input

### DIFF
--- a/src/components/Questionnaire/AutocompleteInput.tsx
+++ b/src/components/Questionnaire/AutocompleteInput.tsx
@@ -57,10 +57,13 @@ const StyledFormControl = styled(FormControl)(() => ({
     borderRadius: "8px",
     border: "1px solid #6B7294",
     marginTop: "2px",
+    maxHeight: "270px",
     "& .MuiAutocomplete-listbox": {
       padding: 0,
       overflow: "auto",
-      maxHeight: "300px",
+      width: "fit-content",
+      minWidth: "100%",
+      maxHeight: "unset",
     },
     "& .MuiAutocomplete-option[aria-selected='true']": {
       color: "#083A50",
@@ -71,6 +74,7 @@ const StyledFormControl = styled(FormControl)(() => ({
       minHeight: "35px",
       color: "#083A50",
       background: "#FFFFFF",
+      whiteSpace: "nowrap",
     },
     "& .MuiAutocomplete-option:hover": {
       backgroundColor: "#3E7E6D",

--- a/src/content/users/ProfileView.test.tsx
+++ b/src/content/users/ProfileView.test.tsx
@@ -1,0 +1,218 @@
+import { MockedProvider, MockedResponse } from "@apollo/client/testing";
+import userEvent from "@testing-library/user-event";
+import { FC, useMemo } from "react";
+import { MemoryRouter, MemoryRouterProps } from "react-router-dom";
+import { axe } from "vitest-axe";
+
+import { SearchParamsProvider } from "@/components/Contexts/SearchParamsContext";
+import { approvedStudyFactory } from "@/factories/approved-study/ApprovedStudyFactory";
+import { authCtxStateFactory } from "@/factories/auth/AuthCtxStateFactory";
+import { userFactory } from "@/factories/auth/UserFactory";
+import { institutionFactory } from "@/factories/institution/InstitutionFactory";
+import {
+  GET_USER,
+  GetUserInput,
+  GetUserResp,
+  LIST_APPROVED_STUDIES,
+  LIST_INSTITUTIONS,
+  ListApprovedStudiesInput,
+  ListApprovedStudiesResp,
+  ListInstitutionsInput,
+  ListInstitutionsResp,
+  RETRIEVE_PBAC_DEFAULTS,
+  RetrievePBACDefaultsInput,
+  RetrievePBACDefaultsResp,
+} from "@/graphql";
+import { act, render, waitFor } from "@/test-utils";
+
+import {
+  Context as AuthContext,
+  ContextState as AuthContextState,
+} from "../../components/Contexts/AuthContext";
+
+import ProfileView from "./ProfileView";
+
+const getUserMock: MockedResponse<GetUserResp, GetUserInput> = {
+  request: {
+    query: GET_USER,
+  },
+  variableMatcher: () => true,
+  result: {
+    data: {
+      getUser: userFactory.build({
+        role: "Submitter",
+        studies: approvedStudyFactory.pick(["_id", "studyName", "studyAbbreviation"]).build(2),
+        institution: institutionFactory.build(),
+      }) as GetUserResp["getUser"],
+    },
+  },
+  maxUsageCount: Infinity,
+};
+
+const listApprovedStudiesMock: MockedResponse<ListApprovedStudiesResp, ListApprovedStudiesInput> = {
+  request: {
+    query: LIST_APPROVED_STUDIES,
+  },
+  variableMatcher: () => true,
+  result: {
+    data: {
+      listApprovedStudies: {
+        total: 2,
+        studies: approvedStudyFactory.build(2),
+      },
+    },
+  },
+  maxUsageCount: Infinity,
+};
+
+const listInstitutionsMock: MockedResponse<ListInstitutionsResp, ListInstitutionsInput> = {
+  request: {
+    query: LIST_INSTITUTIONS,
+  },
+  variableMatcher: () => true,
+  result: {
+    data: {
+      listInstitutions: {
+        total: 3,
+        institutions: [
+          institutionFactory.build({ name: "Alpha Cancer Center" }),
+          institutionFactory.build({ name: "Beta Oncology Institute" }),
+          institutionFactory.build({ name: "Gamma Research Hospital" }),
+        ],
+      },
+    },
+  },
+  maxUsageCount: Infinity,
+};
+
+const retrievePBACDefaults: MockedResponse<RetrievePBACDefaultsResp, RetrievePBACDefaultsInput> = {
+  request: {
+    query: RETRIEVE_PBAC_DEFAULTS,
+  },
+  variableMatcher: () => true,
+  result: {
+    data: {
+      retrievePBACDefaults: [],
+    },
+  },
+  maxUsageCount: Infinity,
+};
+
+type ParentProps = {
+  mocks?: MockedResponse[];
+  user?: Partial<User>;
+  initialEntries?: MemoryRouterProps["initialEntries"];
+  children: React.ReactNode;
+};
+
+const TestParent: FC<ParentProps> = ({
+  mocks = [getUserMock, listApprovedStudiesMock, listInstitutionsMock, retrievePBACDefaults],
+  user = {},
+  initialEntries = ["/"],
+  children,
+}: ParentProps) => {
+  const authCtx: AuthContextState = useMemo<AuthContextState>(
+    () =>
+      authCtxStateFactory.build({
+        user: userFactory.build({
+          permissions: ["access:request", "user:manage"],
+          role: "Submitter",
+          ...user,
+        }),
+      }),
+    [user]
+  );
+
+  return (
+    <MockedProvider mocks={mocks}>
+      <MemoryRouter initialEntries={initialEntries}>
+        <AuthContext.Provider value={authCtx}>
+          <SearchParamsProvider>{children}</SearchParamsProvider>
+        </AuthContext.Provider>
+      </MemoryRouter>
+    </MockedProvider>
+  );
+};
+
+describe("Accessibility", async () => {
+  it("should have no accessibility violations (users)", async () => {
+    const { container } = render(
+      <TestParent>
+        <ProfileView _id="test-id" viewType="users" />
+      </TestParent>
+    );
+
+    await act(async () => {
+      expect(await axe(container)).toHaveNoViolations();
+    });
+  });
+
+  it.todo("should have no accessibility violations (profile)");
+});
+
+describe("Basic Functionality", () => {
+  it("should not crash when rendered", () => {
+    const { container } = render(
+      <TestParent>
+        <ProfileView _id="test-id" viewType="users" />
+      </TestParent>
+    );
+
+    expect(container).toBeInTheDocument();
+  });
+});
+
+describe("Implementation Requirements", () => {
+  it("should render the institution autocomplete input", async () => {
+    const { findByLabelText } = render(
+      <TestParent>
+        <ProfileView _id="test-id" viewType="users" />
+      </TestParent>
+    );
+
+    const input = await findByLabelText(/Institution/i);
+    expect(input).toBeInTheDocument();
+  });
+
+  it("should show institution suggestions as user types (dynamic filtering)", async () => {
+    const { findByLabelText, findByText, queryByText } = render(
+      <TestParent
+        mocks={[getUserMock, listInstitutionsMock, listApprovedStudiesMock, retrievePBACDefaults]}
+      >
+        <ProfileView _id="test-id" viewType="users" />
+      </TestParent>
+    );
+
+    const input = await findByLabelText(/Institution/i);
+    userEvent.click(input);
+    userEvent.clear(input);
+    userEvent.type(input, "Beta");
+
+    await waitFor(async () => {
+      expect(await findByText("Beta Oncology Institute")).toBeInTheDocument();
+      expect(queryByText("Alpha Cancer Center")).not.toBeInTheDocument();
+      expect(queryByText("Gamma Research Hospital")).not.toBeInTheDocument();
+    });
+  });
+
+  it("should allow selecting an institution from the full list if no search input is provided", async () => {
+    const { findByLabelText, findByText } = render(
+      <TestParent
+        mocks={[getUserMock, listInstitutionsMock, listApprovedStudiesMock, retrievePBACDefaults]}
+      >
+        <ProfileView _id="test-id" viewType="users" />
+      </TestParent>
+    );
+
+    const input = await findByLabelText(/Institution/i);
+    userEvent.click(input);
+    userEvent.clear(input);
+    userEvent.type(input, "a");
+    userEvent.clear(input);
+
+    await waitFor(async () => {
+      expect(await findByText("Alpha Cancer Center")).toBeInTheDocument();
+      expect(await findByText("Beta Oncology Institute")).toBeInTheDocument();
+    });
+  });
+});

--- a/src/content/users/ProfileView.tsx
+++ b/src/content/users/ProfileView.tsx
@@ -159,7 +159,7 @@ const StyledPaper = styled(BasePaper)({
 });
 
 const StyledPopper = styled(Popper)({
-  width: "463px !important",
+  width: "363px !important",
 });
 
 const StyledButtonStack = styled(Stack)({
@@ -484,6 +484,8 @@ const ProfileView: FC<Props> = ({ _id, viewType }: Props) => {
     return <SuspenseLoader />;
   }
 
+  const { institutions = [] } = listInstitutions?.listInstitutions || {};
+
   return (
     <>
       <StyledBanner />
@@ -601,21 +603,30 @@ const ProfileView: FC<Props> = ({ _id, viewType }: Props) => {
                       control={control}
                       rules={{ required: false }}
                       render={({ field }) => (
-                        <StyledSelect
+                        <StyledAutocomplete
                           {...field}
-                          size="small"
-                          value={field.value || ""}
+                          options={institutions}
+                          getOptionLabel={(option: Institution) => option.name}
+                          isOptionEqualToValue={(option: Institution, value: Institution) =>
+                            option._id === value._id
+                          }
+                          onChange={(_, data: Institution | null) =>
+                            field.onChange(data?._id || "")
+                          }
+                          value={institutions.find((i) => i._id === field.value) || null}
+                          renderInput={({ inputProps, ...params }) => (
+                            <TextField
+                              {...params}
+                              inputProps={{
+                                "aria-labelledby": "userInstitution",
+                                maxLength: 100,
+                                ...inputProps,
+                              }}
+                              placeholder="100 characters allowed"
+                            />
+                          )}
                           disabled={fieldset.institution === "DISABLED"}
-                          MenuProps={{ disablePortal: true }}
-                          inputProps={{ "aria-labelledby": "userInstitution" }}
-                          required
-                        >
-                          {listInstitutions?.listInstitutions.institutions.map((i) => (
-                            <MenuItem key={i._id} value={i._id}>
-                              {i.name}
-                            </MenuItem>
-                          ))}
-                        </StyledSelect>
+                        />
                       )}
                     />
                   ) : (

--- a/src/content/users/ProfileView.tsx
+++ b/src/content/users/ProfileView.tsx
@@ -619,6 +619,7 @@ const ProfileView: FC<Props> = ({ _id, viewType }: Props) => {
                               {...params}
                               inputProps={{
                                 "aria-labelledby": "userInstitution",
+                                "data-testid": "institution-input",
                                 maxLength: 100,
                                 ...inputProps,
                               }}

--- a/src/content/users/ProfileView.tsx
+++ b/src/content/users/ProfileView.tsx
@@ -614,6 +614,8 @@ const ProfileView: FC<Props> = ({ _id, viewType }: Props) => {
                             field.onChange(data?._id || "")
                           }
                           value={institutions.find((i) => i._id === field.value) || null}
+                          PaperComponent={StyledPaper}
+                          PopperComponent={StyledPopper}
                           renderInput={({ inputProps, ...params }) => (
                             <TextField
                               {...params}

--- a/src/content/users/ProfileView.tsx
+++ b/src/content/users/ProfileView.tsx
@@ -620,10 +620,9 @@ const ProfileView: FC<Props> = ({ _id, viewType }: Props) => {
                               inputProps={{
                                 "aria-labelledby": "userInstitution",
                                 "data-testid": "institution-input",
-                                maxLength: 100,
                                 ...inputProps,
                               }}
-                              placeholder="100 characters allowed"
+                              placeholder="Select an Institution"
                             />
                           )}
                           disabled={fieldset.institution === "DISABLED"}


### PR DESCRIPTION
### Overview

Within the "Edit User" page, the Institution select dropdown was replaced with an autocomplete input.

### Change Details (Specifics)

- Replaced Institution select dropdown with an autocomplete input
- Added basic test coverage for institutions autocomplete

### Related Ticket(s)

[CRDCDH-3016](https://tracker.nci.nih.gov/browse/CRDCDH-3016) (Task)
[CRDCDH-3014](https://tracker.nci.nih.gov/browse/CRDCDH-3014) (US)
