### PR TITLE
CRDCDH-3288 dbGaPID and GPA should be optional fields

### DIFF
--- a/src/content/studies/StudyView.tsx
+++ b/src/content/studies/StudyView.tsx
@@ -261,7 +261,7 @@ const StudyView: FC<Props> = ({ _id }: Props) => {
   ]);
 
   const [saving, setSaving] = useState<boolean>(false);
-  const [error, setError] = useState(null);
+  const [error, setError] = useState<string>(null);
   const [sameAsProgramPrimaryContact, setSameAsProgramPrimaryContact] = useState<boolean>(true);
   const [approvedStudy, setApprovedStudy] = useState<ApprovedStudy>(null);
 
@@ -594,17 +594,12 @@ const StudyView: FC<Props> = ({ _id }: Props) => {
                 </Stack>
               </StyledField>
               <StyledField>
-                <StyledLabel id="dbGaPIDLabel">
-                  dbGaPID
-                  <StyledAsterisk visible={isControlled} />
-                </StyledLabel>
+                <StyledLabel id="dbGaPIDLabel">dbGaPID</StyledLabel>
                 <StyledTextField
                   {...register("dbGaPID", {
-                    required: isControlled === true,
                     setValueAs: (val) => val?.trim(),
                   })}
                   size="small"
-                  required={isControlled === true}
                   disabled={retrievingStudy}
                   readOnly={saving}
                   inputProps={{ "aria-labelledby": "dbGaPIDLabel", "data-testid": "dbGaPID-input" }}
@@ -614,16 +609,13 @@ const StudyView: FC<Props> = ({ _id }: Props) => {
               <StyledField>
                 <StyledLabel id="gpaNameLabel">
                   GPA
-                  <StyledAsterisk visible={isControlled} />
                   <Tooltip title="Genomic Program Administrator" />
                 </StyledLabel>
                 <StyledTextField
                   {...register("GPAName", {
-                    required: isControlled === true,
                     setValueAs: (val) => val?.trim(),
                   })}
                   size="small"
-                  required={isControlled === true}
                   disabled={retrievingStudy}
                   readOnly={saving}
                   inputProps={{


### PR DESCRIPTION
### Overview

PR to fix an oversight where dbGaP ID and GPA Name should not be required fields, even when the study is controlled access.

> [!NOTE]
> The backend has to update the restrictions for dbGaP ID too, so saving will still show an error.

### Change Details (Specifics)

N/A

### Related Ticket(s)

CRDCDH-3288 (Task)
CRDCDH-3287 (US)
