### PR TITLE
CRDCDH-3337 SR Excel export filename contains stale data

### DIFF
--- a/src/components/Contexts/FormContext.tsx
+++ b/src/components/Contexts/FormContext.tsx
@@ -264,6 +264,8 @@ export const FormProvider: FC<ProviderProps> = ({ children, id }: ProviderProps)
 
     newState.data = {
       ...newState.data,
+      programName: d?.saveApplication?.programName,
+      studyAbbreviation: d?.saveApplication?.studyAbbreviation,
       status: d?.saveApplication?.status,
       updatedAt: d?.saveApplication?.updatedAt,
       createdAt: d?.saveApplication?.createdAt,

--- a/src/graphql/getApplication.ts
+++ b/src/graphql/getApplication.ts
@@ -1,7 +1,7 @@
 import { TypedDocumentNode } from "@apollo/client";
 import gql from "graphql-tag";
 
-export const query: TypedDocumentNode<Response> = gql`
+export const query: TypedDocumentNode<Response, GetAppInput> = gql`
   query getApplication($id: ID!) {
     getApplication(_id: $id) {
       _id
@@ -35,6 +35,13 @@ export const query: TypedDocumentNode<Response> = gql`
     }
   }
 `;
+
+export type GetAppInput = {
+  /**
+   * The unique ID of the Application to retrieve
+   */
+  id: string;
+};
 
 export type Response = {
   getApplication: Omit<Application, "questionnaireData"> & {

--- a/src/graphql/index.ts
+++ b/src/graphql/index.ts
@@ -30,7 +30,7 @@ export { query as LAST_APP } from "./getMyLastApplication";
 export type { Response as LastAppResp } from "./getMyLastApplication";
 
 export { query as GET_APP } from "./getApplication";
-export type { Response as GetAppResp } from "./getApplication";
+export type { GetAppInput, Response as GetAppResp } from "./getApplication";
 
 export { mutation as UPDATE_MY_USER } from "./updateMyUser";
 export type { Input as UpdateMyUserInput, Response as UpdateMyUserResp } from "./updateMyUser";

--- a/src/graphql/saveApplication.ts
+++ b/src/graphql/saveApplication.ts
@@ -13,6 +13,8 @@ export const mutation: TypedDocumentNode<Response, Input> = gql`
       openAccess
       controlledAccess
       PI
+      programName
+      studyAbbreviation
       history {
         status
         reviewComment
@@ -99,5 +101,5 @@ export type Input = {
 };
 
 export type Response = {
-  saveApplication: Omit<Application, "programName" | "studyAbbreviation" | "questionnaireData">;
+  saveApplication: Omit<Application, "questionnaireData">;
 };


### PR DESCRIPTION
### Overview

PR to fix the Submission Request excel export using a stale reference to the Study Abbreviation.

### Change Details (Specifics)

- On SR save, propagate the latest Study Abbreviation to the form context
- Add missing generalized test coverage for the saveApp mutation
- Add missing typing for the getApp query input

### Related Ticket(s)

CRDCDH-3337
