### PR TITLE
CRDCDH-3326 Increase 'Study Name' character limit

### DIFF
--- a/src/classes/Excel/B/SectionB.ts
+++ b/src/classes/Excel/B/SectionB.ts
@@ -24,7 +24,7 @@ const DEFAULT_CHARACTER_LIMITS: CharacterLimitsMap<BKeys> = {
   "program.name": 100,
   "program.abbreviation": 100,
   "program.description": 500,
-  "study.name": 100,
+  "study.name": 1_000,
   "study.abbreviation": 20,
   "study.description": 2_500,
   // "study.funding.agency": 0,

--- a/src/classes/QuestionnaireExcelMiddleware.test.ts
+++ b/src/classes/QuestionnaireExcelMiddleware.test.ts
@@ -2444,6 +2444,33 @@ describe("Parsing", () => {
     expect(output.program.description).toBe(InitialQuestionnaire.program.description);
   });
 
+  it("should allow study name to be 1000 characters", async () => {
+    const mockForm = questionnaireDataFactory.build();
+
+    const middleware = new QuestionnaireExcelMiddleware(mockForm, {});
+
+    // @ts-expect-error Private member
+    await middleware.serializeSectionB();
+
+    // Reset data before parsing
+    // @ts-expect-error Private member
+    middleware.data = {
+      ...InitialQuestionnaire,
+      study: { ...InitialQuestionnaire.study, name: "A".repeat(1_000) },
+      sections: [...InitialSections],
+    };
+
+    // @ts-expect-error Private member
+    const result = await middleware.parseSectionB();
+
+    // @ts-expect-error Private member
+    const output = middleware.data;
+
+    expect(result).toEqual(true);
+
+    expect(output.study.name).toBe("A".repeat(1_000));
+  });
+
   it("should allow selecting existing program", async () => {
     const _id = v4();
     const mockForm = questionnaireDataFactory.build({

--- a/src/components/ExportRequestButton/pdf/Generate.ts
+++ b/src/components/ExportRequestButton/pdf/Generate.ts
@@ -87,7 +87,7 @@ const writeHeader = (doc: JsPDF, request: Application): number => {
   });
 
   const computedNameLines = doc.splitTextToSize(formattedName, maxNameWidth);
-  y += (computedNameLines?.length || 1) * 8 + 11;
+  y += (computedNameLines?.length || 1) * 10 + 8;
 
   // Submitted Date
   doc.setFont("Nunito", "normal", 600);

--- a/src/content/questionnaire/sections/B.tsx
+++ b/src/content/questionnaire/sections/B.tsx
@@ -435,8 +435,8 @@ const FormSectionB: FC<FormSectionProps> = ({ SectionOption, refs }: FormSection
           label="Study Title"
           name="study[name]"
           value={study.name}
-          maxLength={100}
-          placeholder="100 characters allowed"
+          maxLength={1000}
+          placeholder="1,000 characters allowed"
           validate={(input: string) => !validateUTF8(input)}
           readOnly={readOnlyInputs}
           hideValidation={readOnlyInputs}

--- a/src/content/studies/StudyView.test.tsx
+++ b/src/content/studies/StudyView.test.tsx
@@ -1502,4 +1502,28 @@ describe("Implementation Requirements", () => {
     expect(pendingGpaCheckbox.checked).toBe(false);
     expect(pendingGpaCheckbox).toBeDisabled();
   });
+
+  it("should not allow a study name larger than 1000 characters", async () => {
+    const { getByTestId, queryByTestId } = render(
+      <TestParent>
+        <StudyView _id="new" />
+      </TestParent>
+    );
+
+    await waitFor(() => {
+      expect(queryByTestId("study-view-suspense-loader")).not.toBeInTheDocument();
+    });
+
+    const programAutocomplete = getByTestId("program-input") as HTMLInputElement;
+    const openAccessCheckbox = getByTestId("openAccess-checkbox") as HTMLInputElement;
+    const studyNameInput = getByTestId("studyName-input") as HTMLInputElement;
+
+    userEvent.click(openAccessCheckbox);
+    userEvent.paste(programAutocomplete, "Not Applicable");
+    userEvent.paste(studyNameInput, "x".repeat(2000));
+
+    // Input only keeps first 1000 chars
+    expect(studyNameInput.value.length).toBe(1000);
+    expect(studyNameInput).toHaveValue("x".repeat(1000));
+  });
 });

--- a/src/content/studies/StudyView.tsx
+++ b/src/content/studies/StudyView.tsx
@@ -520,12 +520,14 @@ const StudyView: FC<Props> = ({ _id }: Props) => {
                     setValueAs: (val) => val?.trim(),
                     validate: { utf8: validateUTF8 },
                   })}
+                  placeholder="1,000 characters allowed"
                   size="small"
                   required
                   disabled={retrievingStudy}
                   readOnly={saving}
                   error={!!errors.studyName}
                   inputProps={{
+                    maxLength: 1000,
                     "aria-labelledby": "studyNameLabel",
                     "data-testid": "studyName-input",
                   }}

--- a/src/schemas/Application.ts
+++ b/src/schemas/Application.ts
@@ -295,7 +295,7 @@ export const studySchema = z
     /**
      * The full study title.
      */
-    name: z.string().max(100).nonempty(),
+    name: z.string().max(1_000).nonempty(),
     /**
      * The short study title.
      */


### PR DESCRIPTION
### Overview

Increased the character limit for 'Study Name' across the board.

### Change Details (Specifics)

- Updated the 'Study Name' field within Submission Request, Excel template, and Add/Edit Study pages character limit to 1000
- Updated placeholder text
- Updated schema to accept the new character limit in the SR form
- Added basic test coverage
- Verified in the following locations that the new Study Name text length will not break the site:
  - SR List
  - SR Form
  - DS List
  - DS Dashboard
  - DS Dashboard - Data View
  - Data Explorer List
  - Data Explorer View
  - Manage Studies List
  - Edit Study View
  - Edit User - Submitter

### Related Ticket(s)

[CRDCDH-3326](https://tracker.nci.nih.gov/browse/CRDCDH-3326) (Task)
[CRDCDH-3303](https://tracker.nci.nih.gov/browse/CRDCDH-3303) (US)
