### PR TITLE
CRDCDH-2994 Update Data Submissions Release Labelling

### DIFF
--- a/src/components/DataSubmissions/DataSubmissionSummary.test.tsx
+++ b/src/components/DataSubmissions/DataSubmissionSummary.test.tsx
@@ -714,56 +714,6 @@ describe("DataSubmissionSummary Collaborators Dialog Tests", () => {
 });
 
 describe("Implementation Requirements", () => {
-  it("shows a tooltip with data commons when hovering over 'Released' status in summary", async () => {
-    const dataSubmission = submissionFactory.build({
-      status: "Released",
-      dataCommonsDisplayName: "DC-1",
-    });
-
-    const { getByText, findByText, queryByText } = render(
-      <BaseComponent>
-        <DataSubmissionSummary dataSubmission={dataSubmission} />
-      </BaseComponent>
-    );
-
-    const status = getByText(/Released/i);
-    userEvent.hover(status);
-
-    expect(await findByText(/Released to DC-1/i)).toBeVisible();
-
-    userEvent.unhover(status);
-    await waitFor(() => {
-      expect(queryByText(/Released to DC-1/i)).not.toBeInTheDocument();
-    });
-  });
-
-  it.each<SubmissionStatus>([
-    "New",
-    "In Progress",
-    "Submitted",
-    "Withdrawn",
-    "Canceled",
-    "Deleted",
-    "Rejected",
-    "Completed",
-  ])("does not show a tooltip for non-'Released' status in summary", async (status) => {
-    const dataSubmission = submissionFactory.build({ status });
-
-    const { getByText, queryByText, queryByRole } = render(
-      <BaseComponent>
-        <DataSubmissionSummary dataSubmission={dataSubmission} />
-      </BaseComponent>
-    );
-
-    const statusText = getByText(status);
-    userEvent.hover(statusText);
-
-    await waitFor(() => {
-      expect(queryByText(/Released to/i)).not.toBeInTheDocument();
-      expect(queryByRole("tooltip")).not.toBeInTheDocument();
-    });
-  });
-
   it("shows tooltip for 'Released' status in full history dialog", async () => {
     const dataSubmission = submissionFactory.build({
       status: "Completed",

--- a/src/components/DataSubmissions/DataSubmissionSummary.tsx
+++ b/src/components/DataSubmissions/DataSubmissionSummary.tsx
@@ -197,21 +197,9 @@ const DataSubmissionSummary: FC<Props> = ({ dataSubmission }) => {
     <StyledSummaryWrapper>
       <Stack direction="row" justifyContent="space-between" alignItems="flex-start" spacing="14px">
         <Stack direction="column" alignItems="center" minWidth="192px">
-          {dataSubmission?.status === "Released" ? (
-            <StyledTooltip
-              title={`Released to ${dataSubmission?.dataCommonsDisplayName}`}
-              placement="top"
-              arrow
-            >
-              <StyledSubmissionStatus variant="h5" aria-label="Data Submission status">
-                {dataSubmission?.status}
-              </StyledSubmissionStatus>
-            </StyledTooltip>
-          ) : (
-            <StyledSubmissionStatus variant="h5" aria-label="Data Submission status">
-              {dataSubmission?.status}
-            </StyledSubmissionStatus>
-          )}
+          <StyledSubmissionStatus variant="h5" aria-label="Data Submission status">
+            {dataSubmission?.status}
+          </StyledSubmissionStatus>
           <StyledButtonWrapper>
             <StyledReviewCommentsButton
               variant="contained"

--- a/src/components/DataSubmissions/DataSubmissionSummary.tsx
+++ b/src/components/DataSubmissions/DataSubmissionSummary.tsx
@@ -138,6 +138,19 @@ const StyledEmailWrapper = styled("a")({
   lineHeight: "19.6px",
 });
 
+const buildReleasedStatusWrapper =
+  (dataCommonsDisplayName: string): React.FC<{ children: React.ReactNode }> =>
+  ({ children }) => (
+    <StyledTooltip
+      title={`Released to ${dataCommonsDisplayName}`}
+      placement="top"
+      open={undefined}
+      arrow
+    >
+      <span>{children}</span>
+    </StyledTooltip>
+  );
+
 const getHistoryTextColorFromStatus = (status: SubmissionStatus) => {
   let color: string;
   switch (status) {
@@ -184,9 +197,21 @@ const DataSubmissionSummary: FC<Props> = ({ dataSubmission }) => {
     <StyledSummaryWrapper>
       <Stack direction="row" justifyContent="space-between" alignItems="flex-start" spacing="14px">
         <Stack direction="column" alignItems="center" minWidth="192px">
-          <StyledSubmissionStatus variant="h5" aria-label="Data Submission status">
-            {dataSubmission?.status}
-          </StyledSubmissionStatus>
+          {dataSubmission?.status === "Released" ? (
+            <StyledTooltip
+              title={`Released to ${dataSubmission?.dataCommonsDisplayName}`}
+              placement="top"
+              arrow
+            >
+              <StyledSubmissionStatus variant="h5" aria-label="Data Submission status">
+                {dataSubmission?.status}
+              </StyledSubmissionStatus>
+            </StyledTooltip>
+          ) : (
+            <StyledSubmissionStatus variant="h5" aria-label="Data Submission status">
+              {dataSubmission?.status}
+            </StyledSubmissionStatus>
+          )}
           <StyledButtonWrapper>
             <StyledReviewCommentsButton
               variant="contained"
@@ -306,6 +331,11 @@ const DataSubmissionSummary: FC<Props> = ({ dataSubmission }) => {
         history={dataSubmission?.history}
         iconMap={DataSubmissionIconMap}
         getTextColor={getHistoryTextColorFromStatus}
+        getStatusWrapper={(status) =>
+          status === "Released"
+            ? buildReleasedStatusWrapper(dataSubmission?.dataCommonsDisplayName)
+            : ({ children }) => children
+        }
       />
       <ReviewCommentsDialog
         open={openDialog === "review comments"}

--- a/src/components/HistoryDialog/index.tsx
+++ b/src/components/HistoryDialog/index.tsx
@@ -352,15 +352,17 @@ const HistoryDialog = <T extends string>({
               </DotContainer>
             </Grid>
             <Grid xs={3}>
-              <StatusWrapper>
-                <StyledEventItem
-                  color={color}
-                  textAlign="left"
-                  data-testid={`history-item-${index}-status`}
-                >
-                  {status?.toUpperCase()}
-                </StyledEventItem>
-              </StatusWrapper>
+              <div style={{ width: "fit-content" }}>
+                <StatusWrapper>
+                  <StyledEventItem
+                    color={color}
+                    textAlign="left"
+                    data-testid={`history-item-${index}-status`}
+                  >
+                    {status?.toUpperCase()}
+                  </StyledEventItem>
+                </StatusWrapper>
+              </div>
             </Grid>
             <Grid xs={3}>
               <StyledEventItem

--- a/src/content/dataSubmissions/DataSubmissionActions.stories.tsx
+++ b/src/content/dataSubmissions/DataSubmissionActions.stories.tsx
@@ -59,6 +59,7 @@ type ContextArgs = {
   dataFileSize: number;
   hasOrphanError: boolean;
   isBatchUploading: boolean;
+  dataCommonsDisplayName: string;
 };
 
 type ComponentProps = ComponentPropsWithoutRef<typeof DataSubmissionActions>;
@@ -77,6 +78,7 @@ const withProviders: Decorator<StoryArgs> = (Story, context) => {
     dataFileSize,
     hasOrphanError = false,
     isBatchUploading = false,
+    dataCommonsDisplayName,
   } = context.args;
 
   return (
@@ -109,6 +111,7 @@ const withProviders: Decorator<StoryArgs> = (Story, context) => {
               status: submissionStatus,
               metadataValidationStatus,
               fileValidationStatus,
+              dataCommonsDisplayName,
               dataType,
               intention,
               dataFileSize: {
@@ -209,6 +212,12 @@ const meta = {
         type: "boolean",
       },
     },
+    dataCommonsDisplayName: {
+      name: "dataCommonsDisplayName",
+      control: {
+        type: "text",
+      },
+    },
   },
   args: {
     role: "Submitter",
@@ -221,6 +230,7 @@ const meta = {
     dataFileSize: 1000,
     hasOrphanError: false,
     isBatchUploading: false,
+    dataCommonsDisplayName: "DC-1",
     onAction: fn(),
   },
   tags: ["autodocs"],

--- a/src/content/dataSubmissions/DataSubmissionActions.test.tsx
+++ b/src/content/dataSubmissions/DataSubmissionActions.test.tsx
@@ -120,4 +120,39 @@ describe("Implementation Requirements - Release", () => {
       expect(releaseBtn).toBeDisabled();
     }
   );
+
+  it("should show data commons within Release button label", () => {
+    shouldDisableReleaseMock.mockReturnValue({ disable: false, requireAlert: false });
+
+    const { getByRole } = render(
+      <TestParent
+        user={{
+          _id: "other-user",
+          role: "Admin",
+          permissions: ["data_submission:view", "data_submission:review"],
+        }}
+        submission={{
+          _id: "submission-id",
+          status: "Submitted",
+          metadataValidationStatus: "Passed",
+          fileValidationStatus: "Passed",
+          crossSubmissionStatus: "Error",
+          dataCommonsDisplayName: "DC-1",
+          otherSubmissions: JSON.stringify({
+            "In Progress": [],
+            Submitted: ["submitted-id"],
+            Released: [],
+          }),
+        }}
+      >
+        <DataSubmissionActions onAction={vi.fn()} />
+      </TestParent>
+    );
+
+    const releaseBtn = getByRole("button", {
+      name: "Release to DC-1",
+    });
+    expect(releaseBtn).toBeInTheDocument();
+    expect(releaseBtn).toHaveTextContent("Release to DC-1");
+  });
 });

--- a/src/content/dataSubmissions/DataSubmissionActions.tsx
+++ b/src/content/dataSubmissions/DataSubmissionActions.tsx
@@ -252,7 +252,7 @@ const DataSubmissionActions = ({ onAction }: Props) => {
               loading={action === "Release"}
               disabled={(action && action !== "Release") || releaseActionButton?.disable}
             >
-              Release
+              Release to {submission?.dataCommonsDisplayName}
             </StyledLoadingButton>
           </span>
         </Tooltip>

--- a/src/content/dataSubmissions/DataSubmissionsListView.tsx
+++ b/src/content/dataSubmissions/DataSubmissionsListView.tsx
@@ -163,7 +163,14 @@ const columns: Column<T>[] = [
 
   {
     label: "Status",
-    renderValue: (a) => a.status,
+    renderValue: (a) =>
+      a.history?.some((event) => event?.status === "Released") && a.dataCommonsDisplayName ? (
+        <StyledTooltip title={`Released to ${a.dataCommonsDisplayName}`} placement="top" arrow>
+          <span>{a.status}</span>
+        </StyledTooltip>
+      ) : (
+        a.status
+      ),
     field: "status",
     hideable: false,
     sx: {

--- a/src/graphql/listSubmissions.ts
+++ b/src/graphql/listSubmissions.ts
@@ -45,6 +45,9 @@ export const query: TypedDocumentNode<Response, Input> = gql`
         createdAt
         updatedAt
         intention
+        history {
+          status
+        }
         dataFileSize {
           formatted
         }
@@ -93,7 +96,10 @@ export type Response = {
       | "createdAt"
       | "updatedAt"
       | "intention"
-    > & { dataFileSize: Pick<Submission["dataFileSize"], "formatted"> })[];
+    > & {
+      dataFileSize: Pick<Submission["dataFileSize"], "formatted">;
+      history: Pick<Submission["history"][number], "status">[];
+    })[];
     organizations: Pick<Organization, "_id" | "name">[];
     submitterNames: string[];
     dataCommons: string[];


### PR DESCRIPTION
### Overview

Updated Release button labeling and added tooltips to Release statuses to include which data commons the submission was released to. 

### Change Details (Specifics)

- Updated the "Release" button label in the Data Submission dashboard to "Release to [DC]"
- Within the Data Submission list table, when the status is anything, but has had a History event indicating the submission has been Released in the past, there will be a tooltip with "Released to [DC]"
- Within the Data Submission full history dialog, when hovering over the "Released" status, it will show a tooltip with "Released to [DC]"
- Added test coverage for the updated label and tooltips

### Related Ticket(s)

[CRDCDH-2994](https://tracker.nci.nih.gov/browse/CRDCDH-2994) (Task)
[CRDCDH-2848](https://tracker.nci.nih.gov/browse/CRDCDH-2848) (US)
