### PR TITLE
CRDCDH-3349 [Bug]: Excel import - Persist values even if they fail validation

### DIFF
--- a/src/classes/Excel/PersistentColumns.test.ts
+++ b/src/classes/Excel/PersistentColumns.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  shouldPersistColumnValue,
+  type ColumnKey,
+  type PersistenceRule,
+} from "./PersistentColumns";
+
+const fooRule = vi.fn((value: string) => value === "foo");
+const barRule = vi.fn((value: string) => value.startsWith("bar:"));
+
+const mockPersistentColumns: readonly PersistenceRule[] = [
+  {
+    key: "mock.foo" as ColumnKey,
+    shouldPersist: fooRule,
+  },
+  {
+    key: "mock.bar" as ColumnKey,
+    shouldPersist: barRule,
+  },
+];
+
+describe("shouldPersistColumnValue", () => {
+  const opts = { persistentColumns: mockPersistentColumns };
+
+  it("uses the matching rule for the key and returns its result", () => {
+    expect(shouldPersistColumnValue("mock.foo" as ColumnKey, "foo", opts)).toBe(true);
+    expect(shouldPersistColumnValue("mock.foo" as ColumnKey, "nope", opts)).toBe(false);
+
+    expect(shouldPersistColumnValue("mock.bar" as ColumnKey, "bar:123", opts)).toBe(true);
+    expect(shouldPersistColumnValue("mock.bar" as ColumnKey, "baz", opts)).toBe(false);
+  });
+
+  it("trims the value before passing it to the rule", () => {
+    fooRule.mockClear();
+    barRule.mockClear();
+
+    expect(shouldPersistColumnValue("mock.foo" as ColumnKey, "  foo  ", opts)).toBe(true);
+
+    expect(fooRule).toHaveBeenCalledTimes(1);
+    expect(fooRule).toHaveBeenCalledWith("foo");
+  });
+
+  it("stringifies non-string values before passing them to the rule", () => {
+    fooRule.mockClear();
+    barRule.mockClear();
+
+    expect(shouldPersistColumnValue("mock.foo" as ColumnKey, null, opts)).toBe(false);
+    expect(fooRule).toHaveBeenCalledWith("");
+
+    barRule.mockClear();
+    expect(shouldPersistColumnValue("mock.bar" as ColumnKey, 123, opts)).toBe(false);
+    expect(barRule).toHaveBeenCalledWith("123");
+  });
+
+  it("returns false when there is no matching rule for the key", () => {
+    fooRule.mockClear();
+    barRule.mockClear();
+
+    const result = shouldPersistColumnValue("some.other.key" as ColumnKey, "anything", opts);
+
+    expect(result).toBe(false);
+    expect(fooRule).not.toHaveBeenCalled();
+    expect(barRule).not.toHaveBeenCalled();
+  });
+});

--- a/src/classes/Excel/PersistentColumns.ts
+++ b/src/classes/Excel/PersistentColumns.ts
@@ -1,0 +1,47 @@
+import dayjs from "dayjs";
+import { toString } from "lodash";
+
+import { AKeys } from "./A/Columns";
+import { BKeys } from "./B/Columns";
+import { CKeys } from "./C/Columns";
+import { DKeys } from "./D/Columns";
+
+export type ColumnKey = AKeys | BKeys | CKeys | DKeys;
+
+export type PersistenceRule = {
+  key: ColumnKey;
+  shouldPersist: (value: string) => boolean;
+};
+
+/**
+ * Columns that retain values if they meet minimum requirements,
+ * even if other validations fail.
+ */
+export const PERSISTENT_COLUMNS: PersistenceRule[] = [
+  {
+    key: "targetedSubmissionDate",
+    shouldPersist: (value: string) => dayjs(value, "MM/DD/YYYY", true)?.isValid(),
+  },
+  {
+    key: "targetedReleaseDate",
+    shouldPersist: (value: string) => dayjs(value, "MM/DD/YYYY", true)?.isValid(),
+  },
+];
+
+/**
+ * Helper to check if a column value should persist its value, even if validation fails.
+ *
+ * @param {ColumnKey} key - The column key to check
+ * @param {unknown} value - The value to validate
+ * @returns True if the value should persist, false otherwise
+ */
+export const shouldPersistColumnValue = (
+  key: ColumnKey,
+  value: unknown,
+  opts?: { persistentColumns: readonly PersistenceRule[] }
+): boolean => {
+  const columns = opts?.persistentColumns || PERSISTENT_COLUMNS;
+  const rule = columns.find((r) => r.key === key);
+
+  return rule ? rule.shouldPersist(toString(value)?.trim()) : false;
+};

--- a/src/classes/Excel/SectionBase.ts
+++ b/src/classes/Excel/SectionBase.ts
@@ -1,7 +1,7 @@
 import type ExcelJS from "exceljs";
 import { CellValue } from "exceljs";
 
-import { Logger } from "@/utils";
+import { Logger } from "@/utils/logger";
 
 import { ErrorCatalog } from "./ErrorCatalog";
 

--- a/src/classes/QuestionnaireExcelMiddleware.test.ts
+++ b/src/classes/QuestionnaireExcelMiddleware.test.ts
@@ -3294,7 +3294,7 @@ describe("Parsing", () => {
     vi.useRealTimers();
   });
 
-  it("should not allow past dates for target dates", async () => {
+  it("should not allow past dates for target dates and persist value", async () => {
     const mockForm = questionnaireDataFactory.build({
       targetedSubmissionDate: "01/01/2000",
       targetedReleaseDate: "01/01/2000",
@@ -3328,8 +3328,8 @@ describe("Parsing", () => {
     const output = middleware.data;
 
     expect(result).toEqual(true);
-    expect(output.targetedSubmissionDate).toEqual(InitialQuestionnaire.targetedSubmissionDate);
-    expect(output.targetedReleaseDate).toEqual(InitialQuestionnaire.targetedReleaseDate);
+    expect(output.targetedSubmissionDate).toEqual("01/01/2000");
+    expect(output.targetedReleaseDate).toEqual("01/01/2000");
   });
 
   it("should handle missing SectionD sheet", async () => {

--- a/src/utils/formUtils.ts
+++ b/src/utils/formUtils.ts
@@ -1,5 +1,7 @@
-import { cloneDeep, mergeWith, has, unset, some, values } from "lodash";
+import { cloneDeep, mergeWith, has, unset, some, values, get } from "lodash";
 import type * as z from "zod";
+
+import { ColumnKey, shouldPersistColumnValue } from "@/classes/Excel/PersistentColumns";
 
 import { NotApplicableProgram, OtherProgram } from "../config/ProgramConfig";
 
@@ -408,6 +410,15 @@ export const parseSchemaObject = <S extends z.ZodObject>(
   const clonedData = cloneDeep(data);
   for (const path of errorFields) {
     if (!has(clonedData, path)) {
+      break;
+    }
+
+    const narrowedData = get(clonedData, path);
+    const columnKey = path?.filter((p) => typeof p === "string")?.join(".") as ColumnKey;
+    if (shouldPersistColumnValue(columnKey, narrowedData)) {
+      Logger.info(`parseSchemaObject: Persisting value for column key ${columnKey}.`, {
+        value: narrowedData,
+      });
       break;
     }
 

--- a/src/utils/formUtils.ts
+++ b/src/utils/formUtils.ts
@@ -419,10 +419,7 @@ export const parseSchemaObject = <S extends z.ZodObject>(
       Logger.info(`parseSchemaObject: Persisting value for column key ${columnKey}.`, {
         value: narrowedData,
       });
-      break;
-    }
-
-    if (!unset(clonedData, path)) {
+    } else if (!unset(clonedData, path)) {
       Logger.error(`parseSchemaObject: Failed to unset path ${JSON.stringify(path)} in object.`);
     }
   }


### PR DESCRIPTION
### Overview

Added support for persisting the value of specified properties so that the values do not get removed if they fail the initial schema validation.

### Change Details (Specifics)

- Added support for persisting property values when validation fails
- Added `targetedSubmissionDate` and `targetedReleaseDate` to persist their date values
- Test coverage for persisting values

### Related Ticket(s)

[CRDCDH-3349](https://tracker.nci.nih.gov/browse/CRDCDH-3349)
