### PR TITLE
CRDCDH-2965 Bug: Fix Manage Users 'User' filter

### DIFF
--- a/src/content/users/ListView.tsx
+++ b/src/content/users/ListView.tsx
@@ -235,7 +235,7 @@ const ListingView: FC = () => {
     }
 
     const filters: FilterFunction<T>[] = [
-      (u: T) => isUserMatch(u, userFilter),
+      (u: T) => (userFilter?.trim()?.length >= 3 ? isUserMatch(u, userFilter) : true),
       (u: T) => (roleFilter && roleFilter !== "All" ? u.role === roleFilter : true),
       (u: T) => (statusFilter && statusFilter !== "All" ? u.userStatus === statusFilter : true),
     ];
@@ -313,6 +313,12 @@ const ListingView: FC = () => {
   const handleFilterChange = (field: keyof FilterForm) => {
     setTouchedFilters((prev) => ({ ...prev, [field]: true }));
   };
+
+  useEffect(() => {
+    if (tableRef.current && userFilter?.length === 0) {
+      tableRef.current.refresh();
+    }
+  }, [userFilter?.length]);
 
   return (
     <>


### PR DESCRIPTION
### Overview

When you type 3 or more characters into the "User" filter, then backspace so that you have <3 characters, the table does not reset to show all results, even if you clear all characters in the input. (Does work if you ctrl + backspace though, weirdly)

### Change Details (Specifics)

- Refreshed table when the user filter has no characters
- Return all matches when less than 3 characters are typed into the input

### Related Ticket(s)

[CRDCDH-2993](https://tracker.nci.nih.gov/browse/CRDCDH-2993) (Task)
[CRDCDH-2965](https://tracker.nci.nih.gov/browse/CRDCDH-2965) (US)
