### PR TITLE
CRDCDH-3297 Fix Category Legend Positioning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10253,8 +10253,8 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/data-model-navigator": {
-      "version": "1.7.0",
-      "resolved": "git+ssh://git@github.com/CBIIT/Data-Model-Navigator.git#e73d115b5ab5fdda39ff930e7cff36914960fdc7",
+      "version": "1.7.1",
+      "resolved": "git+ssh://git@github.com/CBIIT/Data-Model-Navigator.git#d72e0c30c7ce4fb705bd9612da08506eda32aef7",
       "license": "ISC",
       "dependencies": {
         "@material-ui/core": "^4.12.4",


### PR DESCRIPTION
### Overview

This PR bumps DMN to v1.7.1 which fixes the positioning of the node category legend.

To test this, append `show_launch_banner=true` to the URL.

### Change Details (Specifics)

- https://github.com/CBIIT/Data-Model-Navigator/compare/ff49fb8cd2343df74ee1137139fb306ea8a75570..d72e0c30c7ce4fb705bd9612da08506eda32aef7

### Related Ticket(s)

CRDCDH-3297
