### PR TITLE
CRDCDH-3204 [Bug]: Certain fields are not being imported from the Excel file.

### DIFF
--- a/src/classes/Excel/A/SectionA.ts
+++ b/src/classes/Excel/A/SectionA.ts
@@ -131,7 +131,7 @@ export class SectionA extends SectionBase<AKeys, SectionADeps> {
     };
 
     // Primary Contact
-    [I2, J2, K2, L2, N2].forEach((cell) => {
+    [I2, J2, K2, N2].forEach((cell) => {
       const columnKey = ws.getColumn(cell.col).key;
       const cellLimit = DEFAULT_CHARACTER_LIMITS[columnKey as AKeys] ?? 0;
 
@@ -155,6 +155,14 @@ export class SectionA extends SectionBase<AKeys, SectionADeps> {
           this.deps.institutionSheet.rowCount || 0
         ),
       ],
+    };
+
+    L2.dataValidation = {
+      type: "custom",
+      showErrorMessage: true,
+      error: ErrorCatalog.get("email"),
+      allowBlank: true,
+      formulae: [EMAIL(L2)],
     };
 
     // Additional Contacts

--- a/src/utils/excelUtils.ts
+++ b/src/utils/excelUtils.ts
@@ -504,3 +504,50 @@ export const toYesNo = (value: boolean | null | undefined) => {
 
   return null;
 };
+
+/**
+ * Checks if a cell contains a valid hyperlink.
+ *
+ * @param v The cell value to check.
+ * @returns True if the cell contains a hyperlink, false otherwise.
+ */
+export const isHyperlinkValue = (v: ExcelJS.CellValue): v is ExcelJS.CellHyperlinkValue =>
+  typeof v === "object" && v !== null && "hyperlink" in v && "text" in v;
+
+/**
+ * Checks if a cell contains a valid formula.
+ *
+ * @param v The cell value to check.
+ * @returns True if the cell contains a formula, false otherwise.
+ */
+export const isFormulaValue = (v: ExcelJS.CellValue): v is ExcelJS.CellFormulaValue =>
+  typeof v === "object" && v !== null && "formula" in v;
+
+/**
+ * Checks if a cell contains a valid shared formula.
+ *
+ * @param v The cell value to check.
+ * @returns True if the cell contains a shared formula, false otherwise.
+ */
+export const isSharedFormulaValue = (v: ExcelJS.CellValue): v is ExcelJS.CellSharedFormulaValue =>
+  typeof v === "object" && v !== null && "sharedFormula" in v;
+
+/**
+ * Checks if a cell contains a valid rich text value.
+ *
+ * @param v The cell value to check.
+ * @returns True if the cell contains a rich text value, false otherwise.
+ */
+export const isRichTextValue = (v: ExcelJS.CellValue): v is ExcelJS.CellRichTextValue =>
+  typeof v === "object" &&
+  v !== null &&
+  "richText" in v &&
+  Array.isArray((v as { richText: unknown }).richText);
+
+/**
+ * Checks if a cell contains a valid error value.
+ * @param v The cell value to check.
+ * @returns True if the cell contains an error value, false otherwise.
+ */
+export const isErrorValue = (v: ExcelJS.CellValue): v is ExcelJS.CellErrorValue =>
+  typeof v === "object" && v !== null && "error" in v;


### PR DESCRIPTION
### Overview

Excel allows special values within a cell, one of those being hyperlink. This causes the value to be an object instead of just the text value. Updated the data extract function to normalize the data, before mapping, to avoid this issue.

### Change Details (Specifics)

- Normalized both header and and user input cell values 
- Fixed primary contact email doing text length data validation instead of email validation
- Added test coverage for the above scenarios

### Related Ticket(s)

[CRDCDH-3204](https://tracker.nci.nih.gov/browse/CRDCDH-3204) (Bug)
