### PR TITLE
CRDCDH-3347 Fix Excel Form Validation Inconsistencies

### DIFF
--- a/src/schemas/Application.ts
+++ b/src/schemas/Application.ts
@@ -527,7 +527,7 @@ export const questionnaireDataSchema = z
     /**
      * Confirms imaging data have been de-identified.
      */
-    imagingDataDeIdentified: z.boolean().optional(),
+    imagingDataDeIdentified: z.boolean().nullable(),
     /**
      * Confirms non-imaging data have been de-identified.
      */

--- a/src/schemas/Application.ts
+++ b/src/schemas/Application.ts
@@ -170,21 +170,21 @@ export const programInputSchema = z
     description: z.string().max(500).optional(),
   })
   .superRefine((val, ctx) => {
-    if (val._id !== "Not Applicable" && !val.name) {
+    if (val._id === "Other" && !val.name) {
       ctx.addIssue({
         code: "custom",
         path: ["name"],
         message: FIELD_IS_REQUIRED,
       });
     }
-    if (val._id !== "Not Applicable" && !val.abbreviation) {
+    if (val._id === "Other" && !val.abbreviation) {
       ctx.addIssue({
         code: "custom",
         path: ["abbreviation"],
         message: FIELD_IS_REQUIRED,
       });
     }
-    if (val._id !== "Not Applicable" && !val.description) {
+    if (val._id === "Other" && !val.description) {
       ctx.addIssue({
         code: "custom",
         path: ["description"],


### PR DESCRIPTION
### Overview

This PR fixes some validation inconsistencies between the Zod validation and the HTML5 validation.

### Change Details (Specifics)

- Switch Zod definition of `imagingDataDeIdentified` to allow nulls, which is consistent with the default value
- Switch the Zod validation logic for the Program Name, Abbreviation, and Description fields to ONLY validate if the program selection is "Other"

### Related Ticket(s)

CRDCDH-3347
