### PR TITLE
CRDCDH-3273 Fix dynamic snackbar text flowing outside of alert region

### DIFF
--- a/src/components/StyledNotistackAlerts/index.stories.tsx
+++ b/src/components/StyledNotistackAlerts/index.stories.tsx
@@ -1,0 +1,88 @@
+import { Stack, Typography } from "@mui/material";
+import type { Meta, StoryObj } from "@storybook/react";
+import { useSnackbar, VariantType } from "notistack";
+import { useEffect, useRef } from "react";
+
+/**
+ * Demo component that displays a snackbar based on Storybook controls
+ */
+const SnackbarDemo = ({ message, variant }: { message: string; variant: VariantType }) => {
+  const { enqueueSnackbar, closeSnackbar } = useSnackbar();
+  const prevId = useRef<string | number | null>(null);
+
+  useEffect(() => {
+    if (message) {
+      closeSnackbar(prevId.current);
+      prevId.current = enqueueSnackbar(message, { variant, persist: true });
+    }
+  }, [message, variant, enqueueSnackbar]);
+
+  return (
+    <Stack justifyContent="center" alignItems="center" height="100vh" spacing={2} padding={2}>
+      <Typography variant="body1">
+        Use the controls panel to change the snackbar message and variant.
+      </Typography>
+    </Stack>
+  );
+};
+
+const meta: Meta<typeof SnackbarDemo> = {
+  title: "Miscellaneous / Notistack",
+  component: SnackbarDemo,
+  parameters: {
+    layout: "fullscreen",
+  },
+  argTypes: {
+    variant: {
+      control: { type: "select" },
+      options: ["default", "success", "error"],
+      description: "The variant of the snackbar notification",
+    },
+    message: {
+      control: { type: "text" },
+      description: "The message to display in the snackbar",
+    },
+  },
+} satisfies Meta<typeof SnackbarDemo>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Default variant snackbar example
+ */
+export const Default: Story = {
+  args: {
+    message: "This is a default notification message",
+    variant: "default",
+  },
+};
+
+/**
+ * Success variant snackbar example
+ */
+export const Success: Story = {
+  args: {
+    message: "Operation completed successfully!",
+    variant: "success",
+  },
+};
+
+/**
+ * Error variant snackbar example
+ */
+export const Error: Story = {
+  args: {
+    message: "An error occurred while processing your request",
+    variant: "error",
+  },
+};
+
+export const LongMessage: Story = {
+  args: {
+    message: `This is a very long notification message intended to test how the snackbar handles overflow and text wrapping. ${"a".repeat(
+      100
+    )} It should display properly without breaking the layout or causing any visual issues.`,
+    variant: "default",
+  },
+};

--- a/src/components/StyledNotistackAlerts/index.tsx
+++ b/src/components/StyledNotistackAlerts/index.tsx
@@ -1,12 +1,14 @@
 import { styled } from "@mui/material";
 import { MaterialDesignContent } from "notistack";
+import { CSSProperties } from "react";
 
-const BaseSnackbarStyles = {
+const BaseSnackbarStyles: CSSProperties = {
   color: "#ffffff",
   width: "535px",
   minHeight: "50px",
   boxShadow: "-4px 8px 27px 4px rgba(27,28,28,0.09)",
   boxSizing: "border-box",
+  wordBreak: "break-word",
   userSelect: "none",
   justifyContent: "center",
 };


### PR DESCRIPTION
### Overview

PR to fix situations where the content rendered in the snackbar does not break a very long word, and so the text flows outside of the alert element.

Also created a storybook for notistack.

### Change Details (Specifics)

N/A

### Related Ticket(s)

CRDCDH-3273 (Bug)
