### PR TITLE
CRDCDH-3480 Add tooltips to Submit/Withdraw actions

### DIFF
--- a/src/config/DashboardTooltips.ts
+++ b/src/config/DashboardTooltips.ts
@@ -43,6 +43,9 @@ export const TOOLTIP_TEXT = {
           "There are ongoing batch uploads. Please wait for the upload to complete.",
       },
     },
+    WITHDRAW: {
+      ENABLED: "Withdraw will reverse the submission and control will return to the Submitter.",
+    },
   },
   COLLABORATORS_DIALOG: {
     PERMISSIONS: {

--- a/src/config/DashboardTooltips.ts
+++ b/src/config/DashboardTooltips.ts
@@ -42,6 +42,7 @@ export const TOOLTIP_TEXT = {
         BATCH_IS_UPLOADING:
           "There are ongoing batch uploads. Please wait for the upload to complete.",
       },
+      ENABLED: "Submit the data to CRDC for review and inclusion in a data commons.",
     },
     WITHDRAW: {
       ENABLED: "Withdraw will reverse the submission and control will return to the Submitter.",

--- a/src/content/dataSubmissions/DataSubmissionActions.stories.tsx
+++ b/src/content/dataSubmissions/DataSubmissionActions.stories.tsx
@@ -1,5 +1,5 @@
 import type { Decorator, Meta, StoryObj } from "@storybook/react";
-import { fn } from "@storybook/test";
+import { fn, userEvent, within, expect, screen, waitFor } from "@storybook/test";
 import { ComponentPropsWithoutRef } from "react";
 
 import { submissionAttributesFactory } from "@/factories/submission/SubmissionAttributesFactory";
@@ -329,6 +329,18 @@ export const Withdraw: Story = {
   name: "User can Withdraw their submitted submission",
   args: {
     submissionStatus: "Submitted",
+  },
+  play: async ({ canvasElement }) => {
+    const { getByRole } = within(canvasElement);
+    const withdrawBtn = getByRole("button", { name: /withdraw/i });
+
+    expect(withdrawBtn).toBeEnabled();
+
+    userEvent.hover(withdrawBtn);
+
+    await waitFor(() => {
+      expect(screen.getByRole("tooltip")).toBeInTheDocument();
+    });
   },
 };
 

--- a/src/content/dataSubmissions/DataSubmissionActions.test.tsx
+++ b/src/content/dataSubmissions/DataSubmissionActions.test.tsx
@@ -1,4 +1,5 @@
 import { MockedProvider, MockedResponse } from "@apollo/client/testing";
+import userEvent from "@testing-library/user-event";
 import { useMemo } from "react";
 import { Mock } from "vitest";
 
@@ -154,5 +155,40 @@ describe("Implementation Requirements - Release", () => {
     });
     expect(releaseBtn).toBeInTheDocument();
     expect(releaseBtn).toHaveTextContent("Release to DC-1");
+  });
+});
+
+describe("Implementation Requirements - Withdraw", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should show a tooltip on the enabled Withdraw button", async () => {
+    const { getByRole, findByRole } = render(
+      <TestParent
+        user={{
+          _id: "submission-owner",
+          role: "Submitter",
+          permissions: ["data_submission:view", "data_submission:create"],
+        }}
+        submission={{
+          _id: "submission-id",
+          status: "Submitted",
+          submitterID: "submission-owner",
+        }}
+      >
+        <DataSubmissionActions onAction={vi.fn()} />
+      </TestParent>
+    );
+
+    const withdrawBtn = getByRole("button", { name: /withdraw/i });
+    expect(withdrawBtn).toBeEnabled();
+
+    userEvent.hover(withdrawBtn);
+    const tooltip = await findByRole("tooltip");
+    expect(tooltip).toBeInTheDocument();
+    expect(tooltip).toHaveTextContent(
+      "Withdraw will reverse the submission and control will return to the Submitter."
+    );
   });
 });

--- a/src/content/dataSubmissions/DataSubmissionActions.tsx
+++ b/src/content/dataSubmissions/DataSubmissionActions.tsx
@@ -227,7 +227,7 @@ const DataSubmissionActions = ({ onAction }: Props) => {
         <Tooltip
           placement="top"
           title={submitActionButton?.tooltip}
-          open={undefined} // will use hoverListener to open
+          open={undefined}
           disableHoverListener={!submitActionButton?.tooltip || (action && action !== "Submit")}
         >
           <span>
@@ -247,7 +247,7 @@ const DataSubmissionActions = ({ onAction }: Props) => {
         <Tooltip
           placement="top"
           title={TOOLTIP_TEXT.SUBMISSION_ACTIONS.RELEASE.DISABLED.NO_CROSS_VALIDATION}
-          open={undefined} // will use hoverListener to open
+          open={undefined}
           disableHoverListener={!((action && action !== "Release") || releaseActionButton?.disable)}
         >
           <span>
@@ -279,15 +279,24 @@ const DataSubmissionActions = ({ onAction }: Props) => {
         </StyledLoadingButton>
       ) : null}
       {canShowAction("Withdraw") ? (
-        <StyledLoadingButton
-          variant="contained"
-          color="error"
-          onClick={() => onOpenDialog("Withdraw")}
-          loading={action === "Withdraw"}
-          disabled={action && action !== "Withdraw"}
+        <Tooltip
+          placement="top"
+          title={TOOLTIP_TEXT.SUBMISSION_ACTIONS.WITHDRAW.ENABLED}
+          open={undefined}
+          disableHoverListener={action && action !== "Withdraw"}
         >
-          Withdraw
-        </StyledLoadingButton>
+          <span>
+            <StyledLoadingButton
+              variant="contained"
+              color="error"
+              onClick={() => onOpenDialog("Withdraw")}
+              loading={action === "Withdraw"}
+              disabled={action && action !== "Withdraw"}
+            >
+              Withdraw
+            </StyledLoadingButton>
+          </span>
+        </Tooltip>
       ) : null}
       {canShowAction("SubmittedReject") || canShowAction("ReleasedReject") ? (
         <StyledLoadingButton

--- a/src/utils/dataSubmissionUtils.test.ts
+++ b/src/utils/dataSubmissionUtils.test.ts
@@ -1,5 +1,6 @@
 import { MockedFunction } from "vitest";
 
+import { TOOLTIP_TEXT } from "@/config/DashboardTooltips";
 import { userFactory } from "@/factories/auth/UserFactory";
 import { errorMessageFactory } from "@/factories/submission/ErrorMessageFactory";
 import { qcResultFactory } from "@/factories/submission/QCResultFactory";
@@ -422,6 +423,22 @@ describe("General Submit", () => {
     expect(result.isAdminOverride).toBe(false);
   });
 
+  it("should supply a tooltip when allowing submit without override", () => {
+    const submission: Submission = {
+      ...baseSubmission,
+      metadataValidationStatus: "Warning",
+      fileValidationStatus: "Warning",
+    };
+    const result = utils.shouldEnableSubmit(
+      { getSubmission: submission, getSubmissionAttributes: null, submissionStats: null },
+      baseUser
+    );
+
+    expect(result.enabled).toBe(true);
+    expect(result.isAdminOverride).toBe(false);
+    expect(result.tooltip).toBe(TOOLTIP_TEXT.SUBMISSION_ACTIONS.SUBMIT.ENABLED);
+  });
+
   it("should disable submit when submission is null", () => {
     const result = utils.shouldEnableSubmit(null, baseUser);
     expect(result.enabled).toBe(false);
@@ -430,6 +447,26 @@ describe("General Submit", () => {
 });
 
 describe("Admin Submit", () => {
+  it("should not supply a tooltip with admin override", () => {
+    const submission: Submission = {
+      ...baseSubmission,
+      metadataValidationStatus: "Error",
+      fileValidationStatus: "Error",
+    };
+    const user: User = {
+      ...baseUser,
+      role: "Admin",
+      permissions: ["data_submission:view", "data_submission:admin_submit"],
+    };
+    const result = utils.shouldEnableSubmit(
+      { getSubmission: submission, getSubmissionAttributes: null, submissionStats: null },
+      user
+    );
+
+    expect(result.isAdminOverride).toBe(true);
+    expect(result.tooltip).not.toBeDefined();
+  });
+
   it("should allow admin override with validation errors", () => {
     const submission: Submission = {
       ...baseSubmission,

--- a/src/utils/dataSubmissionUtils.ts
+++ b/src/utils/dataSubmissionUtils.ts
@@ -14,7 +14,7 @@ import { safeParse } from "./jsonUtils";
  * @param data - The submission object to evaluate.
  * @param user - The current user.
  * @returns Returns an object indicating whether the submit button is enabled,
- * whether the admin override is in effect, and an optional tooltip explaining why it is disabled.
+ * whether the admin override is in effect, and an optional tooltip explaining the button state.
  */
 export const shouldEnableSubmit = (data: GetSubmissionResp, user: User): SubmitButtonResult => {
   if (!data?.getSubmission?._id || !user) {

--- a/src/utils/dataSubmissionUtils.ts
+++ b/src/utils/dataSubmissionUtils.ts
@@ -1,3 +1,5 @@
+import { TOOLTIP_TEXT } from "@/config/DashboardTooltips";
+
 import { hasPermission } from "../config/AuthPermissions";
 import { ADMIN_OVERRIDE_CONDITIONS, SUBMIT_BUTTON_CONDITIONS } from "../config/SubmitButtonConfig";
 import { GetSubmissionResp } from "../graphql";
@@ -9,10 +11,9 @@ import { safeParse } from "./jsonUtils";
  * For admins, it first checks if an admin override is allowed. If not an admin, it checks remaining conditions
  * to determine if the submission can be enabled.
  *
- * @param {GetSubmissionResp} data - The submission object to evaluate.
- * @param {QCResult[]} qcResults - The QC results for the submission.
- * @param {User} user - The current user.
- * @returns {SubmitButtonResult} - Returns an object indicating whether the submit button is enabled,
+ * @param data - The submission object to evaluate.
+ * @param user - The current user.
+ * @returns Returns an object indicating whether the submit button is enabled,
  * whether the admin override is in effect, and an optional tooltip explaining why it is disabled.
  */
 export const shouldEnableSubmit = (data: GetSubmissionResp, user: User): SubmitButtonResult => {
@@ -44,7 +45,11 @@ export const shouldEnableSubmit = (data: GetSubmissionResp, user: User): SubmitB
 
   // If no failed conditions, enable submit
   if (!failedCondition) {
-    return { enabled: true, isAdminOverride: false };
+    return {
+      enabled: true,
+      isAdminOverride: false,
+      tooltip: TOOLTIP_TEXT.SUBMISSION_ACTIONS.SUBMIT.ENABLED,
+    };
   }
 
   // Otherwise, disable submit and display tooltip if available


### PR DESCRIPTION
### Overview

This PR extends the current data submission action buttons to add tooltips to the **enabled** Submit and Withdraw actions.

### Change Details (Specifics)

- Add tooltip support for the Withdraw button, along with adding the content to the existing config file
- Update the submit logic handler to return the "enabled" tooltip text
- Update test coverage and storybooks per these changes 

### Related Ticket(s)

CRDCDH-3480 (Task)
CRDCDH-3479 (US)
