### PR TITLE
CRDCDH-3441 Export Data Submissions from list page

### DIFF
--- a/src/components/ExportSubmissionsButton/index.stories.tsx
+++ b/src/components/ExportSubmissionsButton/index.stories.tsx
@@ -1,0 +1,147 @@
+import { MockedResponse } from "@apollo/client/testing";
+import type { Meta, StoryObj } from "@storybook/react";
+import { userEvent, within, screen } from "@storybook/test";
+
+import { Context as AuthContext } from "@/components/Contexts/AuthContext";
+import { authCtxStateFactory } from "@/factories/auth/AuthCtxStateFactory";
+import { organizationFactory } from "@/factories/auth/OrganizationFactory";
+import { userFactory } from "@/factories/auth/UserFactory";
+import { submissionFactory } from "@/factories/submission/SubmissionFactory";
+import { LIST_SUBMISSIONS, ListSubmissionsInput, ListSubmissionsResp } from "@/graphql";
+
+import Button from "./index";
+
+const mockSubmissions = submissionFactory.build(2, (idx) => ({
+  _id: `submission-${idx}`,
+  name: `Test Submission ${idx}`,
+  submitterName: `Test Submitter ${idx}`,
+  dataCommonsDisplayName: "GDC",
+  intention: "New/Update",
+  modelVersion: "1.0.0",
+  organization: organizationFactory.pick(["_id", "name", "abbreviation"]).build({
+    _id: `org-${idx}`,
+    name: `Test Organization ${idx}`,
+    abbreviation: `ORG-${idx}`,
+  }),
+  studyAbbreviation: `TEST-${idx}`,
+  dbGaPID: `phs00000${idx}`,
+  status: "In Progress",
+  conciergeName: `Test Concierge ${idx}`,
+  nodeCount: 1000 + idx,
+  dataFileSize: { size: 1024 * 1024 * (idx + 1), formatted: `${idx + 1} MB` },
+  createdAt: "2024-01-01T00:00:00Z",
+  updatedAt: "2024-01-15T00:00:00Z",
+}));
+
+const mockPopulatedResp: MockedResponse<ListSubmissionsResp, ListSubmissionsInput> = {
+  request: {
+    query: LIST_SUBMISSIONS,
+  },
+  variableMatcher: () => true,
+  result: {
+    data: {
+      listSubmissions: {
+        submissions: mockSubmissions,
+        organizations: [],
+        submitterNames: [],
+        dataCommons: [],
+        dataCommonsDisplayNames: [],
+        total: 2,
+      },
+    },
+  },
+};
+
+const defaultScope = {
+  organization: "All",
+  status: ["In Progress" as const],
+  dataCommons: "All",
+  name: "",
+  dbGaPID: "",
+  submitterName: "All",
+  sortDirection: "desc" as const,
+  orderBy: "updatedAt",
+};
+
+/**
+ * A button providing the ability to export the list of Data Submissions to CSV.
+ */
+const meta: Meta<typeof Button> = {
+  title: "Data Submissions / Export Submissions Button",
+  component: Button,
+  tags: ["autodocs"],
+  decorators: [
+    (Story) => (
+      <AuthContext.Provider
+        value={authCtxStateFactory.build({
+          isLoggedIn: true,
+          user: userFactory.build({
+            permissions: ["data_submission:view"],
+          }),
+        })}
+      >
+        <Story />
+      </AuthContext.Provider>
+    ),
+  ],
+  args: {
+    scope: defaultScope,
+    hasData: true,
+  },
+} satisfies Meta<typeof Button>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Default story showing the Export Submissions Button enabled.
+ */
+export const Default: Story = {
+  parameters: {
+    apolloClient: {
+      mocks: [mockPopulatedResp],
+    },
+  },
+};
+
+/**
+ * A story to cover the hover state of the enabled button with the tooltip present.
+ */
+export const DefaultTooltip: Story = {
+  ...Default,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole("button");
+
+    await userEvent.hover(button);
+
+    await screen.findByRole("tooltip");
+  },
+};
+
+/**
+ * A story showing the Export Submissions Button disabled (no data available).
+ */
+export const Disabled: Story = {
+  ...Default,
+  args: {
+    scope: defaultScope,
+    hasData: false,
+  },
+};
+
+/**
+ * A story to cover the hover state of the disabled button with the tooltip present.
+ */
+export const DisabledTooltip: Story = {
+  ...Disabled,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole("button");
+
+    await userEvent.hover(button, { pointerEventsCheck: 0 });
+
+    await screen.findByRole("tooltip");
+  },
+};

--- a/src/components/ExportSubmissionsButton/index.stories.tsx
+++ b/src/components/ExportSubmissionsButton/index.stories.tsx
@@ -3,13 +3,17 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { userEvent, within, screen } from "@storybook/test";
 
 import { Context as AuthContext } from "@/components/Contexts/AuthContext";
+import { Column } from "@/components/GenericTable";
 import { authCtxStateFactory } from "@/factories/auth/AuthCtxStateFactory";
 import { organizationFactory } from "@/factories/auth/OrganizationFactory";
 import { userFactory } from "@/factories/auth/UserFactory";
 import { submissionFactory } from "@/factories/submission/SubmissionFactory";
 import { LIST_SUBMISSIONS, ListSubmissionsInput, ListSubmissionsResp } from "@/graphql";
+import { FormatDate } from "@/utils";
 
 import Button from "./index";
+
+type Submission = ListSubmissionsResp["listSubmissions"]["submissions"][number];
 
 const mockSubmissions = submissionFactory.build(2, (idx) => ({
   _id: `submission-${idx}`,
@@ -63,6 +67,103 @@ const defaultScope = {
   orderBy: "updatedAt",
 };
 
+const defaultColumns: Column<Submission>[] = [
+  {
+    label: "Submission Name",
+    renderValue: (a) => a.name,
+    field: "name",
+    exportValue: (a) => ({ label: "Submission Name", value: a.name }),
+  },
+  {
+    label: "Submitter",
+    renderValue: (a) => a.submitterName,
+    field: "submitterName",
+    exportValue: (a) => ({ label: "Submitter", value: a.submitterName }),
+  },
+  {
+    label: "Data Commons",
+    renderValue: (a) => a.dataCommonsDisplayName,
+    field: "dataCommonsDisplayName",
+    exportValue: (a) => ({ label: "Data Commons", value: a.dataCommonsDisplayName }),
+  },
+  {
+    label: "Type",
+    renderValue: (a) => a.intention,
+    field: "intention",
+    exportValue: (a) => ({ label: "Type", value: a.intention }),
+  },
+  {
+    label: "Model Version",
+    renderValue: (a) => a.modelVersion,
+    field: "modelVersion",
+    exportValue: (a) => ({ label: "Model Version", value: a.modelVersion }),
+  },
+  {
+    label: "Program",
+    renderValue: (a) => a.organization?.name ?? "NA",
+    fieldKey: "organization.name",
+    exportValue: (a) => ({ label: "Program", value: a.organization?.name ?? "" }),
+  },
+  {
+    label: "Study",
+    renderValue: (a) => a.studyAbbreviation,
+    field: "studyAbbreviation",
+    exportValue: (a) => ({ label: "Study", value: a.studyAbbreviation }),
+  },
+  {
+    label: "dbGaP ID",
+    renderValue: (a) => a.dbGaPID,
+    field: "dbGaPID",
+    exportValue: (a) => ({ label: "dbGaP ID", value: a.dbGaPID }),
+  },
+  {
+    label: "Status",
+    renderValue: (a) => a.status,
+    field: "status",
+    exportValue: (a) => ({ label: "Status", value: a.status }),
+  },
+  {
+    label: "Data Concierge",
+    renderValue: (a) => a.conciergeName,
+    field: "conciergeName",
+    exportValue: (a) => ({ label: "Data Concierge", value: a.conciergeName }),
+  },
+  {
+    label: "Record Count",
+    renderValue: (a) =>
+      Intl.NumberFormat("en-US", { maximumFractionDigits: 0 }).format(a.nodeCount || 0),
+    field: "nodeCount",
+    exportValue: (a) => ({
+      label: "Record Count",
+      value: Intl.NumberFormat("en-US", { maximumFractionDigits: 0 }).format(a.nodeCount || 0),
+    }),
+  },
+  {
+    label: "Data File Size",
+    renderValue: (a) => a.dataFileSize.formatted || 0,
+    fieldKey: "dataFileSize.size",
+    exportValue: (a) => ({ label: "Data File Size", value: a.dataFileSize.formatted || 0 }),
+  },
+  {
+    label: "Created Date",
+    renderValue: (a) => FormatDate(a.createdAt, "M/D/YYYY"),
+    field: "createdAt",
+    exportValue: (a) => ({
+      label: "Created Date",
+      value: a.createdAt ? FormatDate(a.createdAt, "M/D/YYYY h:mm A") : "",
+    }),
+  },
+  {
+    label: "Last Updated",
+    renderValue: (a) => FormatDate(a.updatedAt, "M/D/YYYY"),
+    field: "updatedAt",
+    exportValue: (a) => ({
+      label: "Last Updated",
+      value: a.updatedAt ? FormatDate(a.updatedAt, "M/D/YYYY h:mm A") : "",
+    }),
+  },
+];
+
 /**
  * A button providing the ability to export the list of Data Submissions to CSV.
  */
@@ -87,6 +188,7 @@ const meta: Meta<typeof Button> = {
   args: {
     scope: defaultScope,
     hasData: true,
+    visibleColumns: defaultColumns,
   },
 } satisfies Meta<typeof Button>;
 

--- a/src/components/ExportSubmissionsButton/index.test.tsx
+++ b/src/components/ExportSubmissionsButton/index.test.tsx
@@ -1,0 +1,307 @@
+import { MockedProvider, MockedResponse } from "@apollo/client/testing";
+import userEvent from "@testing-library/user-event";
+import { FC } from "react";
+import { axe } from "vitest-axe";
+
+import { authCtxStateFactory } from "@/factories/auth/AuthCtxStateFactory";
+import { organizationFactory } from "@/factories/auth/OrganizationFactory";
+import { userFactory } from "@/factories/auth/UserFactory";
+import { submissionFactory } from "@/factories/submission/SubmissionFactory";
+import { LIST_SUBMISSIONS, ListSubmissionsInput, ListSubmissionsResp } from "@/graphql";
+import { render, waitFor } from "@/test-utils";
+
+import { Status as AuthStatus, useAuthContext } from "../Contexts/AuthContext";
+
+import ExportSubmissionsButton from "./index";
+
+const mockDownloadBlob = vi.fn();
+const mockFetchAllData = vi.fn();
+
+vi.mock("@/utils", async () => ({
+  ...(await vi.importActual("@/utils")),
+  downloadBlob: (...args) => mockDownloadBlob(...args),
+  fetchAllData: (...args) => mockFetchAllData(...args),
+}));
+
+vi.mock("../Contexts/AuthContext", async () => ({
+  ...(await vi.importActual("../Contexts/AuthContext")),
+  useAuthContext: vi.fn(),
+}));
+
+const mockUseAuthContext = useAuthContext as ReturnType<typeof vi.fn>;
+
+const mockSubmissions = submissionFactory.build(10, (idx) => ({
+  _id: `submission-${idx}`,
+  name: `Submission ${idx}`,
+  submitterName: `Submitter ${idx}`,
+  dataCommonsDisplayName: "GDC",
+  intention: "New/Update",
+  modelVersion: "1.0.0",
+  organization: organizationFactory.pick(["_id", "name", "abbreviation"]).build({
+    _id: `org-${idx}`,
+    name: `Organization ${idx}`,
+    abbreviation: `ORG-${idx}`,
+  }),
+  studyAbbreviation: `STUDY-${idx}`,
+  dbGaPID: `phs00${idx}`,
+  status: "In Progress",
+  conciergeName: `Concierge ${idx}`,
+  nodeCount: 100 + idx,
+  dataFileSize: { size: 1024 * (idx + 1), formatted: `${idx + 1} KB` },
+  createdAt: "2024-01-01T00:00:00Z",
+  updatedAt: "2024-01-02T00:00:00Z",
+}));
+
+const listSubmissionsMock: MockedResponse<ListSubmissionsResp, ListSubmissionsInput> = {
+  request: {
+    query: LIST_SUBMISSIONS,
+  },
+  variableMatcher: () => true,
+  result: {
+    data: {
+      listSubmissions: {
+        total: 10,
+        submissions: mockSubmissions,
+        organizations: [],
+        submitterNames: [],
+        dataCommons: [],
+        dataCommonsDisplayNames: [],
+      },
+    },
+  },
+};
+
+type MockParentProps = {
+  mocks: MockedResponse[];
+  children?: React.ReactNode;
+};
+
+const MockParent: FC<MockParentProps> = ({ mocks, children }) => (
+  <MockedProvider mocks={mocks}>{children}</MockedProvider>
+);
+
+const defaultScope = {
+  organization: "All",
+  status: ["In Progress" as const],
+  dataCommons: "All",
+  name: "",
+  dbGaPID: "",
+  submitterName: "All",
+  sortDirection: "desc" as const,
+  orderBy: "updatedAt",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockDownloadBlob.mockReset();
+  mockFetchAllData.mockReset();
+  mockFetchAllData.mockResolvedValue(mockSubmissions);
+
+  mockUseAuthContext.mockReturnValue(
+    authCtxStateFactory.build({
+      user: userFactory.build({
+        _id: "test-user",
+        role: "Admin",
+        permissions: ["data_submission:view"],
+      }),
+      status: AuthStatus.LOADED,
+      isLoggedIn: true,
+    })
+  );
+});
+
+describe("Accessibility", () => {
+  it("should have no accessibility violations", async () => {
+    const { container } = render(<ExportSubmissionsButton scope={defaultScope} hasData />, {
+      wrapper: ({ children }) => <MockParent mocks={[listSubmissionsMock]}>{children}</MockParent>,
+    });
+
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it("should have no accessibility violations (disabled)", async () => {
+    const { container, getByTestId } = render(
+      <ExportSubmissionsButton scope={defaultScope} hasData={false} />,
+      {
+        wrapper: ({ children }) => (
+          <MockParent mocks={[listSubmissionsMock]}>{children}</MockParent>
+        ),
+      }
+    );
+
+    expect(getByTestId("export-data-submissions-button")).toBeDisabled();
+
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});
+
+describe("Basic Functionality", () => {
+  it("should render without crashing", () => {
+    const { getByTestId } = render(<ExportSubmissionsButton scope={defaultScope} hasData />, {
+      wrapper: ({ children }) => <MockParent mocks={[listSubmissionsMock]}>{children}</MockParent>,
+    });
+
+    expect(getByTestId("export-data-submissions-button")).toBeInTheDocument();
+  });
+
+  it("should be disabled when hasData is false", () => {
+    const { getByTestId } = render(
+      <ExportSubmissionsButton scope={defaultScope} hasData={false} />,
+      {
+        wrapper: ({ children }) => (
+          <MockParent mocks={[listSubmissionsMock]}>{children}</MockParent>
+        ),
+      }
+    );
+
+    expect(getByTestId("export-data-submissions-button")).toBeDisabled();
+  });
+
+  it("should be enabled when hasData is true", () => {
+    const { getByTestId } = render(<ExportSubmissionsButton scope={defaultScope} hasData />, {
+      wrapper: ({ children }) => <MockParent mocks={[listSubmissionsMock]}>{children}</MockParent>,
+    });
+
+    expect(getByTestId("export-data-submissions-button")).toBeEnabled();
+  });
+
+  it("should invoke fetchAllData with correct parameters", async () => {
+    const { getByTestId } = render(<ExportSubmissionsButton scope={defaultScope} hasData />, {
+      wrapper: ({ children }) => <MockParent mocks={[listSubmissionsMock]}>{children}</MockParent>,
+    });
+
+    const exportButton = getByTestId("export-data-submissions-button");
+
+    userEvent.click(exportButton);
+
+    await waitFor(() => {
+      expect(mockFetchAllData).toHaveBeenCalledTimes(1);
+    });
+
+    const [, scope] = mockFetchAllData.mock.calls[0];
+    expect(scope).toEqual(defaultScope);
+  });
+});
+
+describe("Implementation Requirements", () => {
+  it("should have a tooltip with correct text when enabled", async () => {
+    const { getByTestId, findByRole } = render(
+      <ExportSubmissionsButton scope={defaultScope} hasData />,
+      {
+        wrapper: ({ children }) => (
+          <MockParent mocks={[listSubmissionsMock]}>{children}</MockParent>
+        ),
+      }
+    );
+
+    userEvent.hover(getByTestId("export-data-submissions-button"));
+
+    const tooltip = await findByRole("tooltip");
+    expect(tooltip).toHaveTextContent("Export the current list of Data Submissions to CSV.");
+
+    userEvent.unhover(getByTestId("export-data-submissions-button"));
+
+    await waitFor(() => {
+      expect(tooltip).not.toBeInTheDocument();
+    });
+  });
+
+  it("should have a tooltip with correct text when disabled", async () => {
+    const { getByTestId, findByRole } = render(
+      <ExportSubmissionsButton scope={defaultScope} hasData={false} />,
+      {
+        wrapper: ({ children }) => (
+          <MockParent mocks={[listSubmissionsMock]}>{children}</MockParent>
+        ),
+      }
+    );
+
+    userEvent.hover(getByTestId("export-data-submissions-tooltip"));
+
+    const tooltip = await findByRole("tooltip");
+    expect(tooltip).toHaveTextContent("No results to export.");
+
+    userEvent.unhover(getByTestId("export-data-submissions-tooltip"));
+
+    await waitFor(() => {
+      expect(tooltip).not.toBeInTheDocument();
+    });
+  });
+
+  it("should be disabled while downloading", async () => {
+    mockFetchAllData.mockImplementation(() => new Promise(() => {}));
+
+    const { getByTestId } = render(<ExportSubmissionsButton scope={defaultScope} hasData />, {
+      wrapper: ({ children }) => <MockParent mocks={[listSubmissionsMock]}>{children}</MockParent>,
+    });
+
+    const button = getByTestId("export-data-submissions-button");
+
+    expect(button).toBeEnabled();
+
+    userEvent.click(button);
+
+    await waitFor(() => {
+      expect(button).toBeDisabled();
+    });
+  });
+
+  it("should download the CSV with the correct filename format", async () => {
+    const { getByTestId } = render(<ExportSubmissionsButton scope={defaultScope} hasData />, {
+      wrapper: ({ children }) => <MockParent mocks={[listSubmissionsMock]}>{children}</MockParent>,
+    });
+
+    userEvent.click(getByTestId("export-data-submissions-button"));
+
+    await waitFor(() => {
+      expect(mockDownloadBlob).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.stringMatching(/^crdc-data-submissions-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}\.csv$/),
+        "text/csv;charset=utf-8;"
+      );
+    });
+  });
+
+  it("should format CSV data correctly", async () => {
+    const { getByTestId } = render(<ExportSubmissionsButton scope={defaultScope} hasData />, {
+      wrapper: ({ children }) => <MockParent mocks={[listSubmissionsMock]}>{children}</MockParent>,
+    });
+
+    userEvent.click(getByTestId("export-data-submissions-button"));
+
+    await waitFor(() => {
+      expect(mockDownloadBlob).toHaveBeenCalled();
+    });
+
+    const csvContent = mockDownloadBlob.mock.calls[0][0];
+
+    expect(csvContent).toContain("Submission Name");
+    expect(csvContent).toContain("Submitter");
+    expect(csvContent).toContain("Data Commons");
+    expect(csvContent).toContain("Program");
+    expect(csvContent).toContain("Study");
+    expect(csvContent).toContain("Status");
+    expect(csvContent).toContain("Record Count");
+    expect(csvContent).toContain("Data File Size");
+    expect(csvContent).toContain("Submission 0");
+    expect(csvContent).toContain("Submitter 0");
+  });
+
+  it("should not be visible for users without data_submission view permission", () => {
+    mockUseAuthContext.mockReturnValue({
+      user: userFactory.build({
+        _id: "test-user",
+        role: "Submitter",
+        permissions: [],
+      }),
+      status: AuthStatus.LOADED,
+      isLoggedIn: true,
+    });
+
+    const { queryByTestId } = render(<ExportSubmissionsButton scope={defaultScope} hasData />, {
+      wrapper: ({ children }) => <MockParent mocks={[listSubmissionsMock]}>{children}</MockParent>,
+    });
+
+    expect(queryByTestId("export-data-submissions-button")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/ExportSubmissionsButton/index.test.tsx
+++ b/src/components/ExportSubmissionsButton/index.test.tsx
@@ -11,8 +11,11 @@ import { LIST_SUBMISSIONS, ListSubmissionsInput, ListSubmissionsResp } from "@/g
 import { render, waitFor } from "@/test-utils";
 
 import { Status as AuthStatus, useAuthContext } from "../Contexts/AuthContext";
+import { Column } from "../GenericTable";
 
 import ExportSubmissionsButton from "./index";
+
+type Submission = ListSubmissionsResp["listSubmissions"]["submissions"][number];
 
 const mockDownloadBlob = vi.fn();
 const mockFetchAllData = vi.fn();
@@ -91,6 +94,93 @@ const defaultScope = {
   orderBy: "updatedAt",
 };
 
+const defaultColumns: Column<Submission>[] = [
+  {
+    label: "Submission Name",
+    renderValue: (a) => a.name,
+    field: "name",
+    exportValue: (a) => ({ label: "Submission Name", value: a.name }),
+  },
+  {
+    label: "Submitter",
+    renderValue: (a) => a.submitterName,
+    field: "submitterName",
+    exportValue: (a) => ({ label: "Submitter", value: a.submitterName }),
+  },
+  {
+    label: "Data Commons",
+    renderValue: (a) => a.dataCommonsDisplayName,
+    field: "dataCommonsDisplayName",
+    exportValue: (a) => ({ label: "Data Commons", value: a.dataCommonsDisplayName }),
+  },
+  {
+    label: "Type",
+    renderValue: (a) => a.intention,
+    field: "intention",
+    exportValue: (a) => ({ label: "Type", value: a.intention }),
+  },
+  {
+    label: "Model Version",
+    renderValue: (a) => a.modelVersion,
+    field: "modelVersion",
+    exportValue: (a) => ({ label: "Model Version", value: a.modelVersion }),
+  },
+  {
+    label: "Program",
+    renderValue: (a) => a.organization?.name ?? "NA",
+    fieldKey: "organization.name",
+    exportValue: (a) => ({ label: "Program", value: a.organization?.name ?? "" }),
+  },
+  {
+    label: "Study",
+    renderValue: (a) => a.studyAbbreviation,
+    field: "studyAbbreviation",
+    exportValue: (a) => ({ label: "Study", value: a.studyAbbreviation }),
+  },
+  {
+    label: "dbGaP ID",
+    renderValue: (a) => a.dbGaPID,
+    field: "dbGaPID",
+    exportValue: (a) => ({ label: "dbGaP ID", value: a.dbGaPID }),
+  },
+  {
+    label: "Status",
+    renderValue: (a) => a.status,
+    field: "status",
+    exportValue: (a) => ({ label: "Status", value: a.status }),
+  },
+  {
+    label: "Data Concierge",
+    renderValue: (a) => a.conciergeName,
+    field: "conciergeName",
+    exportValue: (a) => ({ label: "Data Concierge", value: a.conciergeName }),
+  },
+  {
+    label: "Record Count",
+    renderValue: (a) => a.nodeCount,
+    field: "nodeCount",
+    exportValue: (a) => ({ label: "Record Count", value: a.nodeCount }),
+  },
+  {
+    label: "Data File Size",
+    renderValue: (a) => a.dataFileSize.formatted,
+    fieldKey: "dataFileSize.size",
+    exportValue: (a) => ({ label: "Data File Size", value: a.dataFileSize.formatted }),
+  },
+  {
+    label: "Created Date",
+    renderValue: (a) => a.createdAt,
+    field: "createdAt",
+    exportValue: (a) => ({ label: "Created Date", value: a.createdAt }),
+  },
+  {
+    label: "Last Updated",
+    renderValue: (a) => a.updatedAt,
+    field: "updatedAt",
+    exportValue: (a) => ({ label: "Last Updated", value: a.updatedAt }),
+  },
+];
+
 beforeEach(() => {
   vi.clearAllMocks();
   mockDownloadBlob.mockReset();
@@ -112,16 +202,25 @@ beforeEach(() => {
 
 describe("Accessibility", () => {
   it("should have no accessibility violations", async () => {
-    const { container } = render(<ExportSubmissionsButton scope={defaultScope} hasData />, {
-      wrapper: ({ children }) => <MockParent mocks={[listSubmissionsMock]}>{children}</MockParent>,
-    });
+    const { container } = render(
+      <ExportSubmissionsButton scope={defaultScope} hasData visibleColumns={defaultColumns} />,
+      {
+        wrapper: ({ children }) => (
+          <MockParent mocks={[listSubmissionsMock]}>{children}</MockParent>
+        ),
+      }
+    );
 
     expect(await axe(container)).toHaveNoViolations();
   });
 
   it("should have no accessibility violations (disabled)", async () => {
     const { container, getByTestId } = render(
-      <ExportSubmissionsButton scope={defaultScope} hasData={false} />,
+      <ExportSubmissionsButton
+        scope={defaultScope}
+        hasData={false}
+        visibleColumns={defaultColumns}
+      />,
       {
         wrapper: ({ children }) => (
           <MockParent mocks={[listSubmissionsMock]}>{children}</MockParent>
@@ -137,16 +236,25 @@ describe("Accessibility", () => {
 
 describe("Basic Functionality", () => {
   it("should render without crashing", () => {
-    const { getByTestId } = render(<ExportSubmissionsButton scope={defaultScope} hasData />, {
-      wrapper: ({ children }) => <MockParent mocks={[listSubmissionsMock]}>{children}</MockParent>,
-    });
+    const { getByTestId } = render(
+      <ExportSubmissionsButton scope={defaultScope} hasData visibleColumns={defaultColumns} />,
+      {
+        wrapper: ({ children }) => (
+          <MockParent mocks={[listSubmissionsMock]}>{children}</MockParent>
+        ),
+      }
+    );
 
     expect(getByTestId("export-data-submissions-button")).toBeInTheDocument();
   });
 
   it("should be disabled when hasData is false", () => {
     const { getByTestId } = render(
-      <ExportSubmissionsButton scope={defaultScope} hasData={false} />,
+      <ExportSubmissionsButton
+        scope={defaultScope}
+        hasData={false}
+        visibleColumns={defaultColumns}
+      />,
       {
         wrapper: ({ children }) => (
           <MockParent mocks={[listSubmissionsMock]}>{children}</MockParent>
@@ -158,17 +266,27 @@ describe("Basic Functionality", () => {
   });
 
   it("should be enabled when hasData is true", () => {
-    const { getByTestId } = render(<ExportSubmissionsButton scope={defaultScope} hasData />, {
-      wrapper: ({ children }) => <MockParent mocks={[listSubmissionsMock]}>{children}</MockParent>,
-    });
+    const { getByTestId } = render(
+      <ExportSubmissionsButton scope={defaultScope} hasData visibleColumns={defaultColumns} />,
+      {
+        wrapper: ({ children }) => (
+          <MockParent mocks={[listSubmissionsMock]}>{children}</MockParent>
+        ),
+      }
+    );
 
     expect(getByTestId("export-data-submissions-button")).toBeEnabled();
   });
 
   it("should invoke fetchAllData with correct parameters", async () => {
-    const { getByTestId } = render(<ExportSubmissionsButton scope={defaultScope} hasData />, {
-      wrapper: ({ children }) => <MockParent mocks={[listSubmissionsMock]}>{children}</MockParent>,
-    });
+    const { getByTestId } = render(
+      <ExportSubmissionsButton scope={defaultScope} hasData visibleColumns={defaultColumns} />,
+      {
+        wrapper: ({ children }) => (
+          <MockParent mocks={[listSubmissionsMock]}>{children}</MockParent>
+        ),
+      }
+    );
 
     const exportButton = getByTestId("export-data-submissions-button");
 
@@ -186,7 +304,7 @@ describe("Basic Functionality", () => {
 describe("Implementation Requirements", () => {
   it("should have a tooltip with correct text when enabled", async () => {
     const { getByTestId, findByRole } = render(
-      <ExportSubmissionsButton scope={defaultScope} hasData />,
+      <ExportSubmissionsButton scope={defaultScope} hasData visibleColumns={defaultColumns} />,
       {
         wrapper: ({ children }) => (
           <MockParent mocks={[listSubmissionsMock]}>{children}</MockParent>
@@ -208,7 +326,11 @@ describe("Implementation Requirements", () => {
 
   it("should have a tooltip with correct text when disabled", async () => {
     const { getByTestId, findByRole } = render(
-      <ExportSubmissionsButton scope={defaultScope} hasData={false} />,
+      <ExportSubmissionsButton
+        scope={defaultScope}
+        hasData={false}
+        visibleColumns={defaultColumns}
+      />,
       {
         wrapper: ({ children }) => (
           <MockParent mocks={[listSubmissionsMock]}>{children}</MockParent>
@@ -231,9 +353,14 @@ describe("Implementation Requirements", () => {
   it("should be disabled while downloading", async () => {
     mockFetchAllData.mockImplementation(() => new Promise(() => {}));
 
-    const { getByTestId } = render(<ExportSubmissionsButton scope={defaultScope} hasData />, {
-      wrapper: ({ children }) => <MockParent mocks={[listSubmissionsMock]}>{children}</MockParent>,
-    });
+    const { getByTestId } = render(
+      <ExportSubmissionsButton scope={defaultScope} hasData visibleColumns={defaultColumns} />,
+      {
+        wrapper: ({ children }) => (
+          <MockParent mocks={[listSubmissionsMock]}>{children}</MockParent>
+        ),
+      }
+    );
 
     const button = getByTestId("export-data-submissions-button");
 
@@ -247,9 +374,14 @@ describe("Implementation Requirements", () => {
   });
 
   it("should download the CSV with the correct filename format", async () => {
-    const { getByTestId } = render(<ExportSubmissionsButton scope={defaultScope} hasData />, {
-      wrapper: ({ children }) => <MockParent mocks={[listSubmissionsMock]}>{children}</MockParent>,
-    });
+    const { getByTestId } = render(
+      <ExportSubmissionsButton scope={defaultScope} hasData visibleColumns={defaultColumns} />,
+      {
+        wrapper: ({ children }) => (
+          <MockParent mocks={[listSubmissionsMock]}>{children}</MockParent>
+        ),
+      }
+    );
 
     userEvent.click(getByTestId("export-data-submissions-button"));
 
@@ -263,9 +395,14 @@ describe("Implementation Requirements", () => {
   });
 
   it("should format CSV data correctly", async () => {
-    const { getByTestId } = render(<ExportSubmissionsButton scope={defaultScope} hasData />, {
-      wrapper: ({ children }) => <MockParent mocks={[listSubmissionsMock]}>{children}</MockParent>,
-    });
+    const { getByTestId } = render(
+      <ExportSubmissionsButton scope={defaultScope} hasData visibleColumns={defaultColumns} />,
+      {
+        wrapper: ({ children }) => (
+          <MockParent mocks={[listSubmissionsMock]}>{children}</MockParent>
+        ),
+      }
+    );
 
     userEvent.click(getByTestId("export-data-submissions-button"));
 
@@ -298,10 +435,56 @@ describe("Implementation Requirements", () => {
       isLoggedIn: true,
     });
 
-    const { queryByTestId } = render(<ExportSubmissionsButton scope={defaultScope} hasData />, {
-      wrapper: ({ children }) => <MockParent mocks={[listSubmissionsMock]}>{children}</MockParent>,
-    });
+    const { queryByTestId } = render(
+      <ExportSubmissionsButton scope={defaultScope} hasData visibleColumns={defaultColumns} />,
+      {
+        wrapper: ({ children }) => (
+          <MockParent mocks={[listSubmissionsMock]}>{children}</MockParent>
+        ),
+      }
+    );
 
     expect(queryByTestId("export-data-submissions-button")).not.toBeInTheDocument();
+  });
+
+  it("should only export columns provided in the columns prop", async () => {
+    const visibleColumns: Column<Submission>[] = [
+      {
+        label: "Submission Name",
+        renderValue: (a) => a.name,
+        field: "name",
+        exportValue: (a) => ({ label: "Submission Name", value: a.name }),
+      },
+      {
+        label: "Status",
+        renderValue: (a) => a.status,
+        field: "status",
+        exportValue: (a) => ({ label: "Status", value: a.status }),
+      },
+    ];
+
+    const { getByTestId } = render(
+      <ExportSubmissionsButton scope={defaultScope} hasData visibleColumns={visibleColumns} />,
+      {
+        wrapper: ({ children }) => (
+          <MockParent mocks={[listSubmissionsMock]}>{children}</MockParent>
+        ),
+      }
+    );
+
+    userEvent.click(getByTestId("export-data-submissions-button"));
+
+    await waitFor(() => {
+      expect(mockDownloadBlob).toHaveBeenCalled();
+    });
+
+    const csvContent = mockDownloadBlob.mock.calls[0][0];
+
+    expect(csvContent).toContain("Submission Name");
+    expect(csvContent).toContain("Status");
+
+    expect(csvContent).not.toContain("Submitter");
+    expect(csvContent).not.toContain("Data Commons");
+    expect(csvContent).not.toContain("Program");
   });
 });

--- a/src/components/ExportSubmissionsButton/index.tsx
+++ b/src/components/ExportSubmissionsButton/index.tsx
@@ -1,0 +1,147 @@
+import { useLazyQuery } from "@apollo/client";
+import { CloudDownload } from "@mui/icons-material";
+import { IconButton, IconButtonProps, Stack, styled } from "@mui/material";
+import dayjs from "dayjs";
+import { useSnackbar } from "notistack";
+import { unparse } from "papaparse";
+import { memo, useMemo, useState } from "react";
+
+import StyledFormTooltip from "@/components/StyledFormComponents/StyledTooltip";
+import { hasPermission } from "@/config/AuthPermissions";
+import { LIST_SUBMISSIONS, ListSubmissionsInput, ListSubmissionsResp } from "@/graphql";
+import { downloadBlob, fetchAllData, FormatDate, Logger } from "@/utils";
+
+import { useAuthContext } from "../Contexts/AuthContext";
+
+const StyledIconButton = styled(IconButton)({
+  color: "#606060",
+});
+
+const StyledTooltip = styled(StyledFormTooltip)({
+  "& .MuiTooltip-tooltip": {
+    color: "#000000",
+  },
+});
+
+export type Props = {
+  /**
+   * Provides the contextually relevant scope of the export.
+   */
+  scope: Partial<ListSubmissionsInput> & Omit<ListSubmissionsInput, "first" | "offset">;
+  /**
+   * Whether there is data available to export.
+   */
+  hasData: boolean;
+} & IconButtonProps;
+
+/**
+ * Provides the button and supporting functionality to export the data submissions list to CSV.
+ */
+const ExportSubmissionsButton: React.FC<Props> = ({ scope, hasData, ...buttonProps }: Props) => {
+  const { enqueueSnackbar } = useSnackbar();
+  const { user } = useAuthContext();
+
+  const [loading, setLoading] = useState<boolean>(false);
+
+  const tooltip = useMemo<string>(
+    () =>
+      !hasData ? "No results to export." : "Export the current list of Data Submissions to CSV.",
+    [hasData]
+  );
+
+  const [listSubmissions] = useLazyQuery<ListSubmissionsResp, ListSubmissionsInput>(
+    LIST_SUBMISSIONS,
+    {
+      context: { clientName: "backend" },
+      fetchPolicy: "no-cache",
+    }
+  );
+
+  const handleExport = async () => {
+    setLoading(true);
+
+    enqueueSnackbar("Downloading the requested CSV file. This may take a moment...", {
+      variant: "default",
+    });
+
+    try {
+      const data = await fetchAllData<
+        ListSubmissionsResp,
+        ListSubmissionsInput,
+        ListSubmissionsResp["listSubmissions"]["submissions"][number]
+      >(
+        listSubmissions,
+        scope,
+        (data) => data.listSubmissions.submissions,
+        (data) => data.listSubmissions.total,
+        { pageSize: 1000, total: Infinity }
+      );
+
+      if (!data?.length) {
+        throw new Error("No data returned from fetch");
+      }
+
+      const filename = `crdc-data-submissions-${dayjs().format("YYYY-MM-DD-HH-mm-ss")}.csv`;
+
+      const csvArray = data.map((submission) => ({
+        "Submission Name": submission.name,
+        Submitter: submission.submitterName,
+        "Data Commons": submission.dataCommonsDisplayName,
+        Type: submission.intention,
+        "Model Version": submission.modelVersion,
+        Program: submission.organization?.name ?? "NA",
+        Study: submission.studyAbbreviation,
+        "dbGaP ID": submission.dbGaPID,
+        Status: submission.status,
+        "Data Concierge": submission.conciergeName,
+        "Record Count": Intl.NumberFormat("en-US", { maximumFractionDigits: 0 }).format(
+          submission.nodeCount || 0
+        ),
+        "Data File Size": submission.dataFileSize.formatted || 0,
+        "Created Date": submission.createdAt
+          ? FormatDate(submission.createdAt, "M/D/YYYY h:mm A")
+          : "",
+        "Last Updated": submission.updatedAt
+          ? FormatDate(submission.updatedAt, "M/D/YYYY h:mm A")
+          : "",
+      }));
+
+      downloadBlob(unparse(csvArray, { quotes: true }), filename, "text/csv;charset=utf-8;");
+
+      enqueueSnackbar("CSV file downloaded successfully.", {
+        variant: "success",
+      });
+    } catch (err) {
+      Logger.error("Error during data submissions CSV generation", err);
+      enqueueSnackbar("Failed to generate the CSV file.", {
+        variant: "error",
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!hasPermission(user, "data_submission", "view", null, true)) {
+    return null;
+  }
+
+  return (
+    <Stack direction="row" alignItems="center" gap="8px" marginRight="37px">
+      <StyledTooltip title={tooltip} data-testid="export-data-submissions-tooltip">
+        <span>
+          <StyledIconButton
+            onClick={handleExport}
+            disabled={!hasData || loading}
+            aria-label="Export data submissions button"
+            data-testid="export-data-submissions-button"
+            {...buttonProps}
+          >
+            <CloudDownload />
+          </StyledIconButton>
+        </span>
+      </StyledTooltip>
+    </Stack>
+  );
+};
+
+export default memo<Props>(ExportSubmissionsButton);

--- a/src/components/ExportSubmissionsButton/index.tsx
+++ b/src/components/ExportSubmissionsButton/index.tsx
@@ -2,7 +2,6 @@ import { useLazyQuery } from "@apollo/client";
 import { CloudDownload } from "@mui/icons-material";
 import { IconButton, IconButtonProps, Stack, styled } from "@mui/material";
 import dayjs from "dayjs";
-import { useSnackbar } from "notistack";
 import { unparse } from "papaparse";
 import { memo, useMemo, useState } from "react";
 
@@ -38,7 +37,6 @@ export type Props = {
  * Provides the button and supporting functionality to export the data submissions list to CSV.
  */
 const ExportSubmissionsButton: React.FC<Props> = ({ scope, hasData, ...buttonProps }: Props) => {
-  const { enqueueSnackbar } = useSnackbar();
   const { user } = useAuthContext();
 
   const [loading, setLoading] = useState<boolean>(false);
@@ -59,10 +57,6 @@ const ExportSubmissionsButton: React.FC<Props> = ({ scope, hasData, ...buttonPro
 
   const handleExport = async () => {
     setLoading(true);
-
-    enqueueSnackbar("Downloading the requested CSV file. This may take a moment...", {
-      variant: "default",
-    });
 
     try {
       const data = await fetchAllData<
@@ -107,15 +101,8 @@ const ExportSubmissionsButton: React.FC<Props> = ({ scope, hasData, ...buttonPro
       }));
 
       downloadBlob(unparse(csvArray, { quotes: true }), filename, "text/csv;charset=utf-8;");
-
-      enqueueSnackbar("CSV file downloaded successfully.", {
-        variant: "success",
-      });
     } catch (err) {
       Logger.error("Error during data submissions CSV generation", err);
-      enqueueSnackbar("Failed to generate the CSV file.", {
-        variant: "error",
-      });
     } finally {
       setLoading(false);
     }

--- a/src/components/GenericTable/index.tsx
+++ b/src/components/GenericTable/index.tsx
@@ -147,6 +147,10 @@ export type Column<T> = {
    * Custom styling for the header table cell of the column
    */
   sx?: TableCellProps["sx"];
+  /**
+   * Define how the column label and value should be exported
+   */
+  exportValue?: (a: T) => { label: string; value: string | number };
 };
 
 export type Props<T> = {

--- a/src/content/dataSubmissions/DataSubmissionsListView.tsx
+++ b/src/content/dataSubmissions/DataSubmissionsListView.tsx
@@ -104,6 +104,7 @@ const columns: Column<T>[] = [
       ),
     field: "name",
     hideable: false,
+    exportValue: (a) => ({ label: "Submission Name", value: a.name }),
     sx: {
       width: "139px",
     },
@@ -113,6 +114,7 @@ const columns: Column<T>[] = [
     renderValue: (a) => <TruncatedText text={a.submitterName} />,
     field: "submitterName",
     hideable: true,
+    exportValue: (a) => ({ label: "Submitter", value: a.submitterName }),
     sx: {
       width: "102px",
     },
@@ -122,6 +124,7 @@ const columns: Column<T>[] = [
     renderValue: (a) => a.dataCommonsDisplayName,
     field: "dataCommonsDisplayName",
     hideable: true,
+    exportValue: (a) => ({ label: "Data Commons", value: a.dataCommonsDisplayName }),
     sx: {
       width: "94px",
     },
@@ -131,6 +134,7 @@ const columns: Column<T>[] = [
     renderValue: (a) => a.intention,
     field: "intention",
     hideable: true,
+    exportValue: (a) => ({ label: "Type", value: a.intention }),
     sx: {
       width: "96px",
     },
@@ -140,6 +144,7 @@ const columns: Column<T>[] = [
     renderValue: (a) => <NavigatorLink submission={a} />,
     field: "modelVersion",
     hideable: true,
+    exportValue: (a) => ({ label: "Model Version", value: a.modelVersion }),
     sx: {
       width: "79px",
     },
@@ -148,12 +153,14 @@ const columns: Column<T>[] = [
     label: "Program",
     renderValue: (a) => <TruncatedText text={a.organization?.name ?? "NA"} />,
     fieldKey: "organization.name",
+    exportValue: (a) => ({ label: "Program", value: a.organization?.name ?? "NA" }),
   },
   {
     label: "Study",
     renderValue: (a) => <TruncatedText text={a.studyAbbreviation} />,
     field: "studyAbbreviation",
     hideable: false,
+    exportValue: (a) => ({ label: "Study", value: a.studyAbbreviation }),
   },
 
   {
@@ -161,6 +168,7 @@ const columns: Column<T>[] = [
     renderValue: (a) => <TruncatedText text={a.dbGaPID} maxCharacters={15} />,
     field: "dbGaPID",
     hideable: true,
+    exportValue: (a) => ({ label: "dbGaP ID", value: a.dbGaPID }),
   },
 
   {
@@ -175,6 +183,7 @@ const columns: Column<T>[] = [
       ),
     field: "status",
     hideable: false,
+    exportValue: (a) => ({ label: "Status", value: a.status }),
     sx: {
       width: "87px",
     },
@@ -184,12 +193,17 @@ const columns: Column<T>[] = [
     renderValue: (a) => <TruncatedText text={a.conciergeName} />,
     field: "conciergeName",
     hideable: true,
+    exportValue: (a) => ({ label: "Data Concierge", value: a.conciergeName }),
   },
   {
     label: "Record Count",
     renderValue: (a) =>
       Intl.NumberFormat("en-US", { maximumFractionDigits: 0 }).format(a.nodeCount || 0),
     field: "nodeCount",
+    exportValue: (a) => ({
+      label: "Record Count",
+      value: Intl.NumberFormat("en-US", { maximumFractionDigits: 0 }).format(a.nodeCount || 0),
+    }),
   },
   {
     label: "Data File Size",
@@ -197,6 +211,7 @@ const columns: Column<T>[] = [
     hideable: true,
     defaultHidden: true,
     fieldKey: "dataFileSize.size",
+    exportValue: (a) => ({ label: "Data File Size", value: a.dataFileSize.formatted || 0 }),
     sx: {
       minWidth: "90px",
       width: "90px",
@@ -214,6 +229,10 @@ const columns: Column<T>[] = [
       ),
     field: "createdAt",
     hideable: true,
+    exportValue: (a) => ({
+      label: "Created Date",
+      value: a.createdAt ? FormatDate(a.createdAt, "M/D/YYYY h:mm A") : "",
+    }),
     sx: {
       width: "92px",
     },
@@ -231,6 +250,10 @@ const columns: Column<T>[] = [
     field: "updatedAt",
     hideable: true,
     default: true,
+    exportValue: (a) => ({
+      label: "Last Updated",
+      value: a.updatedAt ? FormatDate(a.updatedAt, "M/D/YYYY h:mm A") : "",
+    }),
     sx: {
       width: "108px",
     },
@@ -384,8 +407,14 @@ const ListingView: FC = () => {
       ...tableRef.current?.tableParams,
     };
 
-    return <DataSubmissionListExport scope={scope} hasData={totalData > 0} />;
-  }, [filtersRef.current, tableRef.current?.tableParams, totalData]);
+    return (
+      <DataSubmissionListExport
+        scope={scope}
+        hasData={totalData > 0}
+        visibleColumns={visibleColumns}
+      />
+    );
+  }, [filtersRef.current, tableRef.current?.tableParams, totalData, visibleColumns]);
 
   return (
     <>

--- a/src/content/dataSubmissions/DataSubmissionsListView.tsx
+++ b/src/content/dataSubmissions/DataSubmissionsListView.tsx
@@ -2,8 +2,10 @@ import { useLazyQuery } from "@apollo/client";
 import { Alert, Container, Stack, styled, TableCell, TableHead, Box } from "@mui/material";
 import { isEqual } from "lodash";
 import { useSnackbar } from "notistack";
-import React, { FC, useRef, useState } from "react";
+import React, { FC, useMemo, useRef, useState } from "react";
 import { Link, useLocation } from "react-router-dom";
+
+import DataSubmissionListExport from "@/components/ExportSubmissionsButton";
 
 import bannerSvg from "../../assets/banner/submission_banner.png";
 import { useAuthContext, Status as AuthStatus } from "../../components/Contexts/AuthContext";
@@ -377,6 +379,16 @@ const ListingView: FC = () => {
     setTablePage(0);
   };
 
+  const exportScope = {
+    ...filtersRef.current,
+    ...tableRef.current?.tableParams,
+  };
+
+  const Actions = useMemo<React.ReactNode>(
+    () => <DataSubmissionListExport scope={exportScope} hasData={totalData > 0} />,
+    [exportScope, totalData]
+  );
+
   return (
     <>
       <PageBanner
@@ -417,7 +429,7 @@ const ListingView: FC = () => {
             defaultRowsPerPage={20}
             defaultOrder="desc"
             disableUrlParams={false}
-            position="bottom"
+            position="both"
             noContentText="You either do not have the appropriate permissions to view data submissions, or there are no data submissions associated with your account."
             onFetchData={handleFetchData}
             containerProps={{
@@ -426,7 +438,12 @@ const ListingView: FC = () => {
                 border: 0,
                 borderTopLeftRadius: 0,
                 borderTopRightRadius: 0,
+                borderTop: "1px solid #6CACDA",
               },
+            }}
+            AdditionalActions={{
+              top: { after: Actions },
+              bottom: { after: Actions },
             }}
             CustomTableHead={StyledTableHead}
             CustomTableHeaderCell={StyledHeaderCell}

--- a/src/content/dataSubmissions/DataSubmissionsListView.tsx
+++ b/src/content/dataSubmissions/DataSubmissionsListView.tsx
@@ -378,16 +378,14 @@ const ListingView: FC = () => {
     filtersRef.current = { ...data };
     setTablePage(0);
   };
+  const Actions = useMemo<React.ReactNode>(() => {
+    const scope = {
+      ...filtersRef.current,
+      ...tableRef.current?.tableParams,
+    };
 
-  const exportScope = {
-    ...filtersRef.current,
-    ...tableRef.current?.tableParams,
-  };
-
-  const Actions = useMemo<React.ReactNode>(
-    () => <DataSubmissionListExport scope={exportScope} hasData={totalData > 0} />,
-    [exportScope, totalData]
-  );
+    return <DataSubmissionListExport scope={scope} hasData={totalData > 0} />;
+  }, [filtersRef.current, tableRef.current?.tableParams, totalData]);
 
   return (
     <>


### PR DESCRIPTION
### Overview

Added ability to export/download Data Submissions from list page given the current table filters/sorting

### Change Details (Specifics)

- Added pagination and export button to top of DS list table
- Applied current filters and table sorting when retrieving exported results
- The exported results will return all results in batches of 1,000 for future proofing
- Included tooltips as well snackbar popups to match other implementation
- Added test and storybook support

### Related Ticket(s)

[CRDCDH-3441](https://tracker.nci.nih.gov/browse/CRDCDH-3441) (Task)
[CRDCDH-3425](https://tracker.nci.nih.gov/browse/CRDCDH-3425) (US)
