### PR TITLE
CRDCDH-3349 [Bug]: Prevent old dates for SR target dates

### DIFF
--- a/src/classes/QuestionnaireExcelMiddleware.test.ts
+++ b/src/classes/QuestionnaireExcelMiddleware.test.ts
@@ -3224,6 +3224,49 @@ describe("Parsing", () => {
     expect(output.targetedReleaseDate).toEqual("12/25/2033");
   });
 
+  it("should allow current date for target dates", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2000, 0, 1, 4, 4, 4));
+
+    const mockForm = questionnaireDataFactory.build({
+      targetedSubmissionDate: "01/01/2000",
+      targetedReleaseDate: "01/01/2000",
+      dataTypes: [],
+      imagingDataDeIdentified: null,
+      otherDataTypes: "",
+      clinicalData: {
+        dataTypes: [],
+        otherDataTypes: "",
+        futureDataTypes: null,
+      },
+      files: [],
+      dataDeIdentified: null,
+      cellLines: null,
+      modelSystems: null,
+      submitterComment: null,
+    });
+
+    const middleware = new QuestionnaireExcelMiddleware(mockForm, {});
+
+    // @ts-expect-error Private member
+    await middleware.serializeSectionD();
+
+    // @ts-expect-error Private member
+    middleware.data = { ...InitialQuestionnaire, sections: [...InitialSections] };
+
+    // @ts-expect-error Private member
+    const result = await middleware.parseSectionD();
+
+    // @ts-expect-error Private member
+    const output = middleware.data;
+
+    expect(result).toEqual(true);
+    expect(output.targetedSubmissionDate).toEqual("01/01/2000");
+    expect(output.targetedReleaseDate).toEqual("01/01/2000");
+
+    vi.useRealTimers();
+  });
+
   it("should not allow past dates for target dates", async () => {
     const mockForm = questionnaireDataFactory.build({
       targetedSubmissionDate: "01/01/2000",

--- a/src/classes/QuestionnaireExcelMiddleware.test.ts
+++ b/src/classes/QuestionnaireExcelMiddleware.test.ts
@@ -3224,6 +3224,44 @@ describe("Parsing", () => {
     expect(output.targetedReleaseDate).toEqual("12/25/2033");
   });
 
+  it("should not allow past dates for target dates", async () => {
+    const mockForm = questionnaireDataFactory.build({
+      targetedSubmissionDate: "01/01/2000",
+      targetedReleaseDate: "01/01/2000",
+      dataTypes: [],
+      imagingDataDeIdentified: null,
+      otherDataTypes: "",
+      clinicalData: {
+        dataTypes: [],
+        otherDataTypes: "",
+        futureDataTypes: null,
+      },
+      files: [],
+      dataDeIdentified: null,
+      cellLines: null,
+      modelSystems: null,
+      submitterComment: null,
+    });
+
+    const middleware = new QuestionnaireExcelMiddleware(mockForm, {});
+
+    // @ts-expect-error Private member
+    await middleware.serializeSectionD();
+
+    // @ts-expect-error Private member
+    middleware.data = { ...InitialQuestionnaire, sections: [...InitialSections] };
+
+    // @ts-expect-error Private member
+    const result = await middleware.parseSectionD();
+
+    // @ts-expect-error Private member
+    const output = middleware.data;
+
+    expect(result).toEqual(true);
+    expect(output.targetedSubmissionDate).toEqual(InitialQuestionnaire.targetedSubmissionDate);
+    expect(output.targetedReleaseDate).toEqual(InitialQuestionnaire.targetedReleaseDate);
+  });
+
   it("should handle missing SectionD sheet", async () => {
     const middleware = new QuestionnaireExcelMiddleware(null, {});
 

--- a/src/schemas/Application.ts
+++ b/src/schemas/Application.ts
@@ -444,13 +444,21 @@ export const questionnaireDataSchema = z
     /**
      * Targeted date to submit initial data.
      * Stored as MM/DD/YYYY (coerced from Date).
+     * Must be a future date.
      */
-    targetedSubmissionDate: z.string().refine((val) => dayjs(val, "MM/DD/YYYY", true)?.isValid()),
+    targetedSubmissionDate: z.string().refine((val) => {
+      const date = dayjs(val, "MM/DD/YYYY", true);
+      return date?.isValid() && date?.isAfter(new Date());
+    }),
     /**
      * Targeted public release date.
      * Stored as MM/DD/YYYY (coerced from Date).
+     * Must be a future date.
      */
-    targetedReleaseDate: z.string().refine((val) => dayjs(val, "MM/DD/YYYY", true)?.isValid()),
+    targetedReleaseDate: z.string().refine((val) => {
+      const date = dayjs(val, "MM/DD/YYYY", true);
+      return date?.isValid() && date?.isAfter(new Date());
+    }),
     /**
      * The submission time constraints.
      *

--- a/src/schemas/Application.ts
+++ b/src/schemas/Application.ts
@@ -447,8 +447,10 @@ export const questionnaireDataSchema = z
      * Must be a future date.
      */
     targetedSubmissionDate: z.string().refine((val) => {
-      const date = dayjs(val, "MM/DD/YYYY", true);
-      return date?.isValid() && date?.isAfter(new Date());
+      const date = dayjs(val, "MM/DD/YYYY", true)?.startOf("day");
+      const dateIsTodayOrAfter =
+        date?.isSame(dayjs().startOf("day")) || date?.isAfter(dayjs().startOf("day"));
+      return date?.isValid() && dateIsTodayOrAfter;
     }),
     /**
      * Targeted public release date.
@@ -457,7 +459,9 @@ export const questionnaireDataSchema = z
      */
     targetedReleaseDate: z.string().refine((val) => {
       const date = dayjs(val, "MM/DD/YYYY", true);
-      return date?.isValid() && date?.isAfter(new Date());
+      const dateIsTodayOrAfter =
+        date?.isSame(dayjs().startOf("day")) || date?.isAfter(dayjs().startOf("day"));
+      return date?.isValid() && dateIsTodayOrAfter;
     }),
     /**
      * The submission time constraints.


### PR DESCRIPTION
### Overview

Previously, the SR target dates only checked for valid dates. This has been updated to also check for future dates to prevent old Excel template forms from remaining valid with outdated dates.

### Change Details (Specifics)

- Updated `targetedSubmissionDate` and `targetedReleaseDate` to enforce checking for valid current or future dates
- Added test coverage to ensure form does not accept old dates

### Related Ticket(s)

[CRDCDH-3349](https://tracker.nci.nih.gov/browse/CRDCDH-3349) (Bug)
