### PR TITLE
CRDCDH-3348 [Bug]: Fix SR Excel Template case insensitive versioning dbGaPID

### DIFF
--- a/src/classes/QuestionnaireExcelMiddleware.ts
+++ b/src/classes/QuestionnaireExcelMiddleware.ts
@@ -35,7 +35,7 @@ import { SectionCtxBase } from "./Excel/SectionBase";
 /**
  * An internal template version identifier.
  */
-export const TEMPLATE_VERSION = "1.0";
+export const TEMPLATE_VERSION = "1.5";
 
 /**
  * The names of the HIDDEN sheets used in the Excel workbook.

--- a/src/utils/excelUtils.test.ts
+++ b/src/utils/excelUtils.test.ts
@@ -479,20 +479,20 @@ describe("PHS_OK", () => {
       "AND(" +
       'LEFT(TRIM($A$1),3)="phs",' +
       "IFERROR(ISNUMBER(VALUE(MID(TRIM($A$1),4,6))),FALSE)," +
-      'MID(TRIM($A$1),10,2)=".v",' +
+      'LOWER(MID(TRIM($A$1),10,2))=".v",' +
       "LEN(TRIM($A$1))>11," +
       "IFERROR(ISNUMBER(VALUE(MID(TRIM($A$1),12,LEN(TRIM($A$1))-11))),FALSE)," +
-      'NOT(IFERROR(FIND(".p",TRIM($A$1)),0)>0)' +
+      'NOT(IFERROR(FIND(".p",LOWER(TRIM($A$1))),0)>0)' +
       ")," +
       "AND(" +
       'LEFT(TRIM($A$1),3)="phs",' +
       "IFERROR(ISNUMBER(VALUE(MID(TRIM($A$1),4,6))),FALSE)," +
-      'MID(TRIM($A$1),10,2)=".v",' +
-      'IFERROR(FIND(".p",TRIM($A$1)),0)>12,' +
-      'IFERROR(ISNUMBER(VALUE(MID(TRIM($A$1),12,IFERROR(FIND(".p",TRIM($A$1)),0)-12))),FALSE),' +
-      'IFERROR(MID(TRIM($A$1),IFERROR(FIND(".p",TRIM($A$1)),0),2),"")=".p",' +
-      'LEN(TRIM($A$1))>IFERROR(FIND(".p",TRIM($A$1)),0)+1,' +
-      'IFERROR(ISNUMBER(VALUE(MID(TRIM($A$1),IFERROR(FIND(".p",TRIM($A$1)),0)+2,LEN(TRIM($A$1))-IFERROR(FIND(".p",TRIM($A$1)),0)))),FALSE)' +
+      'LOWER(MID(TRIM($A$1),10,2))=".v",' +
+      'IFERROR(FIND(".p",LOWER(TRIM($A$1))),0)>12,' +
+      'IFERROR(ISNUMBER(VALUE(MID(TRIM($A$1),12,IFERROR(FIND(".p",LOWER(TRIM($A$1))),0)-12))),FALSE),' +
+      'LOWER(IFERROR(MID(TRIM($A$1),IFERROR(FIND(".p",LOWER(TRIM($A$1))),0),2),""))=".p",' +
+      'LEN(TRIM($A$1))>IFERROR(FIND(".p",LOWER(TRIM($A$1))),0)+1,' +
+      'IFERROR(ISNUMBER(VALUE(MID(TRIM($A$1),IFERROR(FIND(".p",LOWER(TRIM($A$1))),0)+2,LEN(TRIM($A$1))-IFERROR(FIND(".p",LOWER(TRIM($A$1))),0)))),FALSE)' +
       ")" +
       ")";
 

--- a/src/utils/excelUtils.ts
+++ b/src/utils/excelUtils.ts
@@ -572,14 +572,14 @@ export const isErrorValue = (v: ExcelJS.CellValue): v is ExcelJS.CellErrorValue 
  */
 export const PHS_OK = (c: ExcelJS.Cell | string) => {
   const x = TRIM(CELL(c));
-  const pIdx = `IFERROR(FIND(".p",${x}),0)`;
+  const pIdx = `IFERROR(FIND(".p",LOWER(${x})),0)`;
 
   return OR(
     AND(`LEN(${x})=9`, `LEFT(${x},3)="phs"`, `IFERROR(ISNUMBER(VALUE(RIGHT(${x},6))),FALSE)`),
     AND(
       `LEFT(${x},3)="phs"`,
       `IFERROR(ISNUMBER(VALUE(MID(${x},4,6))),FALSE)`,
-      `MID(${x},10,2)=".v"`,
+      `LOWER(MID(${x},10,2))=".v"`,
       `LEN(${x})>11`,
       `IFERROR(ISNUMBER(VALUE(MID(${x},12,LEN(${x})-11))),FALSE)`,
       `NOT(${pIdx}>0)`
@@ -587,10 +587,10 @@ export const PHS_OK = (c: ExcelJS.Cell | string) => {
     AND(
       `LEFT(${x},3)="phs"`,
       `IFERROR(ISNUMBER(VALUE(MID(${x},4,6))),FALSE)`,
-      `MID(${x},10,2)=".v"`,
+      `LOWER(MID(${x},10,2))=".v"`,
       `${pIdx}>12`,
       `IFERROR(ISNUMBER(VALUE(MID(${x},12,${pIdx}-12))),FALSE)`,
-      `IFERROR(MID(${x},${pIdx},2),"")=".p"`,
+      `LOWER(IFERROR(MID(${x},${pIdx},2),""))=".p"`,
       `LEN(${x})>${pIdx}+1`,
       `IFERROR(ISNUMBER(VALUE(MID(${x},${pIdx}+2,LEN(${x})-${pIdx}))),FALSE)`
     )


### PR DESCRIPTION
### Overview

The SR form supported case-insensitive versioning (ex. ".V1" and ".P2"), but the Excel template only supported lowercase. Updated the template to support both.

### Change Details (Specifics)

- Updated SR Excel Template form to support any casing for versioning
- Updated test
- Bumped Excel version: 1.0 => 1.5

### Related Ticket(s)

[CRDCDH-3348](https://tracker.nci.nih.gov/browse/CRDCDH-3348) (Bug)
