### PR TITLE
CRDCDH-3114 External users should not see their PBAC panel

### DIFF
--- a/src/config/AuthPermissions.ts
+++ b/src/config/AuthPermissions.ts
@@ -1,10 +1,6 @@
 import { getUserPermissionExtensions, getUserPermissionKey } from "../utils/profileUtils";
 
-import {
-  Roles as ALL_ROLES,
-  CanDeleteOtherSubmissionRequests,
-  CanSubmitOnlyTheirOwnSubmissionRequestRoles,
-} from "./AuthRoles";
+import { Roles as ALL_ROLES, CanDeleteOtherSubmissionRequests, ExternalRoles } from "./AuthRoles";
 
 /**
  * A flag indicating that no conditions, other than the user having the permission key, need to be met.
@@ -70,7 +66,7 @@ export const PERMISSION_MAP = {
         return false;
       }
 
-      if (CanSubmitOnlyTheirOwnSubmissionRequestRoles.includes(role)) {
+      if (ExternalRoles.includes(role)) {
         return isFormOwner && hasPermissionKey;
       }
 

--- a/src/config/AuthRoles.ts
+++ b/src/config/AuthRoles.ts
@@ -2,7 +2,6 @@
  * Defines a list of valid user roles that can be assigned to a user.
  *
  * @note This list is rendered in the UI exactly as ordered here, without additional sorting.
- * @see {@link UserRole}
  */
 export const Roles: UserRole[] = [
   "User",
@@ -32,7 +31,6 @@ export const CanDeleteOtherSubmissionRequests: UserRole[] = [
 ];
 
 /**
- * A set of roles that are constrained to only be able to submit their own
- * Submission Request forms and cannot submit on behalf of other users.
+ * A set of roles that are considered external users
  */
-export const CanSubmitOnlyTheirOwnSubmissionRequestRoles: UserRole[] = ["User", "Submitter"];
+export const ExternalRoles: UserRole[] = ["User", "Submitter"];

--- a/src/hooks/useProfileFields.test.ts
+++ b/src/hooks/useProfileFields.test.ts
@@ -298,7 +298,7 @@ describe("Profile View", () => {
     }
   );
 
-  it.each<UserRole>(["User", "Submitter", "Data Commons Personnel", "fake role" as UserRole])(
+  it.each<UserRole>(["Admin", "Federal Lead", "Data Commons Personnel", "fake role" as UserRole])(
     "should return DISABLED for the permissions and notifications panel on the profile page for role %s",
     (role) => {
       const user = userFactory.build({ _id: "User-A", role });
@@ -312,6 +312,23 @@ describe("Profile View", () => {
 
       expect(result.current.permissions).toBe("DISABLED");
       expect(result.current.notifications).toBe("DISABLED");
+    }
+  );
+
+  it.each<UserRole>(["User", "Submitter"])(
+    "should return HIDDEN for the permissions and notifications field on the profile page for role %s",
+    (role) => {
+      const user = userFactory.build({ _id: "User-A", role });
+      const profileOf: Pick<User, "_id" | "role"> = userFactory
+        .pick(["_id", "role"])
+        .build({ _id: "User-A", role });
+
+      vi.spyOn(Auth, "useAuthContext").mockReturnValue(authCtxStateFactory.build({ user }));
+
+      const { result } = renderHook(() => useProfileFields(profileOf, "profile"));
+
+      expect(result.current.permissions).toBe("HIDDEN");
+      expect(result.current.notifications).toBe("HIDDEN");
     }
   );
 

--- a/src/hooks/useProfileFields.ts
+++ b/src/hooks/useProfileFields.ts
@@ -1,6 +1,10 @@
 import { useAuthContext } from "../components/Contexts/AuthContext";
 import { hasPermission } from "../config/AuthPermissions";
-import { RequiresInstitutionAssigned, RequiresStudiesAssigned } from "../config/AuthRoles";
+import {
+  ExternalRoles,
+  RequiresInstitutionAssigned,
+  RequiresStudiesAssigned,
+} from "../config/AuthRoles";
 
 /**
  * Constrains the fields that this hook supports generating states for
@@ -69,8 +73,10 @@ const useProfileFields = (
   if (isSelf && viewType === "profile") {
     fields.firstName = "UNLOCKED";
     fields.lastName = "UNLOCKED";
-    fields.permissions = "DISABLED";
-    fields.notifications = "DISABLED";
+
+    // If the profile is external, hide the permissions and notifications fields
+    fields.permissions = ExternalRoles.includes(profileOf?.role) ? "HIDDEN" : "DISABLED";
+    fields.notifications = ExternalRoles.includes(profileOf?.role) ? "HIDDEN" : "DISABLED";
 
     // If the profile requires studies, show a textual representation of the studies field
     fields.studies = RequiresStudiesAssigned.includes(profileOf?.role) ? "READ_ONLY" : "HIDDEN";


### PR DESCRIPTION
### Overview

This PR hides the PBAC panel from external users on their profile page only. If they happen to get Manage Users access, they would still see it under manage users.

### Change Details (Specifics)

- Repurpose a config for external users array
- Update Profile Fields hook to reflect new requirements (hide PBAC from profile page)

### Related Ticket(s)

CRDCDH-3112 (US)
CRDCDH-3114 (Task)
