### PR TITLE
CRDCDH-3168 [Bug]: Fix Release button logic

### DIFF
--- a/src/utils/dataSubmissionUtils.test.ts
+++ b/src/utils/dataSubmissionUtils.test.ts
@@ -977,6 +977,26 @@ describe("shouldDisableRelease", () => {
     }
   );
 
+  it.each<CrossSubmissionStatus>(["Passed"])(
+    "should allow release when crossSubmissionStatus is %s even if other submissions exist",
+    (status) => {
+      const result: ReleaseInfo = utils.shouldDisableRelease({
+        ...baseSubmission,
+        crossSubmissionStatus: status,
+        otherSubmissions: JSON.stringify({
+          "In Progress": ["ABC-123", "XYZ-456"],
+          Submitted: ["DEF-456", "GHI-789"],
+          Released: ["JKL-012", "MNO-345"],
+          Rejected: ["PQR-678", "STU-901"],
+          Withdrawn: ["VWX-234", "YZA-567"],
+        }),
+      });
+
+      expect(result.disable).toBe(false);
+      expect(result.requireAlert).toBe(false);
+    }
+  );
+
   it.each<CrossSubmissionStatus>([
     null,
     "New",
@@ -1069,7 +1089,7 @@ describe("shouldDisableRelease", () => {
     expect(result.requireAlert).toBe(false);
   });
 
-  it("should allow release with alert when cross validation status is 'Passed' and there are In-Progress submissions", () => {
+  it("should allow release without alert when cross validation status is 'Passed' and there are In-Progress submissions", () => {
     const result: ReleaseInfo = utils.shouldDisableRelease({
       ...baseSubmission,
       crossSubmissionStatus: "Passed",
@@ -1083,6 +1103,6 @@ describe("shouldDisableRelease", () => {
     });
 
     expect(result.disable).toBe(false);
-    expect(result.requireAlert).toBe(true);
+    expect(result.requireAlert).toBe(false);
   });
 });

--- a/src/utils/dataSubmissionUtils.ts
+++ b/src/utils/dataSubmissionUtils.ts
@@ -199,27 +199,33 @@ export const shouldDisableRelease = (submission: Submission): ReleaseInfo => {
   const { crossSubmissionStatus, otherSubmissions } = submission || {};
   const parsedSubmissions = safeParse<OtherSubmissions>(otherSubmissions);
 
+  // Cross-validation has already occurred and passed, nothing else required
+  const shortCircuitStatuses: CrossSubmissionStatus[] = ["Passed"];
+  if (crossSubmissionStatus && shortCircuitStatuses.includes(crossSubmissionStatus)) {
+    return { disable: false, requireAlert: false };
+  }
+
   // Scenario 1: Cross-validation has issues, disable release entirely
   if (crossSubmissionStatus === "Error") {
     return { disable: true, requireAlert: false };
   }
 
-  // Scenario 2: More than one other Submitted/Released submission exists, disable release entirely
+  // Scenario 2: All other submissions are "In Progress", "Rejected", or "Withdrawn", allow release with alert
   const hasRelatedSubmitted = parsedSubmissions?.Submitted?.length > 0;
   const hasRelatedReleased = parsedSubmissions?.Released?.length > 0;
 
-  if (hasRelatedSubmitted || hasRelatedReleased) {
-    return { disable: true, requireAlert: false };
-  }
-
-  // Scenario 3: All other submissions are "In Progress", "Rejected", or "Withdrawn", allow release with alert
   const hasRelatedInProgress = parsedSubmissions?.["In Progress"]?.length > 0;
   const hasRelatedRejected = parsedSubmissions?.Rejected?.length > 0;
   const hasRelatedWithdrawn = parsedSubmissions?.Withdrawn?.length > 0;
   const allowRelatedWithAlert = hasRelatedInProgress || hasRelatedRejected || hasRelatedWithdrawn;
 
-  if (allowRelatedWithAlert) {
+  if (!hasRelatedSubmitted && !hasRelatedReleased && allowRelatedWithAlert) {
     return { disable: false, requireAlert: true };
+  }
+
+  // Scenario 3: More than one other Submitted/Released submission exists, disable release entirely
+  if (hasRelatedSubmitted || hasRelatedReleased) {
+    return { disable: true, requireAlert: false };
   }
 
   // Scenario 0: No restrictions, allow release


### PR DESCRIPTION
### Overview

When Release button is "Passed", it still showed the Release button as disabled. This was due to logic removed in previous PR. Reverted those changes and adjusted the tests.

> [!Note]
> Upload/Validation services are failing to resolve ATM. Unable to fully test naturally, only tested by manually manipulating data via DB.

### Change Details (Specifics)

- Reverted logic to how it was, but left the `crossSubmissionStatus === "Error"` guard.
- Reverted test that was removed and updated existing test

### Related Ticket(s)

[CRDCDH-3168](https://tracker.nci.nih.gov/browse/CRDCDH-3168) (Bug)
