### PR TITLE
Bug: Fix validation type default value causing Validation status to show In-Progress

### DIFF
--- a/src/components/DataSubmissions/ValidationStatus.test.tsx
+++ b/src/components/DataSubmissions/ValidationStatus.test.tsx
@@ -118,6 +118,28 @@ describe("Basic Functionality", () => {
     expect(() => getByTestId("validation-status-chip")).toThrow();
   });
 
+  it.each([[], null, undefined, NaN])(
+    "should not appear for a submission with validationType %s",
+    async (validationType) => {
+      const { container, getByTestId } = render(
+        <TestParent
+          submission={{
+            validationStarted: null,
+            validationEnded: null,
+            validationScope: null,
+            // @ts-expect-error Testing invalid values
+            validationType,
+          }}
+        >
+          <ValidationStatus />
+        </TestParent>
+      );
+
+      expect(container.firstChild).toBeNull();
+      expect(() => getByTestId("validation-status-chip")).toThrow();
+    }
+  );
+
   it("should rerender when the validation state changes", async () => {
     const { getByText, rerender } = render(
       <TestParent

--- a/src/components/DataSubmissions/ValidationStatus.tsx
+++ b/src/components/DataSubmissions/ValidationStatus.tsx
@@ -42,7 +42,8 @@ export const ValidationStatus: React.FC = () => {
     data?.getSubmission || {};
 
   const hadValidation: boolean = useMemo<boolean>(
-    () => !!validationStarted || !!validationEnded || !!validationScope || !!validationType,
+    () =>
+      !!validationStarted || !!validationEnded || !!validationScope || validationType?.length > 0,
     [validationStarted, validationEnded, validationScope, validationType]
   );
 


### PR DESCRIPTION
### Overview

Logic previously expected `validationType` to be null as a default value, but now it is an empty array (Due to BE Prisma change). This caused the validation status to show as In-Progress, when it shouldn't be shown. Updated to check array length instead.

### Change Details (Specifics)

N/A

### Related Ticket(s)

N/A
