### PR TITLE
CRDCDH-3251 Fix Column groups missing border

### DIFF
--- a/src/components/GenericTable/ColumnVisibilityPopper.tsx
+++ b/src/components/GenericTable/ColumnVisibilityPopper.tsx
@@ -113,7 +113,6 @@ const StyledGroupContainer = styled(Box)({
   padding: "15px",
   width: "100%",
   "&:not(:last-of-type)": {
-    marginBottom: "-10px",
     borderBottom: "0.5px solid #375F9A",
   },
 });


### PR DESCRIPTION
### Overview

PR to fix the hidden border on the Column Visibility toggle for grouped columns.

> [!NOTE]
> I'm not sure why there was a negative margin, but the spacing seems to be correct with it removed (15px below the last toggle, and 15px above the group title).

### Change Details (Specifics)

N/A

### Related Ticket(s)

CRDCDH-3251 (Bug)
