### PR TITLE
CRDCDH-3328 Fix: Dedupe issue types from dropdown

### DIFF
--- a/src/components/DataSubmissions/QualityControlFilters.test.tsx
+++ b/src/components/DataSubmissions/QualityControlFilters.test.tsx
@@ -122,7 +122,7 @@ const issueTypesMock: MockedResponse<
             code: `ISSUE${index + 1}`,
             title: `Issue Title ${index + 1}`,
             count: 100,
-            desdescription: "",
+            description: "",
             severity: "Error",
           }))
           .withTypename("aggregatedQCResult"),
@@ -626,7 +626,7 @@ describe("QualityControlFilters", () => {
                   code: `ISSUE${index + 1}`,
                   title: `Issue Title ${index + 1}`,
                   count: 100,
-                  desdescription: "",
+                  description: "",
                   severity: "Error",
                 }))
                 .withTypename("aggregatedQCResult"),
@@ -637,7 +637,7 @@ describe("QualityControlFilters", () => {
                   code: `ISSUE${index + 1}`,
                   title: `Issue Title ${index + 1}`,
                   count: 100,
-                  desdescription: "",
+                  description: "",
                   severity: "Error",
                 }))
                 .withTypename("aggregatedQCResult"),

--- a/src/components/DataSubmissions/QualityControlFilters.tsx
+++ b/src/components/DataSubmissions/QualityControlFilters.tsx
@@ -147,6 +147,20 @@ const QualityControlFilters = ({ issueType, isAggregated, onChange }: Props) => 
     [submissionStats?.submissionStats?.stats]
   );
 
+  const dedupedIssueTypes = useMemo(() => {
+    const types = issueTypes?.aggregatedSubmissionQCResults?.results;
+    const seen = new Set<string>();
+
+    return types?.filter((item) => {
+      if (seen.has(item.code)) {
+        return false;
+      }
+
+      seen.add(item.code);
+      return true;
+    });
+  }, [issueTypes?.aggregatedSubmissionQCResults?.results]);
+
   return (
     <StyledFilterContainer data-testid="quality-control-filters">
       {!isAggregated ? (
@@ -172,7 +186,7 @@ const QualityControlFilters = ({ issueType, isAggregated, onChange }: Props) => 
                     <MenuItem value="All" data-testid="issueType-all">
                       All
                     </MenuItem>
-                    {issueTypes?.aggregatedSubmissionQCResults?.results?.map((issue, idx) => (
+                    {dedupedIssueTypes?.map((issue, idx) => (
                       <MenuItem
                         // eslint-disable-next-line react/no-array-index-key
                         key={`issue_${idx}_${issue.code}`}


### PR DESCRIPTION
### Overview

Previously, with certain submissions, there would be duplicate issue types with the same code being returned from the BE. Updated to ensure only unique issue types are shown.

### Change Details (Specifics)

- Deduped issue types by code

### Related Ticket(s)

[CRDCDH-3328](https://tracker.nci.nih.gov/browse/CRDCDH-3328) (Task)
[CRDCDH-3104](https://tracker.nci.nih.gov/browse/CRDCDH-3104) (US)
