### PR TITLE
CRDCDH-3116 Prevent creation of Data Submission when pending GPA

### DIFF
--- a/src/components/AccessRequest/index.stories.tsx
+++ b/src/components/AccessRequest/index.stories.tsx
@@ -2,6 +2,11 @@ import { MockedResponse } from "@apollo/client/testing";
 import type { Meta, StoryObj } from "@storybook/react";
 import { userEvent, within, screen, expect } from "@storybook/test";
 
+import { approvedStudyFactory } from "@/factories/approved-study/ApprovedStudyFactory";
+import { authCtxStateFactory } from "@/factories/auth/AuthCtxStateFactory";
+import { userFactory } from "@/factories/auth/UserFactory";
+import { institutionFactory } from "@/factories/institution/InstitutionFactory";
+
 import { Roles } from "../../config/AuthRoles";
 import {
   LIST_APPROVED_STUDIES,
@@ -11,7 +16,7 @@ import {
   ListInstitutionsInput,
   ListInstitutionsResp,
 } from "../../graphql";
-import { Context as AuthContext, ContextState as AuthCtxState } from "../Contexts/AuthContext";
+import { Context as AuthContext } from "../Contexts/AuthContext";
 
 import Dialog from "./index";
 
@@ -36,7 +41,7 @@ const studiesMock: MockedResponse<ListApprovedStudiesResp, ListApprovedStudiesIn
       listApprovedStudies: {
         total: 2,
         studies: [
-          {
+          approvedStudyFactory.build({
             _id: "study-1",
             studyName: "Study-1",
             studyAbbreviation: "S1",
@@ -51,8 +56,8 @@ const studiesMock: MockedResponse<ListApprovedStudiesResp, ListApprovedStudiesIn
             useProgramPC: false,
             createdAt: "",
             pendingModelChange: false,
-          },
-          {
+          }),
+          approvedStudyFactory.build({
             _id: "study-2",
             studyName: "Study-2",
             studyAbbreviation: "S2",
@@ -67,7 +72,7 @@ const studiesMock: MockedResponse<ListApprovedStudiesResp, ListApprovedStudiesIn
             useProgramPC: false,
             createdAt: "",
             pendingModelChange: false,
-          },
+          }),
         ],
       },
     },
@@ -85,24 +90,24 @@ const institutionsMock: MockedResponse<ListInstitutionsResp, ListInstitutionsInp
       listInstitutions: {
         total: 3,
         institutions: [
-          {
+          institutionFactory.build({
             _id: "institution-1",
             name: "Institution 1",
             status: "Active",
             submitterCount: 0,
-          },
-          {
+          }),
+          institutionFactory.build({
             _id: "institution-2",
             name: "Institution 2",
             status: "Active",
             submitterCount: 5,
-          },
-          {
+          }),
+          institutionFactory.build({
             _id: "institution-3",
             name: "Institution 3",
             status: "Active",
             submitterCount: 2,
-          },
+          }),
         ],
       },
     },
@@ -145,16 +150,14 @@ export const Default: Story = {
   decorators: [
     (Story, context) => (
       <AuthContext.Provider
-        value={
-          {
-            isLoggedIn: true,
-            user: {
-              firstName: "Example",
-              role: context.args.role,
-              permissions: context.args.permissions,
-            } as User,
-          } as AuthCtxState
-        }
+        value={authCtxStateFactory.build({
+          isLoggedIn: true,
+          user: userFactory.build({
+            firstName: "Example",
+            role: context.args.role,
+            permissions: context.args.permissions,
+          }),
+        })}
       >
         <Story />
       </AuthContext.Provider>
@@ -184,16 +187,14 @@ export const Hovered: Story = {
   decorators: [
     (Story, context) => (
       <AuthContext.Provider
-        value={
-          {
-            isLoggedIn: true,
-            user: {
-              firstName: "Example",
-              role: context.args.role,
-              permissions: context.args.permissions,
-            } as User,
-          } as AuthCtxState
-        }
+        value={authCtxStateFactory.build({
+          isLoggedIn: true,
+          user: userFactory.build({
+            firstName: "Example",
+            role: context.args.role,
+            permissions: context.args.permissions,
+          }),
+        })}
       >
         <Story />
       </AuthContext.Provider>

--- a/src/components/DataSubmissions/CreateDataSubmissionDialog.stories.tsx
+++ b/src/components/DataSubmissions/CreateDataSubmissionDialog.stories.tsx
@@ -23,6 +23,7 @@ const partialStudyProperties = [
   "dbGaPID",
   "controlledAccess",
   "pendingModelChange",
+  "isPendingGPA",
 ] satisfies (keyof ApprovedStudy)[];
 
 const baseStudies: GetMyUserResp["getMyUser"]["studies"] = [
@@ -57,6 +58,24 @@ const baseStudies: GetMyUserResp["getMyUser"]["studies"] = [
     dbGaPID: "phsTEST",
     controlledAccess: null,
     pendingModelChange: true,
+  }),
+  approvedStudyFactory.pick(partialStudyProperties).build({
+    _id: "pending-GPA-condition",
+    studyName: "study with pending GPA condition",
+    studyAbbreviation: "PGC",
+    dbGaPID: "phsTEST",
+    controlledAccess: true,
+    pendingModelChange: false,
+    isPendingGPA: true,
+  }),
+  approvedStudyFactory.pick(partialStudyProperties).build({
+    _id: "pending-conditions",
+    studyName: "study with pending conditions",
+    studyAbbreviation: "PC",
+    dbGaPID: null,
+    controlledAccess: true,
+    pendingModelChange: true,
+    isPendingGPA: true,
   }),
 ];
 
@@ -157,5 +176,69 @@ export const DialogWithPendingChanges: Story = {
       /The CRDC team is reviewing the data requirements of this study for potential data model changes/i
     );
     expect(tooltip).toBeInTheDocument();
+  },
+};
+
+export const DialogWithPendingGPACondition: Story = {
+  ...Button,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Open the dialog
+    await userEvent.click(canvas.getByRole("button", { name: "Create a Data Submission" }));
+    await screen.findAllByRole("presentation");
+
+    // Open the study select dropdown and select the pending option
+    const studySelect = await screen.findByTestId("create-data-submission-dialog-study-id-input");
+    await userEvent.click(within(studySelect).getByRole("button"));
+    const pendingOption: HTMLElement = await screen.findByTestId(
+      "study-option-pending-GPA-condition"
+    );
+    await userEvent.click(pendingOption);
+
+    // Check that the "Create" button is disabled
+    const createButton = await screen.findByTestId("create-data-submission-dialog-create-button");
+    expect(createButton).toBeDisabled();
+
+    // Hover over the button parent span to trigger the tooltip
+    const createButtonWrapper = createButton.parentElement as HTMLElement;
+    await userEvent.hover(createButtonWrapper);
+    const tooltip = await screen.findByText(
+      /Data submissions cannot be created until the required GPA updates are provided./i
+    );
+    expect(tooltip).toBeInTheDocument();
+  },
+};
+
+export const DialogWithMultiplePendingConditions: Story = {
+  ...Button,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Open the dialog
+    await userEvent.click(canvas.getByRole("button", { name: "Create a Data Submission" }));
+    await screen.findAllByRole("presentation");
+
+    // Open the study select dropdown and select the pending option
+    const studySelect = await screen.findByTestId("create-data-submission-dialog-study-id-input");
+    await userEvent.click(within(studySelect).getByRole("button"));
+    const pendingOption: HTMLElement = await screen.findByTestId("study-option-pending-conditions");
+    await userEvent.click(pendingOption);
+
+    // Check that the "Create" button is disabled
+    const createButton = await screen.findByTestId("create-data-submission-dialog-create-button");
+    expect(createButton).toBeDisabled();
+
+    // Hover over the button parent span to trigger the tooltip
+    const createButtonWrapper = createButton.parentElement as HTMLElement;
+    await userEvent.hover(createButtonWrapper);
+    const tooltip1 = await screen.findByText(
+      /Data submissions cannot be created until the required GPA updates are provided./i
+    );
+    const tooltip2 = await screen.findByText(
+      /The CRDC team is reviewing the data requirements of this study for potential data model changes/i
+    );
+    expect(tooltip1).toBeInTheDocument();
+    expect(tooltip2).toBeInTheDocument();
   },
 };

--- a/src/components/DataSubmissions/CreateDataSubmissionDialog.test.tsx
+++ b/src/components/DataSubmissions/CreateDataSubmissionDialog.test.tsx
@@ -1254,7 +1254,7 @@ describe("Implementation Requirements", () => {
       expect(getByTestId("create-submission-dialog")).toBeInTheDocument();
     });
 
-    // Open the study select dropdown and select the pending model changes study
+    // Open the study select dropdown and select the pending GPA study
     const studySelectButton = within(
       getByTestId("create-data-submission-dialog-study-id-input")
     ).getByRole("button");
@@ -1308,7 +1308,7 @@ describe("Implementation Requirements", () => {
       expect(getByTestId("create-submission-dialog")).toBeInTheDocument();
     });
 
-    // Open the study select dropdown and select the pending model changes study
+    // Open the study select dropdown and select the multiple pending conditions study
     const studySelectButton = within(
       getByTestId("create-data-submission-dialog-study-id-input")
     ).getByRole("button");

--- a/src/graphql/listApprovedStudies.ts
+++ b/src/graphql/listApprovedStudies.ts
@@ -1,6 +1,7 @@
+import { TypedDocumentNode } from "@apollo/client";
 import gql from "graphql-tag";
 
-export const query = gql`
+export const query: TypedDocumentNode<Response, Input> = gql`
   query listApprovedStudies(
     $first: Int
     $offset: Int
@@ -44,6 +45,7 @@ export const query = gql`
         }
         useProgramPC
         pendingModelChange
+        isPendingGPA
         createdAt
       }
     }

--- a/src/test-utils/factories/approved-study/ApprovedStudyFactory.ts
+++ b/src/test-utils/factories/approved-study/ApprovedStudyFactory.ts
@@ -18,6 +18,7 @@ export const baseApprovedStudy: ApprovedStudy = {
   primaryContact: userFactory.build(),
   useProgramPC: false,
   pendingModelChange: false,
+  isPendingGPA: false,
   createdAt: "",
 };
 

--- a/src/types/ApprovedStudies.d.ts
+++ b/src/types/ApprovedStudies.d.ts
@@ -52,6 +52,10 @@ type ApprovedStudy = {
    */
   pendingModelChange: boolean;
   /**
+   * Indicates whether the study has a pending Genomic Program Administrator (GPA)
+   */
+  isPendingGPA: boolean;
+  /**
    * Submission Request approval date or manual record creation date
    */
   createdAt: string;


### PR DESCRIPTION
### Overview

Within the Create a Data Submission dialog, updated the tooltip for the disable "Create" button to include a message for pending GPA. Also, updated it to display multiple conditions in the same tooltip, if they exist.

### Change Details (Specifics)

- Added `isPendingGPA` to Approved Study, factory, and within listApprovedStudies API
- Updated disabled "Create" button tooltip to include new pending GPA message and support displaying multiple at once
- Added test coverage and storybook stories for the new tooltips
- Updated tests/storybook that were missing factory

### Related Ticket(s)

[CRDCDH-3128](https://tracker.nci.nih.gov/browse/CRDCDH-3128)
