### PR TITLE
fix: Coveralls.io issues causing test job to fail

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,3 +43,4 @@ jobs:
 
       - name: Coveralls GitHub Action
         uses: coverallsapp/github-action@v2
+        continue-on-error: true


### PR DESCRIPTION
### Overview

Coveralls.io instability causing our Unit Testing action to fail. This will just ignore coveralls errors.
