### PR TITLE
CRDCDH-3225 Validate dbGaPID in Submission Request form and Excel

### DIFF
--- a/src/classes/Excel/C/SectionC.ts
+++ b/src/classes/Excel/C/SectionC.ts
@@ -1,7 +1,7 @@
 import type ExcelJS from "exceljs";
 
 import { CUSTOM_CANCER_TYPES } from "@/config/CancerTypesConfig";
-import { IF, STR_EQ, AND, REQUIRED, TEXT_MAX, LIST_FORMULA, Logger } from "@/utils";
+import { STR_EQ, REQUIRED, TEXT_MAX, LIST_FORMULA, Logger, PHS_OK } from "@/utils";
 
 import { YesNoList } from "../D/SectionD";
 import { ErrorCatalog } from "../ErrorCatalog";
@@ -83,7 +83,7 @@ export class SectionC extends SectionBase<CKeys, SectionCDeps> {
       rules: [
         {
           type: "expression",
-          formulae: ['IF($C$2="No",TRUE,FALSE)'],
+          formulae: ['OR($C2="No", LEN(TRIM($C2))=0)'],
           style: {
             fill: {
               type: "pattern",
@@ -119,17 +119,15 @@ export class SectionC extends SectionBase<CKeys, SectionCDeps> {
     };
     D.dataValidation = {
       type: "custom",
-      allowBlank: true,
+      allowBlank: false,
+      errorStyle: "stop",
       showErrorMessage: true,
-      error: ErrorCatalog.get("requiredMax", {
-        max: DEFAULT_CHARACTER_LIMITS["study.dbGaPPPHSNumber"],
-      }),
+      error: ErrorCatalog.get("dbGaPPHSNumber"),
       formulae: [
-        IF(
-          STR_EQ(C, "Yes"),
-          "TRUE",
-          AND(REQUIRED(D), TEXT_MAX(D, DEFAULT_CHARACTER_LIMITS["study.dbGaPPPHSNumber"]))
-        ),
+        `OR(${STR_EQ(C, "No")},AND(${REQUIRED(D)},${TEXT_MAX(
+          D,
+          DEFAULT_CHARACTER_LIMITS["study.dbGaPPPHSNumber"]
+        )} ,${PHS_OK(D)}))`,
       ],
     };
     this.forEachCellInColumn(ws, "cancerTypes", (cell) => {

--- a/src/classes/Excel/ErrorCatalog.ts
+++ b/src/classes/Excel/ErrorCatalog.ts
@@ -24,6 +24,7 @@ const T = {
   // formats
   email: () => `Please provide a valid email address.`,
   orcid: () => `Please provide a valid ORCID.`,
+  dbGaPPHSNumber: () => `Please provide a valid dbGaP PHS number.`,
   phone: () => `Please provide a valid phone number containing only numbers, spaces, and dashes.`,
   dateMMDDYYYY: () => `The date is invalid. Please enter a date in the format MM/DD/YYYY.`,
 

--- a/src/content/questionnaire/sections/C.tsx
+++ b/src/content/questionnaire/sections/C.tsx
@@ -21,6 +21,7 @@ import {
   isValidInRange,
   filterPositiveIntegerString,
   combineQuestionnaireData,
+  validatePHSNumber,
 } from "../../../utils";
 
 const StyledLink = styled(Link)({
@@ -221,6 +222,8 @@ const FormSectionC: FC<FormSectionProps> = ({ SectionOption, refs }: FormSection
           name="study[dbGaPPPHSNumber]"
           value={dbGaPPPHSNumber}
           onChange={(e) => setDbGaPPPHSNumber(e.target.value || "")}
+          validate={validatePHSNumber}
+          errorText="Please provide a valid dbGaP PHS number"
           maxLength={50}
           placeholder='Ex/ "phs002529.v1.p1". 50 characters allowed'
           gridWidth={12}

--- a/src/schemas/Application.ts
+++ b/src/schemas/Application.ts
@@ -5,6 +5,7 @@ import { repositoryDataTypesOptions } from "@/components/Questionnaire/Repositor
 import accessTypeOptions from "@/config/AccessTypesConfig";
 import cancerTypeOptions from "@/config/CancerTypesConfig";
 import DataTypes from "@/config/DataTypesConfig";
+import { validatePHSNumber } from "@/utils";
 
 const FIELD_IS_REQUIRED = "This field is required.";
 
@@ -336,7 +337,12 @@ export const studySchema = z
      *
      * @example "phs002529.v1.p1"
      */
-    dbGaPPPHSNumber: z.string().max(50).optional(),
+    dbGaPPPHSNumber: z
+      .string()
+      .max(50)
+      .trim()
+      .refine((val) => validatePHSNumber(val))
+      .optional(),
     /**
      * The name of the Genomic Program Administrator.
      *

--- a/src/utils/excelUtils.ts
+++ b/src/utils/excelUtils.ts
@@ -562,3 +562,37 @@ export const isRichTextValue = (v: ExcelJS.CellValue): v is ExcelJS.CellRichText
  */
 export const isErrorValue = (v: ExcelJS.CellValue): v is ExcelJS.CellErrorValue =>
   typeof v === "object" && v !== null && "error" in v;
+
+/**
+ * Checks if a cell contains a valid PHS identifier.
+ *
+ * @note Aims to match validatePHSNumber loose implementation.
+ * @param {ExcelJS.Cell} c The cell to check.
+ * @returns The formula string for the validation.
+ */
+export const PHS_OK = (c: ExcelJS.Cell | string) => {
+  const x = TRIM(CELL(c));
+  const pIdx = `IFERROR(FIND(".p",${x}),0)`;
+
+  return OR(
+    AND(`LEN(${x})=9`, `LEFT(${x},3)="phs"`, `IFERROR(ISNUMBER(VALUE(RIGHT(${x},6))),FALSE)`),
+    AND(
+      `LEFT(${x},3)="phs"`,
+      `IFERROR(ISNUMBER(VALUE(MID(${x},4,6))),FALSE)`,
+      `MID(${x},10,2)=".v"`,
+      `LEN(${x})>11`,
+      `IFERROR(ISNUMBER(VALUE(MID(${x},12,LEN(${x})-11))),FALSE)`,
+      `NOT(${pIdx}>0)`
+    ),
+    AND(
+      `LEFT(${x},3)="phs"`,
+      `IFERROR(ISNUMBER(VALUE(MID(${x},4,6))),FALSE)`,
+      `MID(${x},10,2)=".v"`,
+      `${pIdx}>12`,
+      `IFERROR(ISNUMBER(VALUE(MID(${x},12,${pIdx}-12))),FALSE)`,
+      `IFERROR(MID(${x},${pIdx},2),"")=".p"`,
+      `LEN(${x})>${pIdx}+1`,
+      `IFERROR(ISNUMBER(VALUE(MID(${x},${pIdx}+2,LEN(${x})-${pIdx}))),FALSE)`
+    )
+  );
+};

--- a/src/utils/studyUtils.test.ts
+++ b/src/utils/studyUtils.test.ts
@@ -152,3 +152,80 @@ describe("hasStudyWithMultiplePrograms", () => {
     expect(utils.hasStudyWithMultiplePrograms(studies, "prog1")).toBe(false);
   });
 });
+
+describe("validatePHSNumber", () => {
+  it.each(["phs000000", "phs001234", "PHS999999"])("valid base only: %s", (v) => {
+    expect(utils.validatePHSNumber(v)).toBe(true);
+  });
+
+  it.each(["phs001234.v1", "PHS001234.V12", "phs001234.v123456"])(
+    "valid base + version: %s",
+    (v) => {
+      expect(utils.validatePHSNumber(v)).toBe(true);
+    }
+  );
+
+  it.each(["phs001234.v1.p1", "PHS001234.V10.P3", "phs001234.v123.p4567"])(
+    "valid full form: %s",
+    (v) => {
+      expect(utils.validatePHSNumber(v)).toBe(true);
+    }
+  );
+
+  it.each(["  phs001234  ", "\tPHS001234\n", "  phs001234.v2  ", " \n PhS001234.V2.P3 \t "])(
+    "trims and validates (case-insensitive): %s",
+    (v) => {
+      expect(utils.validatePHSNumber(v)).toBe(true);
+    }
+  );
+
+  it.each(["phs12345", "phs1234567", "phs00123"])("invalid base digit count: %s", (v) => {
+    expect(utils.validatePHSNumber(v)).toBe(false);
+  });
+
+  it("rejects participant set without version", () => {
+    expect(utils.validatePHSNumber("phs001234.p1")).toBe(false);
+  });
+
+  it.each(["phs001234.v", "phs001234.v1x", "phs001234.v1.p", "phs001234.v1.p1x"])(
+    "rejects malformed suffixes: %s",
+    (v) => {
+      expect(utils.validatePHSNumber(v)).toBe(false);
+    }
+  );
+
+  it.each([
+    "phs001234 v1",
+    "phs001234. v1",
+    "phs001234.v1 .p1",
+    "phs 001234",
+    "phs001234 .v1",
+    "phs001234.v1. p1",
+    "phs001234.v1.p1 extra",
+  ])("rejects embedded/trailing spaces: %s", (v) => {
+    expect(utils.validatePHSNumber(v)).toBe(false);
+  });
+
+  it.each(["  phs001234  ", "\tPHS001234.V1 \n", " \r phs001234.v10.p3\t "])(
+    "trims leading/trailing whitespace and still validates: %s",
+    (value) => {
+      expect(utils.validatePHSNumber(value)).toBe(true);
+    }
+  );
+
+  it.each([
+    "phs001234,v1",
+    "phs001234,v1.p1",
+    "phs001234,phs001235",
+    "phs001234 phs001235",
+    "phs001234.v1,p1",
+    "phs001234;v1",
+    "phs001234|v1",
+  ])("rejects commas/multiple/separators: %s", (v) => {
+    expect(utils.validatePHSNumber(v)).toBe(false);
+  });
+
+  it.each(["", "   ", "\n\t"])("rejects empty/whitespace: %j", (v) => {
+    expect(utils.validatePHSNumber(v as unknown as string)).toBe(false);
+  });
+});

--- a/src/utils/studyUtils.ts
+++ b/src/utils/studyUtils.ts
@@ -45,3 +45,27 @@ export const hasStudyWithMultiplePrograms = (
     return distinctProgramIds.size > 1;
   });
 };
+
+/**
+ *  Loosely validates a dbGaP PHS accession number, with optional versioning and participant identifiers.
+ *
+ * @param input - The PHS accession number to validate.
+ * @returns True if the input is a valid PHS accession number, false otherwise.
+ * @example
+ * validatePHSNumber("phs001234.v1.p1"); // true
+ * validatePHSNumber("phs001234.v1"); // true
+ * validatePHSNumber("phs001234"); // true
+ * validatePHSNumber("phs00123"); // false
+ * validatePHSNumber("phs001234.p1"); // false
+ */
+export const validatePHSNumber = (input: string): boolean => {
+  const trimmedInput = input?.trim();
+  const BASE_DIGIT_COUNT = 6;
+  const pattern = new RegExp(`^phs\\d{${BASE_DIGIT_COUNT}}(?:\\.v\\d+(?:\\.p\\d+)?)?$`, "i");
+
+  if (!trimmedInput?.length) {
+    return false;
+  }
+
+  return pattern.test(trimmedInput);
+};


### PR DESCRIPTION
### Overview

Add validation to dbGaP PHS Number within the Submission Request form and the Excel form.

### Change Details (Specifics)

- Created and applied loose validation to dbGaP PHS Number within the SR form
- Added similar loose validation to Excel form. (Couldn't get the same regex validation from the SR form to apply to Excel form. Had to manually apply validation)
- Updated Excel error message for dbGaPPHSNumber
- Updated zod schema validation to better represent the new loose validation
- Added test coverage for new Excel form validation

### Related Ticket(s)

[CRDCDH-3225](https://tracker.nci.nih.gov/browse/CRDCDH-3225) (Task)
[CRDCDH-3226](https://tracker.nci.nih.gov/browse/CRDCDH-3226) (US)
