### PR TITLE
CRDCDH-3488 Data View Deletion with Filters Applied

### DIFF
--- a/src/components/DataSubmissions/DeleteNodeDataButton.test.tsx
+++ b/src/components/DataSubmissions/DeleteNodeDataButton.test.tsx
@@ -69,7 +69,7 @@ const TestParent: React.FC<TestParentProps> = ({
 describe("Accessibility", () => {
   it("should have no violations for DeleteNodeDataButton component", async () => {
     const { container, getByTestId } = render(
-      <Button nodeType="test" selectedItems={["ID_1", "ID_2", "ID_3"]} />,
+      <Button nodeType="test" selectedItems={["ID_1", "ID_2", "ID_3"]} selectType="explicit" />,
       { wrapper: TestParent }
     );
 
@@ -78,9 +78,12 @@ describe("Accessibility", () => {
   });
 
   it("should have no violations for DeleteNodeDataButton component when disabled", async () => {
-    const { container, getByTestId } = render(<Button nodeType="test" selectedItems={[]} />, {
-      wrapper: TestParent,
-    });
+    const { container, getByTestId } = render(
+      <Button nodeType="test" selectedItems={[]} selectType="explicit" />,
+      {
+        wrapper: TestParent,
+      }
+    );
 
     expect(getByTestId("delete-node-data-button")).toBeDisabled(); // Sanity check to ensure the button is disabled
     expect(await axe(container)).toHaveNoViolations();
@@ -94,7 +97,9 @@ describe("Basic Functionality", () => {
 
   it("should render without crashing", () => {
     expect(() =>
-      render(<Button nodeType="" selectedItems={[]} />, { wrapper: TestParent })
+      render(<Button nodeType="" selectedItems={[]} selectType="explicit" />, {
+        wrapper: TestParent,
+      })
     ).not.toThrow();
   });
 
@@ -112,7 +117,7 @@ describe("Basic Functionality", () => {
     ];
 
     const { getByTestId, getByRole } = render(
-      <Button nodeType="test" selectedItems={["1 item ID"]} />,
+      <Button nodeType="test" selectedItems={["1 item ID"]} selectType="explicit" />,
       { wrapper: (props) => <TestParent {...props} mocks={mocks} /> }
     );
 
@@ -145,7 +150,7 @@ describe("Basic Functionality", () => {
     ];
 
     const { getByTestId, getByRole } = render(
-      <Button nodeType="test" selectedItems={["1 item ID"]} />,
+      <Button nodeType="test" selectedItems={["1 item ID"]} selectType="explicit" />,
       { wrapper: (props) => <TestParent {...props} mocks={mocks} /> }
     );
 
@@ -185,7 +190,7 @@ describe("Basic Functionality", () => {
     ];
 
     const { getByTestId, getByRole } = render(
-      <Button nodeType="test" selectedItems={["1 item ID"]} />,
+      <Button nodeType="test" selectedItems={["1 item ID"]} selectType="explicit" />,
       { wrapper: (props) => <TestParent {...props} mocks={mocks} /> }
     );
 
@@ -207,9 +212,12 @@ describe("Basic Functionality", () => {
   });
 
   it("should be disabled when there are no selected items", () => {
-    const { getByTestId } = render(<Button nodeType="fake-node" selectedItems={[]} />, {
-      wrapper: TestParent,
-    });
+    const { getByTestId } = render(
+      <Button nodeType="fake-node" selectedItems={[]} selectType="explicit" />,
+      {
+        wrapper: TestParent,
+      }
+    );
 
     expect(getByTestId("delete-node-data-button")).toBeDisabled();
   });
@@ -232,7 +240,7 @@ describe("Basic Functionality", () => {
           ],
         })}
       >
-        <Button nodeType="test" selectedItems={["ID_1", "ID_2", "ID_3"]} />,
+        <Button nodeType="test" selectedItems={["ID_1", "ID_2", "ID_3"]} selectType="explicit" />,
       </TestParent>
     );
 
@@ -259,7 +267,12 @@ describe("Basic Functionality", () => {
     ];
 
     const { getByTestId, getByRole } = render(
-      <Button nodeType="test" selectedItems={["1 item ID"]} onDelete={onDelete} />,
+      <Button
+        nodeType="test"
+        selectedItems={["1 item ID"]}
+        onDelete={onDelete}
+        selectType="explicit"
+      />,
       { wrapper: (props) => <TestParent {...props} mocks={mocks} /> }
     );
 
@@ -282,16 +295,19 @@ describe("Implementation Requirements", () => {
   });
 
   it("should be disabled when a deletion operation is in progress", () => {
-    const { getByTestId } = render(<Button nodeType="test" selectedItems={[]} />, {
-      wrapper: (props) => <TestParent {...props} submission={{ deletingData: true }} />,
-    });
+    const { getByTestId } = render(
+      <Button nodeType="test" selectedItems={[]} selectType="explicit" />,
+      {
+        wrapper: (props) => <TestParent {...props} submission={{ deletingData: true }} />,
+      }
+    );
 
     expect(getByTestId("delete-node-data-button")).toBeDisabled();
   });
 
   it("should have a tooltip on the delete button (enabled)", async () => {
     const { getByTestId, findByRole } = render(
-      <Button nodeType="test" selectedItems={["1 item ID"]} />,
+      <Button nodeType="test" selectedItems={["1 item ID"]} selectType="explicit" />,
       {
         wrapper: TestParent,
       }
@@ -316,7 +332,7 @@ describe("Implementation Requirements", () => {
     "should customize the tooltip text for metadata vs data files",
     async (nodeType, tooltipText) => {
       const { getByTestId, findByRole } = render(
-        <Button nodeType={nodeType} selectedItems={["1 item ID"]} />,
+        <Button nodeType={nodeType} selectedItems={["1 item ID"]} selectType="explicit" />,
         {
           wrapper: TestParent,
         }
@@ -331,9 +347,12 @@ describe("Implementation Requirements", () => {
   );
 
   it("should have a tooltip when the delete button is disabled with an ongoing deletion", async () => {
-    const { getByTestId, findByRole } = render(<Button nodeType="test" selectedItems={[]} />, {
-      wrapper: (props) => <TestParent {...props} submission={{ deletingData: true }} />,
-    });
+    const { getByTestId, findByRole } = render(
+      <Button nodeType="test" selectedItems={[]} selectType="explicit" />,
+      {
+        wrapper: (props) => <TestParent {...props} submission={{ deletingData: true }} />,
+      }
+    );
 
     // NOTE: Cannot hover a disabled button, pointing to the span instead
     userEvent.hover(getByTestId("delete-node-data-button").parentElement);
@@ -347,7 +366,7 @@ describe("Implementation Requirements", () => {
 
   it("should show a confirmation dialog when the 'Delete' icon is clicked", async () => {
     const { getByTestId, getByRole } = render(
-      <Button nodeType="test" selectedItems={["1 item ID"]} />,
+      <Button nodeType="test" selectedItems={["1 item ID"]} selectType="explicit" />,
       {
         wrapper: TestParent,
       }
@@ -380,7 +399,11 @@ describe("Implementation Requirements", () => {
     ];
 
     const { getByTestId, getByRole } = render(
-      <Button nodeType="test-node-type" selectedItems={["ID_1", "ID_2", "ID_3"]} />,
+      <Button
+        nodeType="test-node-type"
+        selectedItems={["ID_1", "ID_2", "ID_3"]}
+        selectType="explicit"
+      />,
       {
         wrapper: (props) => (
           <TestParent {...props} mocks={mocks} submission={{ _id: "mock-submission-id" }} />
@@ -406,7 +429,7 @@ describe("Implementation Requirements", () => {
     });
   });
 
-  it("should use deleteAll API when selectAllActive is true with no exclusions", async () => {
+  it("should use deleteAll API when selectType is true with no exclusions", async () => {
     const mockMatcher = vi.fn().mockImplementation(() => true);
     const mocks: MockedResponse<DeleteDataRecordsResp, DeleteDataRecordsInput>[] = [
       {
@@ -426,7 +449,12 @@ describe("Implementation Requirements", () => {
     ];
 
     const { getByTestId, getByRole } = render(
-      <Button nodeType="test-node-type" selectedItems={[]} selectAllActive totalData={100} />,
+      <Button
+        nodeType="test-node-type"
+        selectedItems={[]}
+        selectType="exclusion"
+        totalData={100}
+      />,
       {
         wrapper: (props) => (
           <TestParent {...props} mocks={mocks} submission={{ _id: "mock-submission-id" }} />
@@ -481,7 +509,7 @@ describe("Implementation Requirements", () => {
       <Button
         nodeType="test-node-type"
         selectedItems={["excluded-id-1", "excluded-id-2"]}
-        selectAllActive
+        selectType="exclusion"
         totalData={100}
       />,
       {
@@ -513,7 +541,7 @@ describe("Implementation Requirements", () => {
       <Button
         nodeType="test-node-type"
         selectedItems={Array(2001).fill("excluded-id")}
-        selectAllActive
+        selectType="exclusion"
         totalData={5000}
       />,
       {
@@ -538,7 +566,7 @@ describe("Implementation Requirements", () => {
       <Button
         nodeType="test-node-type"
         selectedItems={Array(2001).fill("node-id")}
-        selectAllActive={false}
+        selectType="explicit"
         totalData={5000}
       />,
       {
@@ -563,7 +591,7 @@ describe("Implementation Requirements", () => {
       <Button
         nodeType="test-node"
         selectedItems={["excluded-1", "excluded-2"]}
-        selectAllActive
+        selectType="exclusion"
         totalData={100}
       />,
       {
@@ -585,7 +613,7 @@ describe("Implementation Requirements", () => {
       <Button
         nodeType="test-node"
         selectedItems={["id-1", "id-2", "id-3"]}
-        selectAllActive
+        selectType="exclusion"
         totalData={3}
       />,
       {
@@ -599,7 +627,7 @@ describe("Implementation Requirements", () => {
 
   it("should dismiss the dialog when the 'Cancel' button is clicked", async () => {
     const { getByTestId, getByRole } = render(
-      <Button nodeType="test" selectedItems={["1 item ID"]} />,
+      <Button nodeType="test" selectedItems={["1 item ID"]} selectType="explicit" />,
       {
         wrapper: TestParent,
       }
@@ -620,7 +648,7 @@ describe("Implementation Requirements", () => {
 
   it("should contain the nodeType and selection count in the delete dialog content", async () => {
     const { getByTestId, getByRole } = render(
-      <Button nodeType="test-node-123" selectedItems={["node-id-456"]} />,
+      <Button nodeType="test-node-123" selectedItems={["node-id-456"]} selectType="explicit" />,
       {
         wrapper: TestParent,
       }
@@ -642,7 +670,7 @@ describe("Implementation Requirements", () => {
     ["ALL CAPS", "Delete All Caps Node"],
   ])("should use a title-cased nodeType in the dialog header", (nodeType, expected) => {
     const { getByTestId, getByRole } = render(
-      <Button nodeType={nodeType} selectedItems={["node-id-456"]} />,
+      <Button nodeType={nodeType} selectedItems={["node-id-456"]} selectType="explicit" />,
       {
         wrapper: TestParent,
       }
@@ -663,7 +691,11 @@ describe("Implementation Requirements", () => {
     "should use the proper pluralization for the delete dialog title",
     async (selectedItems, expected) => {
       const { getByTestId, getByRole } = render(
-        <Button nodeType="xyz-node" selectedItems={Array(selectedItems).fill("fake-node-id")} />,
+        <Button
+          nodeType="xyz-node"
+          selectedItems={Array(selectedItems).fill("fake-node-id")}
+          selectType="explicit"
+        />,
         {
           wrapper: TestParent,
         }
@@ -697,6 +729,7 @@ describe("Implementation Requirements", () => {
         <Button
           nodeType="test-node-123"
           selectedItems={Array(selectedItems).fill("fake-node-id")}
+          selectType="explicit"
         />,
         {
           wrapper: TestParent,
@@ -747,6 +780,7 @@ describe("Implementation Requirements", () => {
           nodeType="test-node-123"
           selectedItems={Array(selectedItems).fill("fake-node-id")}
           onDelete={mockOnDelete}
+          selectType="explicit"
         />,
         {
           wrapper: (props) => <TestParent {...props} mocks={[mock]} />,
@@ -810,6 +844,7 @@ describe("Implementation Requirements", () => {
           nodeType="data file"
           selectedItems={Array(selectedItems).fill("fake-data-file")}
           onDelete={mockOnDelete}
+          selectType="explicit"
         />,
         {
           wrapper: (props) => <TestParent {...props} mocks={[mock]} />,
@@ -832,25 +867,31 @@ describe("Implementation Requirements", () => {
   );
 
   it("should be visible and interactive when the user has the required permissions", async () => {
-    const { getByTestId } = render(<Button nodeType="test" selectedItems={[]} />, {
-      wrapper: (props) => (
-        <TestParent
-          {...props}
-          user={{
-            role: "Submitter",
-            permissions: ["data_submission:view", "data_submission:create"],
-          }}
-        />
-      ),
-    });
+    const { getByTestId } = render(
+      <Button nodeType="test" selectedItems={[]} selectType="explicit" />,
+      {
+        wrapper: (props) => (
+          <TestParent
+            {...props}
+            user={{
+              role: "Submitter",
+              permissions: ["data_submission:view", "data_submission:create"],
+            }}
+          />
+        ),
+      }
+    );
 
     expect(getByTestId("delete-node-data-button")).toBeVisible();
   });
 
   it("should not be rendered when the user is missing the required permissions", async () => {
-    const { queryByTestId } = render(<Button nodeType="test" selectedItems={[]} />, {
-      wrapper: (props) => <TestParent {...props} user={{ role: "Submitter", permissions: [] }} />,
-    });
+    const { queryByTestId } = render(
+      <Button nodeType="test" selectedItems={[]} selectType="explicit" />,
+      {
+        wrapper: (props) => <TestParent {...props} user={{ role: "Submitter", permissions: [] }} />,
+      }
+    );
 
     expect(queryByTestId("delete-node-data-button")).not.toBeInTheDocument();
   });
@@ -858,9 +899,12 @@ describe("Implementation Requirements", () => {
   it.each<SubmissionStatus>(["New", "In Progress", "Rejected", "Withdrawn"])(
     "should (implicitly) be enabled for the Submission Status %s",
     (status) => {
-      const { getByTestId } = render(<Button nodeType="test" selectedItems={["item-1"]} />, {
-        wrapper: (props) => <TestParent {...props} submission={{ status }} />,
-      });
+      const { getByTestId } = render(
+        <Button nodeType="test" selectedItems={["item-1"]} selectType="explicit" />,
+        {
+          wrapper: (props) => <TestParent {...props} submission={{ status }} />,
+        }
+      );
 
       expect(getByTestId("delete-node-data-button")).toBeEnabled();
     }
@@ -869,9 +913,12 @@ describe("Implementation Requirements", () => {
   it.each<SubmissionStatus>(["Submitted", "Released", "Completed", "Canceled", "Deleted"])(
     "should be disabled for the Submission Status %s",
     (status) => {
-      const { getByTestId } = render(<Button nodeType="test" selectedItems={["item-1"]} />, {
-        wrapper: (props) => <TestParent {...props} submission={{ status }} />,
-      });
+      const { getByTestId } = render(
+        <Button nodeType="test" selectedItems={["item-1"]} selectType="explicit" />,
+        {
+          wrapper: (props) => <TestParent {...props} submission={{ status }} />,
+        }
+      );
 
       expect(getByTestId("delete-node-data-button")).toBeDisabled();
     }

--- a/src/components/DataSubmissions/DeleteNodeDataButton.test.tsx
+++ b/src/components/DataSubmissions/DeleteNodeDataButton.test.tsx
@@ -561,6 +561,31 @@ describe("Implementation Requirements", () => {
     });
   });
 
+  it("should show error when nodeIds exceed the 2000 limit (non-selectAll mode)", async () => {
+    const { getByTestId } = render(
+      <Button
+        nodeType="test-node-type"
+        selectedItems={Array(2001).fill("node-id")}
+        selectType="explicit"
+        totalData={5000}
+      />,
+      {
+        wrapper: TestParent,
+      }
+    );
+
+    userEvent.click(getByTestId("delete-node-data-button"));
+
+    await waitFor(() => {
+      expect(global.mockEnqueue).toHaveBeenCalledWith(
+        "Cannot delete more than 2000 items at once. Please refine your filters or adjust your selection.",
+        {
+          variant: "error",
+        }
+      );
+    });
+  });
+
   it("should show correct item count in dialog when selectAllActive is true", async () => {
     const { getByTestId, getByRole } = render(
       <Button

--- a/src/components/DataSubmissions/DeleteNodeDataButton.test.tsx
+++ b/src/components/DataSubmissions/DeleteNodeDataButton.test.tsx
@@ -561,31 +561,6 @@ describe("Implementation Requirements", () => {
     });
   });
 
-  it("should show error when nodeIds exceed the 2000 limit (non-selectAll mode)", async () => {
-    const { getByTestId } = render(
-      <Button
-        nodeType="test-node-type"
-        selectedItems={Array(2001).fill("node-id")}
-        selectType="explicit"
-        totalData={5000}
-      />,
-      {
-        wrapper: TestParent,
-      }
-    );
-
-    userEvent.click(getByTestId("delete-node-data-button"));
-
-    await waitFor(() => {
-      expect(global.mockEnqueue).toHaveBeenCalledWith(
-        'Cannot delete more than 2000 items at once. Please use "Select All" or reduce your selection.',
-        {
-          variant: "error",
-        }
-      );
-    });
-  });
-
   it("should show correct item count in dialog when selectAllActive is true", async () => {
     const { getByTestId, getByRole } = render(
       <Button

--- a/src/components/DataSubmissions/DeleteNodeDataButton.tsx
+++ b/src/components/DataSubmissions/DeleteNodeDataButton.tsx
@@ -47,7 +47,7 @@ type Props = {
   /**
    * An indicator specifying if the delete type is explicit selection or exclusion selection
    */
-  selectType: "explicit" | "exclusion";
+  selectType: "explicit" | "exclusion" | null;
   /**
    * An array of the selected node IDs.
    *

--- a/src/components/DataSubmissions/SubmittedDataFilters.test.tsx
+++ b/src/components/DataSubmissions/SubmittedDataFilters.test.tsx
@@ -8,7 +8,7 @@ import { submissionStatisticFactory } from "@/factories/submission/SubmissionSta
 import { SUBMISSION_STATS, SubmissionStatsInput, SubmissionStatsResp } from "../../graphql";
 import { render, waitFor, within } from "../../test-utils";
 
-import SubmittedDataFilters from "./SubmittedDataFilters";
+import SubmittedDataFilters, { hasFiltersApplied } from "./SubmittedDataFilters";
 
 type ParentProps = {
   mocks?: MockedResponse[];
@@ -405,5 +405,21 @@ describe("SubmittedDataFilters cases", () => {
     vi.advanceTimersByTime(500);
 
     expect(mockOnChange).not.toHaveBeenCalled();
+  });
+});
+
+describe("SubmittedDataFilters utility functions", () => {
+  it("hasFiltersApplied should return true if any filters other than nodeType are applied", () => {
+    expect(hasFiltersApplied({ nodeType: "any", status: "Error", submittedID: "" })).toBeTruthy();
+    expect(
+      hasFiltersApplied({ nodeType: "any", status: "All", submittedID: "some-id" })
+    ).toBeTruthy();
+    expect(
+      hasFiltersApplied({ nodeType: "any", status: "Warning", submittedID: "some-id" })
+    ).toBeTruthy();
+  });
+
+  it("hasFiltersApplied should return false if no filters other than nodeType are applied", () => {
+    expect(hasFiltersApplied({ nodeType: "any", status: "All", submittedID: "" })).toBeFalsy();
   });
 });

--- a/src/components/DataSubmissions/SubmittedDataFilters.tsx
+++ b/src/components/DataSubmissions/SubmittedDataFilters.tsx
@@ -33,6 +33,8 @@ export type FilterMethods = {
 
 export type FilterForm = Pick<GetSubmissionNodesInput, "nodeType" | "status" | "submittedID">;
 
+export const DEFAULT_VALUES: FilterForm = { nodeType: "", status: "All", submittedID: "" };
+
 const StyledContainer = styled(Box)({
   display: "flex",
   alignItems: "center",
@@ -57,6 +59,15 @@ const StyledInlineLabel = styled("label")({
 });
 
 /**
+ * A utility function to determine if any filters are applied, ignoring `nodeType` filter
+ *
+ * @param filters The current filter form values
+ * @returns True if any filters other than `nodeType` are applied, false otherwise
+ */
+export const hasFiltersApplied = (filters: FilterForm) =>
+  filters.status !== DEFAULT_VALUES.status || filters.submittedID !== DEFAULT_VALUES.submittedID;
+
+/**
  * A component that provides filters for the Submitted Data table
  *
  * @see {@link FilterProps} for the props
@@ -65,7 +76,7 @@ const StyledInlineLabel = styled("label")({
 const SubmittedDataFilters = forwardRef<FilterMethods, FilterProps>(
   ({ submissionId, onChange }, ref) => {
     const { watch, setValue, getValues, control } = useForm<FilterForm>({
-      defaultValues: { nodeType: "", status: "All", submittedID: "" },
+      defaultValues: DEFAULT_VALUES,
     });
 
     const debouncedOnChangeRef = useRef(

--- a/src/content/dataSubmissions/Contexts/DataViewContext.tsx
+++ b/src/content/dataSubmissions/Contexts/DataViewContext.tsx
@@ -19,7 +19,7 @@ const DataViewContext = React.createContext<{
    * An indicator specifying what type of selection is currently active
    * When true, selectedItems contains exclusions instead of inclusions.
    */
-  selectType?: "explicit" | "exclusion";
+  selectType?: "explicit" | "exclusion" | null;
   /**
    * Toggle the current row selection
    *

--- a/src/content/dataSubmissions/Contexts/DataViewContext.tsx
+++ b/src/content/dataSubmissions/Contexts/DataViewContext.tsx
@@ -16,10 +16,10 @@ const DataViewContext = React.createContext<{
    */
   isFetchingAllData?: React.MutableRefObject<boolean>;
   /**
-   * Indicates if "select all" (inverse selection) mode is active.
+   * An indicator specifying what type of selection is currently active
    * When true, selectedItems contains exclusions instead of inclusions.
    */
-  selectAllActive?: boolean;
+  selectType?: "explicit" | "exclusion";
   /**
    * Toggle the current row selection
    *

--- a/src/content/dataSubmissions/SubmittedData.test.tsx
+++ b/src/content/dataSubmissions/SubmittedData.test.tsx
@@ -1252,4 +1252,425 @@ describe("SubmittedData > Table", () => {
       expect(getByTestId("generic-table-rows-per-page-bottom")).toHaveValue("20");
     });
   });
+
+  it("should use 'exclusion' mode when selecting all without filters", async () => {
+    const getNodesMock: MockedResponse<GetSubmissionNodesResp, GetSubmissionNodesInput> = {
+      maxUsageCount: 2, // initial query + orderBy bug
+      request: {
+        query: GET_SUBMISSION_NODES,
+      },
+      variableMatcher: () => true,
+      result: {
+        data: {
+          getSubmissionNodes: {
+            total: 100,
+            properties: ["col-xyz"],
+            IDPropName: "col-xyz",
+            nodes: Array(20).fill({
+              nodeType: "example-node",
+              nodeID: "example-node-id",
+              props: JSON.stringify({
+                "col-xyz": "value-for-column-xyz",
+              }),
+              status: "New",
+            }),
+          },
+        },
+      },
+    };
+
+    const { getAllByRole } = render(
+      <TestParent
+        mocks={[mockSubmissionQuery, getNodesMock]}
+        submissionId="example-exclusion-mode"
+        submissionName={undefined}
+      >
+        <SubmittedData />
+      </TestParent>
+    );
+
+    await waitFor(() => {
+      expect(getAllByRole("checkbox")).toHaveLength(21); // header + 20 rows
+    });
+
+    // Click 'Select All' - should use exclusion mode (no filters applied)
+    userEvent.click(getAllByRole("checkbox")[0]);
+
+    await waitFor(() => {
+      // Header should be checked (exclusion mode with no exclusions)
+      expect(getAllByRole("checkbox")[0]).toBeChecked();
+      // All visible row checkboxes should be checked
+      getAllByRole("checkbox")
+        .slice(1)
+        .forEach((checkbox) => {
+          expect(checkbox).toBeChecked();
+        });
+    });
+  });
+
+  it("should use 'explicit' mode when selecting all with filters applied", async () => {
+    const getNodesMock: MockedResponse<GetSubmissionNodesResp, GetSubmissionNodesInput> = {
+      maxUsageCount: 3, // initial query + orderBy bug + filter fetch
+      request: {
+        query: GET_SUBMISSION_NODES,
+      },
+      variableMatcher: (vars) => !vars.partial,
+      result: {
+        data: {
+          getSubmissionNodes: {
+            total: 2,
+            properties: ["col-xyz"],
+            IDPropName: "col-xyz",
+            nodes: [
+              {
+                nodeType: "example-node",
+                nodeID: "node-1",
+                props: JSON.stringify({
+                  "col-xyz": "value-1",
+                }),
+                status: "New",
+              },
+              {
+                nodeType: "example-node",
+                nodeID: "node-2",
+                props: JSON.stringify({
+                  "col-xyz": "value-2",
+                }),
+                status: "New",
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    const getAllNodesMock: MockedResponse<GetSubmissionNodesResp<true>, GetSubmissionNodesInput> = {
+      request: {
+        query: GET_SUBMISSION_NODES,
+      },
+      variableMatcher: (vars) => vars.partial === true && vars.first === -1,
+      result: {
+        data: {
+          getSubmissionNodes: {
+            total: 2,
+            nodes: [{ nodeID: "node-1" }, { nodeID: "node-2" }],
+          },
+        },
+      },
+    };
+
+    const { getAllByRole, getByLabelText } = render(
+      <TestParent
+        mocks={[mockSubmissionQuery, getNodesMock, getAllNodesMock]}
+        submissionId="example-explicit-mode"
+        submissionName={undefined}
+      >
+        <SubmittedData />
+      </TestParent>
+    );
+
+    await waitFor(() => {
+      expect(getAllByRole("checkbox")).toHaveLength(3); // header + 2 rows
+    });
+
+    // Apply a filter to trigger explicit mode
+    userEvent.type(getByLabelText("Submitted ID"), "test-filter");
+
+    await waitFor(() => {
+      expect(getByLabelText("Submitted ID")).toHaveValue("test-filter");
+    });
+
+    // Wait for data to load after filter
+    await waitFor(() => {
+      expect(getAllByRole("checkbox")).toHaveLength(3);
+    });
+
+    // Click 'Select All' - should use explicit mode (filters applied)
+    userEvent.click(getAllByRole("checkbox")[0]);
+
+    await waitFor(() => {
+      // Header should be checked
+      expect(getAllByRole("checkbox")[0]).toBeChecked();
+      // All row checkboxes should be checked
+      expect(getAllByRole("checkbox")[1]).toBeChecked();
+      expect(getAllByRole("checkbox")[2]).toBeChecked();
+    });
+  });
+
+  it("should transition from 'exclusion' mode to no selection when header is clicked", async () => {
+    const getNodesMock: MockedResponse<GetSubmissionNodesResp, GetSubmissionNodesInput> = {
+      maxUsageCount: 2, // initial query + orderBy bug
+      request: {
+        query: GET_SUBMISSION_NODES,
+      },
+      variableMatcher: () => true,
+      result: {
+        data: {
+          getSubmissionNodes: {
+            total: 100,
+            properties: ["col-xyz"],
+            IDPropName: "col-xyz",
+            nodes: Array(20).fill({
+              nodeType: "example-node",
+              nodeID: "example-node-id",
+              props: JSON.stringify({
+                "col-xyz": "value-for-column-xyz",
+              }),
+              status: "New",
+            }),
+          },
+        },
+      },
+    };
+
+    const { getAllByRole } = render(
+      <TestParent
+        mocks={[mockSubmissionQuery, getNodesMock]}
+        submissionId="example-exclusion-deselect"
+        submissionName={undefined}
+      >
+        <SubmittedData />
+      </TestParent>
+    );
+
+    await waitFor(() => {
+      expect(getAllByRole("checkbox")).toHaveLength(21);
+    });
+
+    // Enter exclusion mode by clicking 'Select All'
+    userEvent.click(getAllByRole("checkbox")[0]);
+
+    await waitFor(() => {
+      expect(getAllByRole("checkbox")[0]).toBeChecked();
+    });
+
+    // Click again to deselect all (transition from exclusion to no selection)
+    userEvent.click(getAllByRole("checkbox")[0]);
+
+    await waitFor(() => {
+      // All checkboxes should be unchecked
+      expect(getAllByRole("checkbox")[0]).not.toBeChecked();
+      getAllByRole("checkbox")
+        .slice(1)
+        .forEach((checkbox) => {
+          expect(checkbox).not.toBeChecked();
+        });
+    });
+  });
+
+  it("should maintain exclusion mode when unchecking individual rows", async () => {
+    const getNodesMock: MockedResponse<GetSubmissionNodesResp, GetSubmissionNodesInput> = {
+      maxUsageCount: 2, // initial query + orderBy bug
+      request: {
+        query: GET_SUBMISSION_NODES,
+      },
+      variableMatcher: () => true,
+      result: {
+        data: {
+          getSubmissionNodes: {
+            total: 100,
+            properties: ["col-xyz"],
+            IDPropName: "col-xyz",
+            nodes: [
+              {
+                nodeType: "example-node",
+                nodeID: "node-1",
+                props: JSON.stringify({ "col-xyz": "value-1" }),
+                status: "New",
+              },
+              {
+                nodeType: "example-node",
+                nodeID: "node-2",
+                props: JSON.stringify({ "col-xyz": "value-2" }),
+                status: "New",
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    const { getAllByRole } = render(
+      <TestParent
+        mocks={[mockSubmissionQuery, getNodesMock]}
+        submissionId="example-exclusion-uncheck"
+        submissionName={undefined}
+      >
+        <SubmittedData />
+      </TestParent>
+    );
+
+    await waitFor(() => {
+      expect(getAllByRole("checkbox")).toHaveLength(3); // header + 2 rows
+    });
+
+    // Enter exclusion mode by clicking 'Select All'
+    userEvent.click(getAllByRole("checkbox")[0]);
+
+    await waitFor(() => {
+      expect(getAllByRole("checkbox")[0]).toBeChecked();
+      expect(getAllByRole("checkbox")[1]).toBeChecked();
+      expect(getAllByRole("checkbox")[2]).toBeChecked();
+    });
+
+    // Uncheck one row - should add to exclusion list
+    userEvent.click(getAllByRole("checkbox")[1]);
+
+    await waitFor(() => {
+      // Header should be indeterminate (partial selection)
+      expect(getAllByRole("checkbox")[0]).toHaveAttribute("data-indeterminate", "true");
+      // First row unchecked, second row still checked
+      expect(getAllByRole("checkbox")[1]).not.toBeChecked();
+      expect(getAllByRole("checkbox")[2]).toBeChecked();
+    });
+  });
+
+  it("should transition from 'explicit' mode to no selection when last item is unchecked", async () => {
+    const getNodesMock: MockedResponse<GetSubmissionNodesResp, GetSubmissionNodesInput> = {
+      maxUsageCount: 2, // initial query + orderBy bug
+      request: {
+        query: GET_SUBMISSION_NODES,
+      },
+      variableMatcher: () => true,
+      result: {
+        data: {
+          getSubmissionNodes: {
+            total: 2,
+            properties: ["col-xyz"],
+            IDPropName: "col-xyz",
+            nodes: [
+              {
+                nodeType: "example-node",
+                nodeID: "node-1",
+                props: JSON.stringify({ "col-xyz": "value-1" }),
+                status: "New",
+              },
+              {
+                nodeType: "example-node",
+                nodeID: "node-2",
+                props: JSON.stringify({ "col-xyz": "value-2" }),
+                status: "New",
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    const { getAllByRole } = render(
+      <TestParent
+        mocks={[mockSubmissionQuery, getNodesMock]}
+        submissionId="example-explicit-deselect"
+        submissionName={undefined}
+      >
+        <SubmittedData />
+      </TestParent>
+    );
+
+    await waitFor(() => {
+      expect(getAllByRole("checkbox")).toHaveLength(3);
+    });
+
+    // Manually select one row (explicit mode)
+    userEvent.click(getAllByRole("checkbox")[1]);
+
+    await waitFor(() => {
+      expect(getAllByRole("checkbox")[1]).toBeChecked();
+      expect(getAllByRole("checkbox")[0]).toHaveAttribute("data-indeterminate", "true");
+    });
+
+    // Uncheck the selected row - should transition to no selection
+    userEvent.click(getAllByRole("checkbox")[1]);
+
+    await waitFor(() => {
+      // All checkboxes should be unchecked
+      expect(getAllByRole("checkbox")[0]).not.toBeChecked();
+      expect(getAllByRole("checkbox")[0]).toHaveAttribute("data-indeterminate", "false");
+      expect(getAllByRole("checkbox")[1]).not.toBeChecked();
+    });
+  });
+
+  it("should skip fetching when all data is already visible with filters", async () => {
+    const getNodesMock: MockedResponse<GetSubmissionNodesResp, GetSubmissionNodesInput> = {
+      maxUsageCount: 3, // initial query + orderBy bug + filter fetch
+      request: {
+        query: GET_SUBMISSION_NODES,
+      },
+      variableMatcher: (vars) => !vars.partial,
+      result: {
+        data: {
+          getSubmissionNodes: {
+            total: 2,
+            properties: ["col-xyz"],
+            IDPropName: "col-xyz",
+            nodes: [
+              {
+                nodeType: "example-node",
+                nodeID: "node-1",
+                props: JSON.stringify({ "col-xyz": "value-1" }),
+                status: "New",
+              },
+              {
+                nodeType: "example-node",
+                nodeID: "node-2",
+                props: JSON.stringify({ "col-xyz": "value-2" }),
+                status: "New",
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    const mockMatcherAllNodes = vi.fn().mockImplementation((vars) => vars.partial === true);
+    const getAllNodesMock: MockedResponse<GetSubmissionNodesResp<true>, GetSubmissionNodesInput> = {
+      request: {
+        query: GET_SUBMISSION_NODES,
+      },
+      variableMatcher: mockMatcherAllNodes,
+      result: {
+        data: {
+          getSubmissionNodes: {
+            total: 2,
+            nodes: [{ nodeID: "node-1" }, { nodeID: "node-2" }],
+          },
+        },
+      },
+    };
+
+    const { getAllByRole, getByLabelText } = render(
+      <TestParent
+        mocks={[mockSubmissionQuery, getNodesMock, getAllNodesMock]}
+        submissionId="example-skip-fetch"
+        submissionName={undefined}
+      >
+        <SubmittedData />
+      </TestParent>
+    );
+
+    await waitFor(() => {
+      expect(getAllByRole("checkbox")).toHaveLength(3);
+    });
+
+    // Apply a filter
+    userEvent.type(getByLabelText("Submitted ID"), "test");
+
+    await waitFor(() => {
+      expect(getByLabelText("Submitted ID")).toHaveValue("test");
+    });
+
+    // Wait for filtered data
+    await waitFor(() => {
+      expect(getAllByRole("checkbox")).toHaveLength(3);
+    });
+
+    // Click 'Select All' - should NOT fetch because all data is visible (2 rows shown, 2 total)
+    userEvent.click(getAllByRole("checkbox")[0]);
+
+    await waitFor(() => {
+      expect(getAllByRole("checkbox")[0]).toBeChecked();
+      // Should not have called the partial fetch
+      expect(mockMatcherAllNodes).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/content/dataSubmissions/SubmittedData.test.tsx
+++ b/src/content/dataSubmissions/SubmittedData.test.tsx
@@ -849,15 +849,17 @@ describe("SubmittedData > Table", () => {
       expect(getAllByRole("checkbox")[0]).toHaveAttribute("data-indeterminate", "true");
     });
 
-    // With new inverse selection, clicking header when indeterminate toggles to "select all" mode
+    // TODO: The current implementation clears selection when clicking header in indeterminate state
+    // This doesn't match the expected behavior described in CRDCDH-3488 notes
     userEvent.click(getAllByRole("checkbox")[0]); // click 'Select All' checkbox
 
     await waitFor(() => {
-      // Header should now be checked (select all mode active with no exclusions)
-      expect(getAllByRole("checkbox")[0]).toBeChecked();
-      // All row checkboxes should be checked
-      expect(getAllByRole("checkbox")[1]).toBeChecked();
-      expect(getAllByRole("checkbox")[2]).toBeChecked();
+      // Current behavior: header checkbox becomes unchecked (all selections cleared)
+      expect(getAllByRole("checkbox")[0]).not.toBeChecked();
+      expect(getAllByRole("checkbox")[0]).toHaveAttribute("data-indeterminate", "false");
+      // All row checkboxes should be unchecked
+      expect(getAllByRole("checkbox")[1]).not.toBeChecked();
+      expect(getAllByRole("checkbox")[2]).not.toBeChecked();
     });
   });
 

--- a/src/content/dataSubmissions/SubmittedData.test.tsx
+++ b/src/content/dataSubmissions/SubmittedData.test.tsx
@@ -1266,14 +1266,16 @@ describe("SubmittedData > Table", () => {
             total: 100,
             properties: ["col-xyz"],
             IDPropName: "col-xyz",
-            nodes: Array(20).fill({
-              nodeType: "example-node",
-              nodeID: "example-node-id",
-              props: JSON.stringify({
-                "col-xyz": "value-for-column-xyz",
-              }),
-              status: "New",
-            }),
+            nodes: Array(20)
+              .fill(null)
+              .map((_, idx) => ({
+                nodeType: "example-node",
+                nodeID: `example-node-id-${idx}`,
+                props: JSON.stringify({
+                  "col-xyz": `value-for-column-xyz-${idx}`,
+                }),
+                status: "New",
+              })),
           },
         },
       },
@@ -1410,14 +1412,16 @@ describe("SubmittedData > Table", () => {
             total: 100,
             properties: ["col-xyz"],
             IDPropName: "col-xyz",
-            nodes: Array(20).fill({
-              nodeType: "example-node",
-              nodeID: "example-node-id",
-              props: JSON.stringify({
-                "col-xyz": "value-for-column-xyz",
-              }),
-              status: "New",
-            }),
+            nodes: Array(20)
+              .fill(null)
+              .map((_, idx) => ({
+                nodeType: "example-node",
+                nodeID: `example-node-id-${idx}`,
+                props: JSON.stringify({
+                  "col-xyz": `value-for-column-xyz-${idx}`,
+                }),
+                status: "New",
+              })),
           },
         },
       },

--- a/src/content/dataSubmissions/SubmittedData.test.tsx
+++ b/src/content/dataSubmissions/SubmittedData.test.tsx
@@ -849,12 +849,9 @@ describe("SubmittedData > Table", () => {
       expect(getAllByRole("checkbox")[0]).toHaveAttribute("data-indeterminate", "true");
     });
 
-    // TODO: The current implementation clears selection when clicking header in indeterminate state
-    // This doesn't match the expected behavior described in CRDCDH-3488 notes
     userEvent.click(getAllByRole("checkbox")[0]); // click 'Select All' checkbox
 
     await waitFor(() => {
-      // Current behavior: header checkbox becomes unchecked (all selections cleared)
       expect(getAllByRole("checkbox")[0]).not.toBeChecked();
       expect(getAllByRole("checkbox")[0]).toHaveAttribute("data-indeterminate", "false");
       // All row checkboxes should be unchecked

--- a/src/content/dataSubmissions/SubmittedData.tsx
+++ b/src/content/dataSubmissions/SubmittedData.tsx
@@ -432,7 +432,16 @@ const SubmittedData: FC = () => {
     setSelectType("exclusion");
     setSelectedItems([]);
     isFetchingAllData.current = false;
-  }, [selectType, isFetchingAllData, filterRef.current, setSelectedItems, setSelectType]);
+  }, [
+    _id,
+    data,
+    totalData,
+    selectType,
+    isFetchingAllData,
+    filterRef.current,
+    setSelectedItems,
+    setSelectType,
+  ]);
 
   const handleOnDelete = (successMessage: string) => {
     setDeleteSuccessMessage(successMessage);

--- a/src/content/dataSubmissions/SubmittedData.tsx
+++ b/src/content/dataSubmissions/SubmittedData.tsx
@@ -415,6 +415,7 @@ const SubmittedData: FC = () => {
           variant: "error",
         });
         setSelectedItems([]);
+        setSelectType(null);
         isFetchingAllData.current = false;
         return;
       }


### PR DESCRIPTION
### Overview

This is a very critical PR that resolves a significant oversight during the fix of the bug CRDCDH-3369. On the data view tab, when a user leverages the filters, then selects to delete all of the nodes, the applied filters are NOT accounted for when asking the backend to delete "all nodes." As a result, this bug causes unexpected data loss to a data submission.

Here's how it was fixed:

- Scenario A – Select all, NO FILTERS: We leverage the delete all functionality that was introduced via CRDCDH-3369.
- Scenario B – Select all, w/Filters: We revert back to the old delete mechanism, where the frontend queries for all node IDs matching the current filter criteria, and sends that to the backend.

Downside: In scenario B, if the user is trying to delete more than 2K records, they literally would be blocked from doing so. I added a snackbar message telling them to refine their filters. 

> [!Warning]
> I tested every scenario I could think of, but please also thoroughly test this as well. Fixing it correctly is critical.

### Change Details (Specifics)

N/A – Refer to above for the specifics

### Related Ticket(s)

CRDCDH-3488
