### PR TITLE
CRDCDH-2994 Update 'Released to <DC>' tooltip to only show when status is Released

### DIFF
--- a/src/content/dataSubmissions/DataSubmissionsListView.tsx
+++ b/src/content/dataSubmissions/DataSubmissionsListView.tsx
@@ -164,7 +164,7 @@ const columns: Column<T>[] = [
   {
     label: "Status",
     renderValue: (a) =>
-      a.history?.some((event) => event?.status === "Released") && a.dataCommonsDisplayName ? (
+      a.status === "Released" && a.dataCommonsDisplayName ? (
         <StyledTooltip title={`Released to ${a.dataCommonsDisplayName}`} placement="top" arrow>
           <span>{a.status}</span>
         </StyledTooltip>


### PR DESCRIPTION
### Overview

Previous US said to display the "Released to <DC>" for any status. It has since been updated to only show when status is "Released" within the Data Submissions list page.

### Change Details (Specifics)

N/A

### Related Ticket(s)

[CRDCDH-2994](https://tracker.nci.nih.gov/browse/CRDCDH-2994) (Task)
[CRDCDH-2848](https://tracker.nci.nih.gov/browse/CRDCDH-2848) (US)
