### PR TITLE
CRDCDH-2990 [Bug]: Add a missing waitFor causing storybook play function to fail

### DIFF
--- a/src/components/Collaborators/CollaboratorsTable.stories.tsx
+++ b/src/components/Collaborators/CollaboratorsTable.stories.tsx
@@ -123,7 +123,7 @@ export const Editable: Story = {
     const c = within(canvasElement);
 
     const addBtn = await c.findByTestId("add-collaborator-button");
-    await expect(addBtn).not.toBeDisabled();
+    await waitFor(() => expect(addBtn).not.toBeDisabled());
 
     await userEvent.click(addBtn);
     const rows = await c.findAllByTestId(/collaborator-row-/);
@@ -147,7 +147,7 @@ export const MaxReached: Story = {
     const c = within(canvasElement);
 
     const addBtn = await c.findByTestId("add-collaborator-button");
-    await expect(addBtn).not.toBeDisabled();
+    await waitFor(() => expect(addBtn).not.toBeDisabled());
 
     new Array(NUM_COLLABORATORS - 1).fill(null).forEach(() => {
       userEvent.click(addBtn);


### PR DESCRIPTION
### Overview

Chromatic build failing due to CollaboratorsTable storybook. Was unable to reproduce locally (It is passing locally), but added missing waitFor that will (hopefully) allow the play function to properly wait.

### Change Details (Specifics)

N/A

### Related Ticket(s)

[CRDCDH-2990](https://tracker.nci.nih.gov/browse/CRDCDH-2990) (Task)
[CRDCDH-2693](https://tracker.nci.nih.gov/browse/CRDCDH-2693) (US)
