### PR TITLE
CRDCDH-3360 [Bug]: Program option not set to NA by default

### DIFF
--- a/src/content/studies/StudyView.test.tsx
+++ b/src/content/studies/StudyView.test.tsx
@@ -1526,4 +1526,22 @@ describe("Implementation Requirements", () => {
     expect(studyNameInput.value.length).toBe(1000);
     expect(studyNameInput).toHaveValue("x".repeat(1000));
   });
+
+  it("should default to 'Not Applicable' instead of empty program field", async () => {
+    const { getByTestId, queryByTestId } = render(
+      <TestParent>
+        <StudyView _id="new" />
+      </TestParent>
+    );
+
+    await waitFor(() => {
+      expect(queryByTestId("study-view-suspense-loader")).not.toBeInTheDocument();
+    });
+
+    const programAutocomplete = getByTestId("program-input") as HTMLInputElement;
+
+    await waitFor(() => {
+      expect(programAutocomplete.value).toBe("Not Applicable");
+    });
+  });
 });

--- a/src/content/studies/StudyView.tsx
+++ b/src/content/studies/StudyView.tsx
@@ -365,13 +365,14 @@ const StudyView: FC<Props> = ({ _id }: Props) => {
   );
 
   useEffect(() => {
-    if (!programField?._id && programOptions?.length > 0) {
-      const NAProgram = programOptions?.find(
-        (p) => p.readOnly && p.name === "Not Applicable"
-      ) as Organization;
+    const NAProgram = programOptions?.find(
+      (p) => p.readOnly && p.name === "Not Applicable"
+    ) as Organization;
+
+    if (!programField?._id && NAProgram) {
       setValue("program", NAProgram);
     }
-  }, [programOptions, programField?._id]);
+  }, [programOptions, programField?._id, setValue]);
 
   /**
    * Reset the form values, and preventing invalid

--- a/src/content/studies/StudyView.tsx
+++ b/src/content/studies/StudyView.tsx
@@ -366,7 +366,10 @@ const StudyView: FC<Props> = ({ _id }: Props) => {
 
   useEffect(() => {
     if (!programField?._id && programOptions?.length > 0) {
-      setValue("program", programOptions[0] as Organization);
+      const NAProgram = programOptions?.find(
+        (p) => p.readOnly && p.name === "Not Applicable"
+      ) as Organization;
+      setValue("program", NAProgram);
     }
   }, [programOptions, programField?._id]);
 

--- a/src/content/studies/StudyView.tsx
+++ b/src/content/studies/StudyView.tsx
@@ -13,7 +13,7 @@ import {
   Typography,
 } from "@mui/material";
 import { useSnackbar } from "notistack";
-import { FC, useMemo, useRef, useState } from "react";
+import { FC, useEffect, useMemo, useRef, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { useNavigate } from "react-router-dom";
 
@@ -363,6 +363,12 @@ const StudyView: FC<Props> = ({ _id }: Props) => {
       fetchPolicy: "no-cache",
     }
   );
+
+  useEffect(() => {
+    if (!programField?._id && programOptions?.length > 0) {
+      setValue("program", programOptions[0] as Organization);
+    }
+  }, [programOptions, programField?._id]);
 
   /**
    * Reset the form values, and preventing invalid


### PR DESCRIPTION
### Overview

Previously, the program dropdown within the Add/Edit Study was allowed to be empty, but required the user to select an option. This has been changed to not allow it to be empty and instead default to "Not Applicable" program.

### Change Details (Specifics)

- Updated program field to always populate with "Not Applicable" program instead of being empty.
- Added test to check this

### Related Ticket(s)

[CRDCDH-3360](https://tracker.nci.nih.gov/browse/CRDCDH-3360)
