### PR TITLE
CRDCDH-3439 Support Auto Enabling of Version History

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10253,8 +10253,8 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/data-model-navigator": {
-      "version": "1.9.0",
-      "resolved": "git+ssh://git@github.com/CBIIT/Data-Model-Navigator.git#00e344485dba64c1dc3880acbe22dc01c81e5617",
+      "version": "1.9.1",
+      "resolved": "git+ssh://git@github.com/CBIIT/Data-Model-Navigator.git#4b887fa870de70572870e3351068b3ead36a79e8",
       "license": "ISC",
       "dependencies": {
         "@material-ui/core": "^4.12.4",

--- a/src/hooks/useBuildReduxStore.test.tsx
+++ b/src/hooks/useBuildReduxStore.test.tsx
@@ -1,0 +1,423 @@
+import { MockedProvider, MockedResponse } from "@apollo/client/testing";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import * as dmn from "data-model-navigator";
+import { vi } from "vitest";
+
+import { RETRIEVE_CDEs, RetrieveCDEsInput, RetrieveCDEsResp } from "@/graphql";
+import * as utils from "@/utils";
+
+import useBuildReduxStore from "./useBuildReduxStore";
+
+// Mock the data-model-navigator module
+vi.mock("data-model-navigator", () => ({
+  ddgraph: (state = null) => state,
+  moduleReducers: { submission: (state = null) => state },
+  versionInfo: (state = null) => state,
+  changelogInfo: (state = null) => state,
+  iconMapInfo: (state = null) => state,
+  getModelExploreData: vi.fn(),
+  getChangelog: vi.fn(),
+}));
+
+// Mock the utils
+vi.mock("@/utils", async () => {
+  const actual = await vi.importActual<typeof import("@/utils")>("@/utils");
+  return {
+    ...actual,
+    buildAssetUrls: vi.fn(),
+    buildBaseFilterContainers: vi.fn(),
+    buildFilterOptionsList: vi.fn(),
+    extractSupportedCDEs: vi.fn(),
+    populateCDEData: vi.fn(),
+  };
+});
+
+const mockDataCommon = {
+  name: "TestModel",
+  displayName: "Test Model",
+  assets: {
+    "current-version": "1.0.0",
+    "model-files": ["test.yaml"],
+    "readme-file": "README.md",
+    "release-notes": "version-history.md",
+    "loading-file": "loading.txt",
+    "model-navigator-logo": "logo.png",
+    "model-navigator-config": {
+      facetFilterSearchData: [],
+      facetFilterSectionVariables: {},
+      pdfConfig: {
+        footnote: "Test Model",
+      },
+      pageTitle: "Test Model",
+    },
+  },
+} as DataCommon;
+
+describe("useBuildReduxStore", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Setup default mock implementations
+    vi.mocked(utils.buildAssetUrls).mockReturnValue({
+      model_files: ["file1.yaml", "file2.yaml"],
+      readme: "readme.md",
+      loading_file: "loading.txt",
+      navigator_icon: "icon.png",
+      changelog: "version-history.md",
+    });
+
+    vi.mocked(utils.buildBaseFilterContainers).mockReturnValue({});
+    vi.mocked(utils.buildFilterOptionsList).mockReturnValue([]);
+    vi.mocked(utils.extractSupportedCDEs).mockReturnValue([]);
+    vi.mocked(utils.populateCDEData).mockImplementation(() => {});
+  });
+
+  it("should initialize with status 'waiting'", () => {
+    const { result } = renderHook(() => useBuildReduxStore(), {
+      wrapper: ({ children }) => <MockedProvider>{children}</MockedProvider>,
+    });
+
+    expect(result.current[0].status).toBe("waiting");
+    expect(result.current[0].store).toBeDefined();
+  });
+
+  it("should set status to 'error' when datacommon is missing required fields", async () => {
+    const { result } = renderHook(() => useBuildReduxStore(), {
+      wrapper: ({ children }) => <MockedProvider>{children}</MockedProvider>,
+    });
+
+    const [, populateStore] = result.current;
+
+    const invalidDataCommon = {
+      ...mockDataCommon,
+      name: null,
+    } as unknown as DataCommon;
+
+    await act(async () => {
+      populateStore(invalidDataCommon, "1.0.0");
+    });
+
+    await waitFor(() => {
+      expect(result.current[0].status).toBe("error");
+    });
+  });
+
+  it("should set status to 'error' when getModelExploreData returns null", async () => {
+    vi.mocked(dmn.getModelExploreData).mockResolvedValue(null);
+    vi.mocked(dmn.getChangelog).mockResolvedValue("# Changelog");
+
+    const { result } = renderHook(() => useBuildReduxStore(), {
+      wrapper: ({ children }) => <MockedProvider>{children}</MockedProvider>,
+    });
+
+    const [, populateStore] = result.current;
+
+    await act(async () => {
+      populateStore(mockDataCommon, "1.0.0");
+    });
+
+    await waitFor(() => {
+      expect(result.current[0].status).toBe("error");
+    });
+  });
+
+  it("should successfully populate store when all data is valid", async () => {
+    const mockDictionary = { nodes: [], edges: [] };
+    const mockVersion = "1.0.0";
+    const mockChangelog = "# Changelog\n\n- Feature 1";
+
+    vi.mocked(dmn.getModelExploreData).mockResolvedValue({
+      data: mockDictionary,
+      version: mockVersion,
+    });
+    vi.mocked(dmn.getChangelog).mockResolvedValue(mockChangelog);
+
+    const { result } = renderHook(() => useBuildReduxStore(), {
+      wrapper: ({ children }) => <MockedProvider>{children}</MockedProvider>,
+    });
+
+    const [, populateStore] = result.current;
+
+    await act(async () => {
+      populateStore(mockDataCommon, "1.0.0");
+    });
+
+    await waitFor(() => {
+      expect(result.current[0].status).toBe("success");
+    });
+
+    expect(vi.mocked(dmn.getModelExploreData)).toHaveBeenCalled();
+    expect(vi.mocked(dmn.getChangelog)).toHaveBeenCalled();
+  });
+
+  it("should dispatch RECEIVE_CHANGELOG_INFO when changelog is successfully retrieved", async () => {
+    const mockDictionary = { nodes: [], edges: [] };
+    const mockVersion = "1.0.0";
+    const mockChangelog = "# Changelog\n\n- Feature 1";
+
+    vi.mocked(dmn.getModelExploreData).mockResolvedValue({
+      data: mockDictionary,
+      version: mockVersion,
+    });
+    vi.mocked(dmn.getChangelog).mockResolvedValue(mockChangelog);
+
+    const { result } = renderHook(() => useBuildReduxStore(), {
+      wrapper: ({ children }) => <MockedProvider>{children}</MockedProvider>,
+    });
+
+    const [{ store }, populateStore] = result.current;
+    const dispatchSpy = vi.spyOn(store, "dispatch");
+
+    await act(async () => {
+      populateStore(mockDataCommon, "1.0.0");
+    });
+
+    await waitFor(() => {
+      expect(result.current[0].status).toBe("success");
+    });
+
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "RECEIVE_CHANGELOG_INFO",
+        data: {
+          changelogMD: mockChangelog,
+          changelogTabName: "Version History",
+        },
+      })
+    );
+  });
+
+  it("should not dispatch RECEIVE_CHANGELOG_INFO when changelog retrieval fails", async () => {
+    const mockDictionary = { nodes: [], edges: [] };
+    const mockVersion = "1.0.0";
+
+    vi.mocked(dmn.getModelExploreData).mockResolvedValue({
+      data: mockDictionary,
+      version: mockVersion,
+    });
+    vi.mocked(dmn.getChangelog).mockResolvedValue(null);
+
+    const { result } = renderHook(() => useBuildReduxStore(), {
+      wrapper: ({ children }) => <MockedProvider>{children}</MockedProvider>,
+    });
+
+    const [{ store }, populateStore] = result.current;
+    const dispatchSpy = vi.spyOn(store, "dispatch");
+
+    await act(async () => {
+      populateStore(mockDataCommon, "1.0.0");
+    });
+
+    await waitFor(() => {
+      expect(result.current[0].status).toBe("success");
+    });
+
+    expect(dispatchSpy).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "RECEIVE_CHANGELOG_INFO",
+      })
+    );
+  });
+
+  it("should retrieve and populate CDEs when supported CDEs are found", async () => {
+    const mockDictionary = { nodes: [], edges: [] };
+    const mockVersion = "1.0.0";
+    const mockCDEs: CDEInfo[] = [
+      { CDECode: "CDE001", CDEVersion: "1.0", CDEOrigin: "caDSR" },
+      { CDECode: "CDE002", CDEVersion: "2.0", CDEOrigin: "caDSR" },
+    ];
+
+    vi.mocked(dmn.getModelExploreData).mockResolvedValue({
+      data: mockDictionary,
+      version: mockVersion,
+    });
+    vi.mocked(dmn.getChangelog).mockResolvedValue(null);
+    vi.mocked(utils.extractSupportedCDEs).mockReturnValue(mockCDEs);
+
+    const mockCDEResponse: MockedResponse<RetrieveCDEsResp, RetrieveCDEsInput> = {
+      request: {
+        query: RETRIEVE_CDEs,
+      },
+      variableMatcher: () => true,
+      result: {
+        data: {
+          retrieveCDEs: [
+            {
+              CDEFullName: "CDE 001 Full Name",
+              CDECode: "CDE001",
+              CDEVersion: "1.0",
+              PermissibleValues: ["value1", "value2"],
+            },
+            {
+              CDEFullName: "CDE 002 Full Name",
+              CDECode: "CDE002",
+              CDEVersion: "2.0",
+              PermissibleValues: ["value3", "value4"],
+            },
+          ],
+        },
+      },
+    };
+
+    const { result } = renderHook(() => useBuildReduxStore(), {
+      wrapper: ({ children }) => (
+        <MockedProvider mocks={[mockCDEResponse]} addTypename={false}>
+          {children}
+        </MockedProvider>
+      ),
+    });
+
+    const [, populateStore] = result.current;
+
+    await act(async () => {
+      populateStore(mockDataCommon, "1.0.0");
+    });
+
+    await waitFor(() => {
+      expect(result.current[0].status).toBe("success");
+    });
+
+    expect(vi.mocked(utils.extractSupportedCDEs)).toHaveBeenCalledWith(mockDictionary);
+    expect(vi.mocked(utils.populateCDEData)).toHaveBeenCalledWith(mockDictionary, [
+      {
+        CDEFullName: "CDE 001 Full Name",
+        CDECode: "CDE001",
+        CDEVersion: "1.0",
+        PermissibleValues: ["value1", "value2"],
+      },
+      {
+        CDEFullName: "CDE 002 Full Name",
+        CDECode: "CDE002",
+        CDEVersion: "2.0",
+        PermissibleValues: ["value3", "value4"],
+      },
+    ]);
+  });
+
+  it("should handle CDE retrieval errors gracefully", async () => {
+    const mockDictionary = { nodes: [], edges: [] };
+    const mockVersion = "1.0.0";
+    const mockCDEs: CDEInfo[] = [{ CDECode: "CDE001", CDEVersion: "1.0", CDEOrigin: "caDSR" }];
+
+    vi.mocked(dmn.getModelExploreData).mockResolvedValue({
+      data: mockDictionary,
+      version: mockVersion,
+    });
+    vi.mocked(dmn.getChangelog).mockResolvedValue(null);
+    vi.mocked(utils.extractSupportedCDEs).mockReturnValue(mockCDEs);
+
+    const mockCDEResponse: MockedResponse<RetrieveCDEsResp, RetrieveCDEsInput> = {
+      request: {
+        query: RETRIEVE_CDEs,
+      },
+      variableMatcher: () => true,
+      error: new Error("CDE retrieval failed"),
+    };
+
+    const { result } = renderHook(() => useBuildReduxStore(), {
+      wrapper: ({ children }) => (
+        <MockedProvider mocks={[mockCDEResponse]} addTypename={false}>
+          {children}
+        </MockedProvider>
+      ),
+    });
+
+    const [, populateStore] = result.current;
+
+    await act(async () => {
+      populateStore(mockDataCommon, "1.0.0");
+    });
+
+    await waitFor(() => {
+      expect(result.current[0].status).toBe("success");
+    });
+
+    expect(vi.mocked(utils.populateCDEData)).toHaveBeenCalledWith(mockDictionary, []);
+  });
+
+  it("should not attempt CDE retrieval when no supported CDEs are found", async () => {
+    const mockDictionary = { nodes: [], edges: [] };
+    const mockVersion = "1.0.0";
+
+    vi.mocked(dmn.getModelExploreData).mockResolvedValue({
+      data: mockDictionary,
+      version: mockVersion,
+    });
+    vi.mocked(dmn.getChangelog).mockResolvedValue(null);
+    vi.mocked(utils.extractSupportedCDEs).mockReturnValue([]);
+
+    const { result } = renderHook(() => useBuildReduxStore(), {
+      wrapper: ({ children }) => <MockedProvider>{children}</MockedProvider>,
+    });
+
+    const [, populateStore] = result.current;
+
+    await act(async () => {
+      populateStore(mockDataCommon, "1.0.0");
+    });
+
+    await waitFor(() => {
+      expect(result.current[0].status).toBe("success");
+    });
+
+    expect(vi.mocked(utils.extractSupportedCDEs)).toHaveBeenCalledWith(mockDictionary);
+    expect(vi.mocked(utils.populateCDEData)).not.toHaveBeenCalled();
+  });
+
+  it("should dispatch all required actions when both changelog and model data succeed", async () => {
+    const mockDictionary = { nodes: [], edges: [] };
+    const mockVersion = "1.0.0";
+    const mockChangelog = "# Changelog";
+
+    vi.mocked(dmn.getModelExploreData).mockResolvedValue({
+      data: mockDictionary,
+      version: mockVersion,
+    });
+    vi.mocked(dmn.getChangelog).mockResolvedValue(mockChangelog);
+
+    const { result } = renderHook(() => useBuildReduxStore(), {
+      wrapper: ({ children }) => <MockedProvider>{children}</MockedProvider>,
+    });
+
+    const [{ store }, populateStore] = result.current;
+    const dispatchSpy = vi.spyOn(store, "dispatch");
+
+    await act(async () => {
+      populateStore(mockDataCommon, "1.0.0");
+    });
+
+    await waitFor(() => {
+      expect(result.current[0].status).toBe("success");
+    });
+
+    // Verify version info dispatch
+    expect(dispatchSpy).toHaveBeenCalledWith({
+      type: "RECEIVE_VERSION_INFO",
+      data: mockVersion,
+    });
+
+    // Verify dictionary dispatch
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "RECEIVE_DICTIONARY",
+      })
+    );
+
+    // Verify graph dictionary dispatch
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "REACT_FLOW_GRAPH_DICTIONARY",
+      })
+    );
+
+    // Verify changelog dispatch
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "RECEIVE_CHANGELOG_INFO",
+      })
+    );
+
+    // Verify search clear history dispatch
+    expect(dispatchSpy).toHaveBeenCalledWith({ type: "SEARCH_CLEAR_HISTORY" });
+  });
+});

--- a/src/hooks/useBuildReduxStore.ts
+++ b/src/hooks/useBuildReduxStore.ts
@@ -87,7 +87,7 @@ const useBuildReduxStore = (): ReduxStoreResult => {
     const assets = buildAssetUrls(datacommon, modelVersion);
     const dmnConfig = datacommon.assets["model-navigator-config"];
 
-    const [changelogMD, { data: dictionary, version }] = await Promise.allSettled([
+    const [changelogMD, modelData] = await Promise.allSettled([
       getChangelog(assets?.changelog),
       getModelExploreData(...assets.model_files),
     ]).then((results) =>
@@ -101,6 +101,7 @@ const useBuildReduxStore = (): ReduxStoreResult => {
       })
     );
 
+    const { data: dictionary, version } = modelData || {};
     if (!dictionary || !version) {
       setStatus("error");
       return;

--- a/src/utils/dataModelUtils.test.ts
+++ b/src/utils/dataModelUtils.test.ts
@@ -383,6 +383,32 @@ describe("buildAssetUrls cases", () => {
       `${MODEL_FILE_REPO}prod/cache/test-name/1.0/prop-file`,
     ]);
   });
+
+  it("should use the changelog fallback 'version-history.md' if release-notes is not defined", () => {
+    const dc: DataCommon = dataCommonFactory.build({
+      name: "test-name",
+      assets: manifestAssetsFactory.build({}),
+    });
+
+    const result = utils.buildAssetUrls(dc, "1.0.0");
+    expect(result.changelog).toEqual(
+      `${MODEL_FILE_REPO}prod/cache/test-name/1.0.0/version-history.md`
+    );
+  });
+
+  it("should use the changelog filename provided if release-notes is defined", () => {
+    const dc: DataCommon = dataCommonFactory.build({
+      name: "test-name",
+      assets: manifestAssetsFactory.build({
+        "release-notes": "custom-release-notes.md",
+      }),
+    });
+
+    const result = utils.buildAssetUrls(dc, "1.0.1");
+    expect(result.changelog).toEqual(
+      `${MODEL_FILE_REPO}prod/cache/test-name/1.0.1/custom-release-notes.md`
+    );
+  });
 });
 
 describe("buildBaseFilterContainers tests", () => {

--- a/src/utils/dataModelUtils.ts
+++ b/src/utils/dataModelUtils.ts
@@ -83,7 +83,7 @@ export const buildAssetUrls = (model: DataCommon, modelVersion: string): ModelAs
       : "",
     changelog: assets?.["release-notes"]
       ? `${MODEL_FILE_REPO}${tier}/cache/${name}/${version}/${assets?.["release-notes"]}`
-      : null,
+      : `${MODEL_FILE_REPO}${tier}/cache/${name}/${version}/version-history.md`,
   };
 };
 


### PR DESCRIPTION
### Overview

This PR removes the explicit check for whether a version history document exists or not before trying to fetch it from GitHub. If the release-notes attribute isn't defined in our Model Repo content.json file, we fallback to the default "version-history.md" file.

This implementation still inherently supports non-standard document names by providing the release-notes attribute with the custom filename.

### Change Details (Specifics)

- Instead of falling back to `null` for the version history asset, use the official `version-history.md` filename
- Update the test coverage for these requirements
- Update DMN v1.9.1, which explicitly throws an error when the version-history document fetching fails

### Related Ticket(s)

CRDCDH-3439 (Task)
CRDCDH-3342 (User Story)
