### PR TITLE
CRDCDH-3323 [Bug]: 508 issues

### DIFF
--- a/src/components/CreateApplicationButton/index.tsx
+++ b/src/components/CreateApplicationButton/index.tsx
@@ -140,6 +140,7 @@ const CreateApplicationButton: FC<CreateApplicationButtonProps> = ({
             },
           },
         }}
+        aria-labelledby="dialog-description"
       />
     </>
   );

--- a/src/components/DeleteDialog/index.tsx
+++ b/src/components/DeleteDialog/index.tsx
@@ -112,10 +112,15 @@ const DeleteDialog = ({
     >
       <CloseIconSvg />
     </StyledCloseDialogButton>
-    <StyledHeader variant="h3" data-testid="delete-dialog-header" {...headerProps}>
+    <StyledHeader
+      variant="h3"
+      data-testid="delete-dialog-header"
+      aria-label="Dialog header"
+      {...headerProps}
+    >
       {header}
     </StyledHeader>
-    <StyledDescription data-testid="delete-dialog-description">
+    <StyledDescription id="dialog-description" data-testid="delete-dialog-description">
       {description || (
         <>
           The metadata or files specified in the selected files, along with their associated child


### PR DESCRIPTION
### Overview

Fixed broken aria reference and missing header accessibility issues.

### Change Details (Specifics)

- Fixed broken aria reference with SR "Start a Submission Request" acknowledgement dialog
- Fixed missing header accessibility error by providing aria label. This was due to Dialog does not have a header

False-positives that could not be resolved:
- All MUI select dropdowns are now throwing contrast error on native element. This is a false-positive, and couldn't find an easy fix
- All MUI Textarea elements throw "Missing form label" accessibility errors. This is also a false-positive, MUI has 2 input elements in their textarea component.

### Related Ticket(s)

[CRDCDH-3323](https://tracker.nci.nih.gov/browse/CRDCDH-3323)
