### PR TITLE
CRDCDH-3442 Fix z-index's to avoid overlapping

### DIFF
--- a/docs/ZIndex.md
+++ b/docs/ZIndex.md
@@ -1,0 +1,45 @@
+# Z-Index Standards
+
+This document defines the z-index standards for the CRDC Submission Portal to ensure consistent layering and avoid stacking context conflicts.
+
+## Z-Index Scale
+
+### Base Layer (0-99)
+
+| Value | Use Case                 |
+| ----- | ------------------------ |
+| 0-99  | Local component stacking |
+
+### UI Controls (100-999)
+
+| Value | Use Case                      |
+| ----- | ----------------------------- |
+| 250   | Table loading overlay         |
+| 300   | Column visibility popper      |
+| 500   | Custom Backdrop               |
+| 600   | Clear button for Select input |
+| 700   | Dropdown menus                |
+| 999   | Scroll button, timeline dots  |
+
+### Material UI Defaults (1000-1500)
+
+See [MUI z-index documentation](https://mui.com/material-ui/customization/z-index/)
+
+| Value | Component       |
+| ----- | --------------- |
+| 1000  | Mobile Stepper  |
+| 1050  | Fab, Speed Dial |
+| 1100  | App Bar         |
+| 1200  | Drawer          |
+| 1300  | Modal           |
+| 1400  | Snackbar        |
+| 1500  | Tooltip         |
+
+### Application-Specific
+
+| Value | Use Case                            |
+| ----- | ----------------------------------- |
+| 1100  | Navbar                              |
+| 1200  | Mobile header menu                  |
+| 1400  | Alert notifications                 |
+| 2000  | Full-screen loader (SuspenseLoader) |

--- a/src/components/AdminPortal/Studies/ApprovedStudyFilters.tsx
+++ b/src/components/AdminPortal/Studies/ApprovedStudyFilters.tsx
@@ -225,7 +225,7 @@ const ApprovedStudyFilters = ({ onChange }: Props) => {
                 }
                 MenuProps={{
                   disablePortal: true,
-                  sx: { width: selectMinWidth ? `${selectMinWidth}px` : "auto" },
+                  sx: { zIndex: 700, width: selectMinWidth ? `${selectMinWidth}px` : "auto" },
                 }}
                 inputProps={{ id: "programID-filter" }}
                 data-testid="programID-select"
@@ -258,7 +258,11 @@ const ApprovedStudyFilters = ({ onChange }: Props) => {
               <StyledSelect
                 {...field}
                 value={field.value}
-                MenuProps={{ disablePortal: true, PaperProps: { sx: { maxWidth: "300px" } } }}
+                MenuProps={{
+                  disablePortal: true,
+                  PaperProps: { sx: { maxWidth: "300px" } },
+                  sx: { zIndex: 700 },
+                }}
                 inputProps={{ id: "accessType-filter" }}
                 data-testid="accessType-select"
                 onChange={(e) => {

--- a/src/components/ClearButton/index.tsx
+++ b/src/components/ClearButton/index.tsx
@@ -7,7 +7,7 @@ const StyledClearButton = styled(IconButton)({
   padding: "4px",
   marginRight: "14px",
   position: "relative",
-  zIndex: 10001,
+  zIndex: 600,
   backgroundColor: "#E7F2EF",
   border: "1px solid #D6D6D6",
   "&:hover": {

--- a/src/components/DataExplorerFilters/index.tsx
+++ b/src/components/DataExplorerFilters/index.tsx
@@ -165,7 +165,7 @@ const DataExplorerFilters = ({
                     }
                     MenuProps={{
                       disablePortal: true,
-                      sx: { width: selectMinWidth ? `${selectMinWidth}px` : "auto" },
+                      sx: { zIndex: 700, width: selectMinWidth ? `${selectMinWidth}px` : "auto" },
                     }}
                     inputProps={{
                       id: "nodeType-filter",

--- a/src/components/DataSubmissions/DataSubmissionListFilters.test.tsx
+++ b/src/components/DataSubmissions/DataSubmissionListFilters.test.tsx
@@ -1237,6 +1237,6 @@ describe("DataSubmissionListFilters Component", () => {
     const clearButton = getByTestId("status-clear-button");
     const styles = window.getComputedStyle(clearButton);
 
-    expect(parseInt(styles.zIndex, 10)).toBeGreaterThan(9999);
+    expect(parseInt(styles.zIndex, 10)).toBeGreaterThan(250);
   });
 });

--- a/src/components/DataSubmissions/DataSubmissionListFilters.tsx
+++ b/src/components/DataSubmissions/DataSubmissionListFilters.tsx
@@ -386,7 +386,7 @@ const DataSubmissionListFilters = ({
                     }
                     MenuProps={{
                       disablePortal: true,
-                      sx: { width: selectMinWidth ? `${selectMinWidth}px` : "auto" },
+                      sx: { zIndex: 700, width: selectMinWidth ? `${selectMinWidth}px` : "auto" },
                     }}
                     inputProps={{
                       id: "organization-filter",
@@ -429,7 +429,7 @@ const DataSubmissionListFilters = ({
                     MenuProps={{
                       disablePortal: true,
                       hideBackdrop: true,
-                      sx: { zIndex: 10002, pointerEvents: "none" },
+                      sx: { zIndex: 700, pointerEvents: "none" },
                       PaperProps: {
                         sx: { pointerEvents: "auto" },
                       },
@@ -477,7 +477,7 @@ const DataSubmissionListFilters = ({
               <Backdrop
                 open={isStatusesMenuOpen}
                 onClick={() => setIsStatusesMenuOpen(false)}
-                sx={{ zIndex: 10000, opacity: "0 !important", cursor: "text" }}
+                sx={{ zIndex: 500, opacity: "0 !important", cursor: "text" }}
               />
             </StyledFormControl>
           </Grid>
@@ -496,7 +496,7 @@ const DataSubmissionListFilters = ({
                   <StyledSelect
                     {...field}
                     value={dataCommons?.length ? field.value : "All"}
-                    MenuProps={{ disablePortal: true }}
+                    MenuProps={{ disablePortal: true, sx: { zIndex: 700 } }}
                     inputProps={{
                       id: "data-commons-filter",
                       "data-testid": "data-commons-select-input",
@@ -582,7 +582,7 @@ const DataSubmissionListFilters = ({
                     }}
                     MenuProps={{
                       disablePortal: true,
-                      sx: { width: selectMinWidth ? `${selectMinWidth}px` : "auto" },
+                      sx: { zIndex: 700, width: selectMinWidth ? `${selectMinWidth}px` : "auto" },
                     }}
                     inputProps={{
                       id: "submitter-name-filter",

--- a/src/components/DataSubmissions/QualityControlFilters.tsx
+++ b/src/components/DataSubmissions/QualityControlFilters.tsx
@@ -181,7 +181,7 @@ const QualityControlFilters = ({ issueType, isAggregated, onChange }: Props) => 
                     {...field}
                     inputProps={{ id: "issueType-filter", "data-testid": "issueType-filter" }}
                     data-testid="quality-control-issueType-filter"
-                    MenuProps={{ disablePortal: true, sx: { zIndex: 99999 } }}
+                    MenuProps={{ disablePortal: true, sx: { zIndex: 700 } }}
                   >
                     <MenuItem value="All" data-testid="issueType-all">
                       All
@@ -218,7 +218,7 @@ const QualityControlFilters = ({ issueType, isAggregated, onChange }: Props) => 
                     {...field}
                     inputProps={{ id: "batchID-filter" }}
                     data-testid="quality-control-batchID-filter"
-                    MenuProps={{ disablePortal: true, sx: { zIndex: 99999 } }}
+                    MenuProps={{ disablePortal: true, sx: { zIndex: 700 } }}
                   >
                     <MenuItem value="All" data-testid="batchID-all">
                       All
@@ -255,7 +255,7 @@ const QualityControlFilters = ({ issueType, isAggregated, onChange }: Props) => 
                     {...field}
                     inputProps={{ id: "nodeType-filter" }}
                     data-testid="quality-control-nodeType-filter"
-                    MenuProps={{ disablePortal: true, sx: { zIndex: 99999 } }}
+                    MenuProps={{ disablePortal: true, sx: { zIndex: 700 } }}
                   >
                     <MenuItem value="All" data-testid="nodeType-all">
                       All
@@ -292,7 +292,7 @@ const QualityControlFilters = ({ issueType, isAggregated, onChange }: Props) => 
                 {...field}
                 inputProps={{ id: "severity-filter" }}
                 data-testid="quality-control-severity-filter"
-                MenuProps={{ disablePortal: true, sx: { zIndex: 99999 } }}
+                MenuProps={{ disablePortal: true, sx: { zIndex: 700 } }}
               >
                 <MenuItem value="All" data-testid="severity-all">
                   All

--- a/src/components/GenericAlert/index.tsx
+++ b/src/components/GenericAlert/index.tsx
@@ -12,7 +12,7 @@ const StyledAlert = styled(Alert, {
   borderColor: bgColor || "none",
   boxShadow: "-4px 8px 27px 4px rgba(27,28,28,0.09)",
   justifyContent: "center",
-  zIndex: "1200",
+  zIndex: "1400",
   position: "fixed",
   top: "20px",
   left: "50%",

--- a/src/components/GenericTable/ColumnVisibilityPopper.tsx
+++ b/src/components/GenericTable/ColumnVisibilityPopper.tsx
@@ -19,7 +19,7 @@ import CloseIconSvg from "../../assets/icons/close_icon.svg?react";
 import Tooltip from "../Tooltip";
 
 const StyledPopper = styled(Popper)({
-  zIndex: 100,
+  zIndex: 300,
 });
 
 const StyledResetButton = styled(Button)(({ theme }) => ({

--- a/src/components/GenericTable/index.tsx
+++ b/src/components/GenericTable/index.tsx
@@ -490,7 +490,11 @@ const GenericTable = <T,>(
   return (
     <StyledTableContainer {...containerProps}>
       {(!paramsInitialized || showDelayedLoading) && (
-        <SuspenseLoader fullscreen={false} data-testid="generic-table-suspense-loader" />
+        <SuspenseLoader
+          fullscreen={false}
+          zIndex={250}
+          data-testid="generic-table-suspense-loader"
+        />
       )}
       {(position === "top" || position === "both") && (
         <Pagination verticalPlacement="top" disabled={!data || loading || !paramsInitialized} />

--- a/src/components/Header/components/NavbarDesktop.tsx
+++ b/src/components/Header/components/NavbarDesktop.tsx
@@ -19,7 +19,7 @@ const Nav = styled("div")({
   width: "100%",
   background: "#ffffff",
   boxShadow: "-0.1px 6px 9px -6px rgba(0, 0, 0, 0.5)",
-  zIndex: 11000,
+  zIndex: 1100,
   position: "relative",
   "& .dropdownContainer": {
     margin: "0 auto",

--- a/src/components/Header/components/NavbarDesktopDropdown.tsx
+++ b/src/components/Header/components/NavbarDesktopDropdown.tsx
@@ -12,7 +12,7 @@ const Dropdown = styled("div")({
   right: 0,
   width: "100%",
   background: "#1F4671",
-  zIndex: 11000,
+  zIndex: 1100,
   display: "block",
   position: "absolute",
   paddingTop: "35px",

--- a/src/components/InstitutionListFilters/index.tsx
+++ b/src/components/InstitutionListFilters/index.tsx
@@ -148,7 +148,7 @@ const InstitutionListFilters = ({ onChange }: Props) => {
             <StyledSelect
               {...field}
               value={field.value}
-              MenuProps={{ disablePortal: true }}
+              MenuProps={{ disablePortal: true, sx: { zIndex: 700 } }}
               inputProps={{ id: "status-filter", "data-testid": "status-select-input" }}
               data-testid="status-select"
               onChange={(e) => {

--- a/src/components/Questionnaire/TableFileTypeAndExtensionInput.tsx
+++ b/src/components/Questionnaire/TableFileTypeAndExtensionInput.tsx
@@ -232,7 +232,7 @@ const TableAutocompleteInput: FC<Props> = ({
               disablePortal: true,
               sx: {
                 top: "-2px !important",
-                zIndex: "2000",
+                zIndex: 700,
               },
               modifiers: [
                 {
@@ -303,7 +303,7 @@ const TableAutocompleteInput: FC<Props> = ({
               disablePortal: true,
               sx: {
                 top: "-2px !important",
-                zIndex: "2000",
+                zIndex: 700,
               },
               modifiers: [
                 {

--- a/src/components/SuspenseLoader/index.tsx
+++ b/src/components/SuspenseLoader/index.tsx
@@ -25,7 +25,7 @@ const StyledBox = styled(Box, {
   height: "100%",
 }));
 
-const SuspenseLoader: FC<Props> = ({ fullscreen = true, zIndex = 9999, ...rest }: Props) => (
+const SuspenseLoader: FC<Props> = ({ fullscreen = true, zIndex = 2000, ...rest }: Props) => (
   <StyledBox
     display="flex"
     alignItems="center"

--- a/src/components/SuspenseLoader/index.tsx
+++ b/src/components/SuspenseLoader/index.tsx
@@ -1,4 +1,4 @@
-import { Box, CircularProgress, styled } from "@mui/material";
+import { Box, BoxProps, CircularProgress, styled } from "@mui/material";
 import { ComponentProps, FC } from "react";
 
 type Props = {
@@ -8,6 +8,10 @@ type Props = {
    * @default true
    */
   fullscreen?: boolean;
+  /**
+   * Defines the zIndex of the entire suspense loader.
+   */
+  zIndex?: BoxProps["zIndex"];
 } & ComponentProps<typeof CircularProgress>;
 
 const StyledBox = styled(Box, {
@@ -19,11 +23,16 @@ const StyledBox = styled(Box, {
   top: 0,
   width: "100%",
   height: "100%",
-  zIndex: "9999",
 }));
 
-const SuspenseLoader: FC<Props> = ({ fullscreen = true, ...rest }: Props) => (
-  <StyledBox display="flex" alignItems="center" justifyContent="center" fullscreen={fullscreen}>
+const SuspenseLoader: FC<Props> = ({ fullscreen = true, zIndex = 9999, ...rest }: Props) => (
+  <StyledBox
+    display="flex"
+    alignItems="center"
+    justifyContent="center"
+    fullscreen={fullscreen}
+    zIndex={zIndex}
+  >
     <CircularProgress size={64} disableShrink thickness={3} aria-label="Content Loader" {...rest} />
   </StyledBox>
 );

--- a/src/content/DataExplorer/ListFilters.tsx
+++ b/src/content/DataExplorer/ListFilters.tsx
@@ -258,7 +258,7 @@ const ListFilters = ({ dataCommonsDisplayNames, onChange }: Props) => {
                 <StyledSelect
                   {...field}
                   value={field.value}
-                  MenuProps={{ disablePortal: true }}
+                  MenuProps={{ disablePortal: true, sx: { zIndex: 700 } }}
                   inputProps={{
                     id: "data-commons-display-names-filter",
                     "data-testid": "data-commons-display-names-select-input",

--- a/src/content/questionnaire/ListFilters.test.tsx
+++ b/src/content/questionnaire/ListFilters.test.tsx
@@ -412,6 +412,6 @@ describe("ListFilters Component", () => {
     const clearButton = getByTestId("status-clear-button");
     const styles = window.getComputedStyle(clearButton);
 
-    expect(parseInt(styles.zIndex, 10)).toBeGreaterThan(9999);
+    expect(parseInt(styles.zIndex, 10)).toBeGreaterThan(250);
   });
 });

--- a/src/content/questionnaire/ListFilters.tsx
+++ b/src/content/questionnaire/ListFilters.tsx
@@ -338,7 +338,7 @@ const ListFilters = ({ applicationData, onChange }: FilterProps) => {
                     slotProps={{
                       popper: {
                         sx: {
-                          zIndex: 99999,
+                          zIndex: 700,
                         },
                       },
                     }}
@@ -382,7 +382,7 @@ const ListFilters = ({ applicationData, onChange }: FilterProps) => {
                     MenuProps={{
                       disablePortal: true,
                       hideBackdrop: true,
-                      sx: { zIndex: 10002, pointerEvents: "none" },
+                      sx: { zIndex: 700, pointerEvents: "none" },
                       PaperProps: {
                         sx: { pointerEvents: "auto" },
                       },
@@ -430,7 +430,7 @@ const ListFilters = ({ applicationData, onChange }: FilterProps) => {
               <Backdrop
                 open={isStatusesMenuOpen}
                 onClick={() => setIsStatusesMenuOpen(false)}
-                sx={{ zIndex: 10000, opacity: "0 !important", cursor: "text" }}
+                sx={{ zIndex: 500, opacity: "0 !important", cursor: "text" }}
               />
             </StyledFormControl>
           </Grid>


### PR DESCRIPTION
### Overview

Adjust the z-index of several components to make it easier to layer.

### Change Details (Specifics)

- Adjusted dropdowns, backdrops, clear buttons, and suspense loader zindex's according to the following format:
```
- Table Suspense Loader: 250
- (Custom) Backdrop: 500 - Only needed when clear button is used
- Clear Button: 600
- Dropdown: 700
- Navbar: 1100
- Alert: 1400
```
- Please test and LMK if I missed anything

### Related Ticket(s)

[CRDCDH-3442](https://tracker.nci.nih.gov/browse/CRDCDH-3442) (Task)
[CRDCDH-3427](https://tracker.nci.nih.gov/browse/CRDCDH-3427) (US)