### PR TITLE
CRDCDH-3516 Persist chat conversation

### DIFF
--- a/src/components/ChatBot/api/knowledgeBaseClient.test.ts
+++ b/src/components/ChatBot/api/knowledgeBaseClient.test.ts
@@ -109,7 +109,11 @@ describe("askQuestion", () => {
       TEST_API_URL,
       expect.objectContaining({
         method: "POST",
-        body: JSON.stringify({ question: "Test question", sessionId: "existing-session" }),
+        body: JSON.stringify({
+          question: "Test question",
+          sessionId: "existing-session",
+          conversationHistory: [],
+        }),
       })
     );
   });

--- a/src/components/ChatBot/api/knowledgeBaseClient.ts
+++ b/src/components/ChatBot/api/knowledgeBaseClient.ts
@@ -12,6 +12,7 @@ export type AskKnowledgeBaseResponse = {
 type AskQuestionArgs = {
   question: string;
   sessionId?: string | null;
+  conversationHistory?: ConversationHistory[];
   onChunk?: (chunk: string) => void;
   onCitation?: (citation: ChatCitation) => void;
   signal?: AbortSignal;
@@ -155,6 +156,7 @@ export async function processStreamingResponse(
 export async function askQuestion({
   question,
   sessionId = null,
+  conversationHistory = [],
   onChunk,
   onCitation,
   signal,
@@ -168,7 +170,7 @@ export async function askQuestion({
   try {
     const response = await fetch(url, {
       method: "POST",
-      body: JSON.stringify({ question, sessionId }),
+      body: JSON.stringify({ question, sessionId, conversationHistory }),
       signal,
     });
 

--- a/src/components/ChatBot/api/knowledgeBaseClient.ts
+++ b/src/components/ChatBot/api/knowledgeBaseClient.ts
@@ -118,11 +118,11 @@ export async function processStreamingResponse(
           await emitWithTypewriter(outputText, onChunk, typewriterDelay, signal);
         }
 
-        const citationHasContent = !!parsed.citation && !!parsed.citation.url;
-        const citationIsNotDuplicate = !seenCitationUrls.has(parsed.citation.url);
+        const citationHasContent = !!parsed?.citation && !!parsed?.citation?.url;
+        const citationIsNotDuplicate = !seenCitationUrls.has(parsed?.citation?.url);
 
         if (citationHasContent && citationIsNotDuplicate) {
-          seenCitationUrls.add(parsed.citation.url);
+          seenCitationUrls.add(parsed.citation?.url);
           citations.push(parsed.citation);
           onCitation?.(parsed.citation);
         }

--- a/src/components/ChatBot/context/ChatConversationContext.test.tsx
+++ b/src/components/ChatBot/context/ChatConversationContext.test.tsx
@@ -4,6 +4,8 @@ import userEvent from "@testing-library/user-event";
 import React from "react";
 
 import * as knowledgeBaseClient from "../api/knowledgeBaseClient";
+import * as chatUtils from "../utils/chatUtils";
+import * as conversationStorageUtils from "../utils/conversationStorageUtils";
 import * as sessionStorageUtils from "../utils/sessionStorageUtils";
 
 import * as ChatBotContextModule from "./ChatBotContext";
@@ -35,10 +37,22 @@ vi.mock("../utils/sessionStorageUtils", () => ({
   clearStoredSessionId: vi.fn(),
 }));
 
+vi.mock("../utils/conversationStorageUtils", () => ({
+  getStoredConversationMessages: vi.fn(),
+  storeConversationMessages: vi.fn(),
+  clearConversationMessages: vi.fn(),
+}));
+
 const mockAskQuestion = vi.mocked(knowledgeBaseClient.askQuestion);
 const mockUseChatBotContext = vi.mocked(ChatBotContextModule.useChatBotContext);
 const mockGetStoredSessionId = vi.mocked(sessionStorageUtils.getStoredSessionId);
 const mockClearStoredSessionId = vi.mocked(sessionStorageUtils.clearStoredSessionId);
+const mockGetStoredConversationMessages = vi.mocked(
+  conversationStorageUtils.getStoredConversationMessages
+);
+const mockStoreConversationMessages = vi.mocked(conversationStorageUtils.storeConversationMessages);
+const mockClearConversationMessages = vi.mocked(conversationStorageUtils.clearConversationMessages);
+const mockCreateChatMessage = vi.mocked(chatUtils.createChatMessage);
 
 const TestParent = () => {
   const conversation = useChatConversationContext();
@@ -54,8 +68,14 @@ const TestParent = () => {
             data-testid={`message-${msg.id}`}
             data-sender={msg.sender}
             data-variant={msg.variant}
+            data-citations={msg.citations?.length ?? 0}
           >
             {msg.text}
+            {msg.citations && msg.citations.length > 0 && (
+              <span data-testid={`citations-${msg.id}`}>
+                {msg.citations.map((c) => c.title).join(", ")}
+              </span>
+            )}
           </div>
         ))}
       </div>
@@ -88,12 +108,19 @@ const TestParent = () => {
   );
 };
 
-const renderWithProvider = () =>
-  render(
+const renderWithProvider = async () => {
+  const view = render(
     <ChatConversationProvider>
       <TestParent />
     </ChatConversationProvider>
   );
+
+  await waitFor(() => {
+    expect(view.getByTestId("messages-count")).toBeInTheDocument();
+  });
+
+  return view;
+};
 
 describe("ChatConversationContext", () => {
   beforeEach(() => {
@@ -105,57 +132,52 @@ describe("ChatConversationContext", () => {
     });
     mockGetStoredSessionId.mockReturnValue("test-session-id");
     mockAskQuestion.mockResolvedValue({ sessionId: "test-session-id", citations: [] });
+    mockGetStoredConversationMessages.mockResolvedValue([]);
+    mockStoreConversationMessages.mockResolvedValue();
+    mockClearConversationMessages.mockResolvedValue();
   });
 
   describe("Initial State", () => {
-    it("should initialize with greeting message", () => {
+    it("should initialize with greeting message", async () => {
       const { getByTestId } = render(
         <ChatConversationProvider>
           <TestParent />
         </ChatConversationProvider>
       );
 
-      expect(getByTestId("messages-count")).toHaveTextContent("1");
+      await waitFor(() => {
+        expect(getByTestId("messages-count")).toHaveTextContent("1");
+      });
     });
 
-    it("should initialize with empty input value", () => {
+    it("should initialize with empty input value", async () => {
       const { getByTestId } = render(
         <ChatConversationProvider>
           <TestParent />
         </ChatConversationProvider>
       );
 
-      expect(getByTestId("input-value")).toHaveValue("");
+      await waitFor(() => {
+        expect(getByTestId("input-value")).toHaveValue("");
+      });
     });
 
-    it("should initialize with isBotTyping as false", () => {
-      const { getByTestId } = render(
-        <ChatConversationProvider>
-          <TestParent />
-        </ChatConversationProvider>
-      );
+    it("should initialize with isBotTyping as false", async () => {
+      const { getByTestId } = await renderWithProvider();
 
       expect(getByTestId("is-bot-typing")).toHaveTextContent("false");
     });
 
-    it("should initialize with greeting timestamp", () => {
-      const { getByTestId } = render(
-        <ChatConversationProvider>
-          <TestParent />
-        </ChatConversationProvider>
-      );
+    it("should initialize with greeting timestamp", async () => {
+      const { getByTestId } = await renderWithProvider();
 
       const timestamp = getByTestId("greeting-timestamp").textContent;
       expect(timestamp).toBeTruthy();
       expect(() => new Date(timestamp)).not.toThrow();
     });
 
-    it("should have stable greeting timestamp across re-renders", () => {
-      const { getByTestId, rerender } = render(
-        <ChatConversationProvider>
-          <TestParent />
-        </ChatConversationProvider>
-      );
+    it("should have stable greeting timestamp across re-renders", async () => {
+      const { getByTestId, rerender } = await renderWithProvider();
 
       const firstTimestamp = getByTestId("greeting-timestamp").textContent;
       rerender(
@@ -163,6 +185,11 @@ describe("ChatConversationContext", () => {
           <TestParent />
         </ChatConversationProvider>
       );
+
+      await waitFor(() => {
+        expect(getByTestId("messages-count")).toBeInTheDocument();
+      });
+
       const secondTimestamp = getByTestId("greeting-timestamp").textContent;
 
       expect(firstTimestamp).toBe(secondTimestamp);
@@ -171,7 +198,7 @@ describe("ChatConversationContext", () => {
 
   describe("setInputValue", () => {
     it("should update input value", async () => {
-      const { getByTestId } = renderWithProvider();
+      const { getByTestId } = await renderWithProvider();
 
       const input = getByTestId("input-value");
       userEvent.clear(input);
@@ -181,7 +208,7 @@ describe("ChatConversationContext", () => {
     });
 
     it("should update input value multiple times", async () => {
-      const { getByTestId } = renderWithProvider();
+      const { getByTestId } = await renderWithProvider();
 
       const input = getByTestId("input-value");
       userEvent.clear(input);
@@ -196,7 +223,7 @@ describe("ChatConversationContext", () => {
     });
 
     it("should handle empty string", async () => {
-      const { getByTestId } = renderWithProvider();
+      const { getByTestId } = await renderWithProvider();
 
       const input = getByTestId("input-value");
       userEvent.type(input, "Test");
@@ -208,7 +235,7 @@ describe("ChatConversationContext", () => {
 
   describe("sendMessage", () => {
     it("should not send empty message", async () => {
-      const { getByTestId } = renderWithProvider();
+      const { getByTestId } = await renderWithProvider();
 
       const sendButton = getByTestId("send-button");
       userEvent.click(sendButton);
@@ -218,7 +245,7 @@ describe("ChatConversationContext", () => {
     });
 
     it("should not send whitespace-only message", async () => {
-      const { getByTestId } = renderWithProvider();
+      const { getByTestId } = await renderWithProvider();
 
       const input = getByTestId("input-value");
       userEvent.type(input, "   ");
@@ -231,7 +258,7 @@ describe("ChatConversationContext", () => {
     });
 
     it("should add user message when sending", async () => {
-      const { getByTestId } = renderWithProvider();
+      const { getByTestId } = await renderWithProvider();
 
       const input = getByTestId("input-value");
       userEvent.type(input, "Hello bot");
@@ -245,7 +272,7 @@ describe("ChatConversationContext", () => {
     });
 
     it("should clear input after sending", async () => {
-      const { getByTestId } = renderWithProvider();
+      const { getByTestId } = await renderWithProvider();
 
       const input = getByTestId("input-value");
       userEvent.type(input, "Test message");
@@ -266,7 +293,7 @@ describe("ChatConversationContext", () => {
           })
       );
 
-      const { getByTestId } = renderWithProvider();
+      const { getByTestId } = await renderWithProvider();
 
       const input = getByTestId("input-value");
       userEvent.type(input, "Test");
@@ -280,7 +307,7 @@ describe("ChatConversationContext", () => {
     });
 
     it("should call askQuestion with correct parameters", async () => {
-      const { getByTestId } = renderWithProvider();
+      const { getByTestId } = await renderWithProvider();
 
       const input = getByTestId("input-value");
       userEvent.type(input, "What is CRDC?");
@@ -310,7 +337,7 @@ describe("ChatConversationContext", () => {
         return { sessionId: "test-session-id", citations: [] };
       });
 
-      const { getByTestId } = renderWithProvider();
+      const { getByTestId } = await renderWithProvider();
 
       const input = getByTestId("input-value");
       userEvent.type(input, "Hi");
@@ -334,7 +361,7 @@ describe("ChatConversationContext", () => {
         return { sessionId: "test-session-id", citations: [] };
       });
 
-      const { getByTestId } = renderWithProvider();
+      const { getByTestId } = await renderWithProvider();
 
       const input = getByTestId("input-value");
       userEvent.type(input, "Test");
@@ -356,7 +383,7 @@ describe("ChatConversationContext", () => {
         return { sessionId: "test-session-id", citations: [] };
       });
 
-      const { getByTestId } = renderWithProvider();
+      const { getByTestId } = await renderWithProvider();
 
       const input = getByTestId("input-value");
       userEvent.type(input, "Test");
@@ -375,7 +402,7 @@ describe("ChatConversationContext", () => {
     it("should handle error response", async () => {
       mockAskQuestion.mockRejectedValue(new Error("API Error"));
 
-      const { getByTestId, getByText } = renderWithProvider();
+      const { getByTestId, getByText } = await renderWithProvider();
 
       const input = getByTestId("input-value");
       userEvent.type(input, "Test");
@@ -398,7 +425,7 @@ describe("ChatConversationContext", () => {
           })
       );
 
-      const { getByTestId } = renderWithProvider();
+      const { getByTestId } = await renderWithProvider();
 
       const input = getByTestId("input-value");
       userEvent.type(input, "First message");
@@ -419,6 +446,33 @@ describe("ChatConversationContext", () => {
       expect(getByTestId("messages-count")).toHaveTextContent(messageCount);
     });
 
+    it("should return early from sendMessage when bot is typing (via keydown)", async () => {
+      mockAskQuestion.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            setTimeout(() => resolve({ sessionId: "test-session-id", citations: [] }), 200);
+          })
+      );
+
+      const { getByTestId } = await renderWithProvider();
+
+      const input = getByTestId("input-value");
+      userEvent.type(input, "First message{Enter}");
+
+      await waitFor(() => {
+        expect(getByTestId("is-bot-typing")).toHaveTextContent("true");
+      });
+
+      const messageCount = getByTestId("messages-count").textContent;
+      const callCount = mockAskQuestion.mock.calls.length;
+
+      userEvent.clear(input);
+      userEvent.type(input, "Second message{Enter}");
+
+      expect(getByTestId("messages-count")).toHaveTextContent(messageCount);
+      expect(mockAskQuestion).toHaveBeenCalledTimes(callCount);
+    });
+
     it("should abort previous request when sending new message", async () => {
       const abortSignals: AbortSignal[] = [];
 
@@ -433,7 +487,7 @@ describe("ChatConversationContext", () => {
         return { sessionId: "test-session-id", citations: [] };
       });
 
-      const { getByTestId } = renderWithProvider();
+      const { getByTestId } = await renderWithProvider();
 
       const input = getByTestId("input-value");
       const sendButton = getByTestId("send-button");
@@ -461,7 +515,7 @@ describe("ChatConversationContext", () => {
       abortError.name = "AbortError";
       mockAskQuestion.mockRejectedValue(abortError);
 
-      const { getByTestId, queryByText } = renderWithProvider();
+      const { getByTestId, queryByText } = await renderWithProvider();
 
       const input = getByTestId("input-value");
       userEvent.type(input, "Test");
@@ -479,7 +533,7 @@ describe("ChatConversationContext", () => {
 
   describe("handleKeyDown", () => {
     it("should send message on Enter key", async () => {
-      const { getByTestId } = renderWithProvider();
+      const { getByTestId } = await renderWithProvider();
 
       const input = getByTestId("input-value");
       userEvent.type(input, "Test message{Enter}");
@@ -490,7 +544,7 @@ describe("ChatConversationContext", () => {
     });
 
     it("should not send message on Shift+Enter", async () => {
-      const { getByTestId } = renderWithProvider();
+      const { getByTestId } = await renderWithProvider();
 
       const input = getByTestId("input-value");
       userEvent.type(input, "Test message");
@@ -502,7 +556,7 @@ describe("ChatConversationContext", () => {
     });
 
     it("should not send message on other keys", async () => {
-      const { getByTestId } = renderWithProvider();
+      const { getByTestId } = await renderWithProvider();
 
       const input = getByTestId("input-value");
       userEvent.type(input, "Test message");
@@ -516,7 +570,7 @@ describe("ChatConversationContext", () => {
 
   describe("endConversation", () => {
     it("should clear stored session ID", async () => {
-      const { getByTestId } = renderWithProvider();
+      const { getByTestId } = await renderWithProvider();
 
       const endButton = getByTestId("end-conversation-button");
       userEvent.click(endButton);
@@ -535,7 +589,7 @@ describe("ChatConversationContext", () => {
         return { sessionId: "test-session-id", citations: [] };
       });
 
-      const { getByTestId } = renderWithProvider();
+      const { getByTestId } = await renderWithProvider();
 
       const input = getByTestId("input-value");
       userEvent.type(input, "Test");
@@ -564,7 +618,7 @@ describe("ChatConversationContext", () => {
         return { sessionId: "test-session-id", citations: [] };
       });
 
-      const { getByTestId, unmount } = renderWithProvider();
+      const { getByTestId, unmount } = await renderWithProvider();
 
       const input = getByTestId("input-value");
       userEvent.type(input, "Test");
@@ -588,6 +642,7 @@ describe("ChatConversationContext", () => {
         messages: [],
         inputValue: "test",
         status: "idle" as const,
+        isInitialized: true,
       };
 
       const result = chatReducer(initialState, { type: "unknown" } as never);
@@ -598,7 +653,7 @@ describe("ChatConversationContext", () => {
 
   describe("Edge Cases", () => {
     it("should handle multiple rapid setInputValue calls", async () => {
-      const { getByTestId } = renderWithProvider();
+      const { getByTestId } = await renderWithProvider();
 
       const input = getByTestId("input-value");
       userEvent.clear(input);
@@ -616,7 +671,7 @@ describe("ChatConversationContext", () => {
         return { sessionId: "test-session-id", citations: [] };
       });
 
-      const { getByTestId } = renderWithProvider();
+      const { getByTestId } = await renderWithProvider();
 
       const input = getByTestId("input-value");
       userEvent.type(input, "Test");
@@ -631,7 +686,7 @@ describe("ChatConversationContext", () => {
     });
 
     it("should trim message before sending", async () => {
-      const { getByTestId } = renderWithProvider();
+      const { getByTestId } = await renderWithProvider();
 
       const input = getByTestId("input-value");
       userEvent.type(input, "  Test message  ");
@@ -648,8 +703,8 @@ describe("ChatConversationContext", () => {
       });
     });
 
-    it("should handle Shift+Enter without sending message", () => {
-      const { getByTestId } = renderWithProvider();
+    it("should handle Shift+Enter without sending message", async () => {
+      const { getByTestId } = await renderWithProvider();
 
       const input = getByTestId("input-value");
       userEvent.type(input, "Test message");
@@ -689,7 +744,7 @@ describe("ChatConversationContext", () => {
         return { sessionId: "test-session-id", citations: [] };
       });
 
-      const { getByTestId } = renderWithProvider();
+      const { getByTestId } = await renderWithProvider();
 
       const input = getByTestId("input-value");
       userEvent.type(input, "First");
@@ -724,7 +779,7 @@ describe("ChatConversationContext", () => {
         throw new Error("Synchronous error");
       });
 
-      const { getByTestId } = renderWithProvider();
+      const { getByTestId } = await renderWithProvider();
 
       const input = getByTestId("input-value");
       userEvent.type(input, "Test");
@@ -735,6 +790,39 @@ describe("ChatConversationContext", () => {
       await waitFor(() => {
         expect(getByTestId("is-bot-typing")).toHaveTextContent("false");
       });
+    });
+
+    it("should reset status to idle when runReply throws non-abort error", async () => {
+      const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+      const originalImplementation = mockCreateChatMessage.getMockImplementation();
+      let shouldThrow = false;
+
+      mockCreateChatMessage.mockImplementation((params) => {
+        if (shouldThrow && params.variant === "error") {
+          throw new Error("createChatMessage failed");
+        }
+        return originalImplementation(params);
+      });
+
+      mockAskQuestion.mockImplementation(async () => {
+        shouldThrow = true;
+        throw new Error("API Error");
+      });
+
+      const { getByTestId } = await renderWithProvider();
+
+      const input = getByTestId("input-value");
+      userEvent.type(input, "Test");
+
+      const sendButton = getByTestId("send-button");
+      userEvent.click(sendButton);
+
+      await waitFor(() => {
+        expect(getByTestId("is-bot-typing")).toHaveTextContent("false");
+      });
+
+      mockCreateChatMessage.mockImplementation(originalImplementation);
+      consoleError.mockRestore();
     });
 
     it("should return early when aborted after askQuestion completes", async () => {
@@ -758,7 +846,7 @@ describe("ChatConversationContext", () => {
         return { sessionId: "test-session-id", citations: [] };
       });
 
-      const { getByTestId } = renderWithProvider();
+      const { getByTestId } = await renderWithProvider();
 
       const input = getByTestId("input-value");
       userEvent.type(input, "First");
@@ -790,5 +878,104 @@ describe("ChatConversationContext", () => {
         { timeout: 2000 }
       );
     });
+
+    it("should add citations to bot message when citations are provided", async () => {
+      const mockCitation: ChatCitation = {
+        title: "Test Citation",
+        url: "https://example.com",
+        snippet: "Test snippet",
+      };
+
+      mockAskQuestion.mockImplementation(async ({ onChunk, onCitation }) => {
+        if (onChunk) {
+          onChunk("Response with citation");
+        }
+        if (onCitation) {
+          onCitation(mockCitation);
+        }
+        return { sessionId: "test-session-id", citations: [mockCitation] };
+      });
+
+      const { getByTestId } = await renderWithProvider();
+
+      const input = getByTestId("input-value");
+      userEvent.type(input, "Test");
+
+      const sendButton = getByTestId("send-button");
+      userEvent.click(sendButton);
+
+      await waitFor(() => {
+        const messages = getByTestId("messages");
+        expect(messages.textContent).toContain("Test Citation");
+      });
+    });
+
+    it("should handle multiple citations", async () => {
+      const citations: ChatCitation[] = [
+        { title: "Citation 1", url: "https://example.com/1", snippet: "Snippet 1" },
+        { title: "Citation 2", url: "https://example.com/2", snippet: "Snippet 2" },
+      ];
+
+      mockAskQuestion.mockImplementation(async ({ onChunk, onCitation }) => {
+        if (onChunk) {
+          onChunk("Response");
+        }
+        if (onCitation) {
+          citations.forEach((c) => onCitation(c));
+        }
+        return { sessionId: "test-session-id", citations };
+      });
+
+      const { getByTestId } = await renderWithProvider();
+
+      const input = getByTestId("input-value");
+      userEvent.type(input, "Test");
+
+      const sendButton = getByTestId("send-button");
+      userEvent.click(sendButton);
+
+      await waitFor(() => {
+        const messages = getByTestId("messages");
+        expect(messages.textContent).toContain("Citation 1");
+        expect(messages.textContent).toContain("Citation 2");
+      });
+    });
+
+    it("should not add citations block when no citations provided", async () => {
+      mockAskQuestion.mockImplementation(async ({ onChunk }) => {
+        if (onChunk) {
+          onChunk("Response without citations");
+        }
+        return { sessionId: "test-session-id", citations: [] };
+      });
+
+      const { getByTestId, queryByTestId } = await renderWithProvider();
+
+      const input = getByTestId("input-value");
+      userEvent.type(input, "Test");
+
+      const sendButton = getByTestId("send-button");
+      userEvent.click(sendButton);
+
+      await waitFor(() => {
+        expect(getByTestId("messages-count")).toHaveTextContent("3");
+      });
+
+      const messagesContainer = getByTestId("messages");
+      const botMessages = messagesContainer.querySelectorAll('[data-sender="bot"]');
+      const lastBotMessage = botMessages[botMessages.length - 1];
+      expect(lastBotMessage?.getAttribute("data-citations")).toBe("0");
+      expect(queryByTestId(/^citations-/)).not.toBeInTheDocument();
+    });
+  });
+
+  it("should throw error when used outside provider", () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    expect(() => render(<TestParent />)).toThrow(
+      "useChatConversationContext must be used within ChatConversationProvider"
+    );
+
+    consoleError.mockRestore();
   });
 });

--- a/src/components/ChatBot/context/ChatConversationContext.tsx
+++ b/src/components/ChatBot/context/ChatConversationContext.tsx
@@ -11,6 +11,11 @@ import React, {
 import { askQuestion } from "../api/knowledgeBaseClient";
 import chatConfig from "../config/chatConfig";
 import { createChatMessage, createId, isAbortError } from "../utils/chatUtils";
+import {
+  clearConversationMessages,
+  getStoredConversationMessages,
+  storeConversationMessages,
+} from "../utils/conversationStorageUtils";
 import { clearStoredSessionId, getStoredSessionId } from "../utils/sessionStorageUtils";
 
 import { useChatBotContext } from "./ChatBotContext";
@@ -19,6 +24,7 @@ type ChatState = {
   messages: ChatMessage[];
   inputValue: string;
   status: ChatStatus;
+  isInitialized: boolean;
 };
 
 type ChatAction =
@@ -26,7 +32,8 @@ type ChatAction =
   | { type: "input_cleared" }
   | { type: "message_added"; message: ChatMessage }
   | { type: "status_changed"; status: ChatStatus }
-  | { type: "conversation_reset" };
+  | { type: "conversation_reset" }
+  | { type: "chat_initialized"; messages: ChatMessage[] };
 
 export type ChatConversationActions = {
   greetingTimestamp: Date;
@@ -38,6 +45,16 @@ export type ChatConversationActions = {
   handleKeyDown: React.KeyboardEventHandler<HTMLDivElement>;
   endConversation: () => void;
 };
+
+/**
+ * Creates the initial greeting message for the chat.
+ */
+const createGreetingMessage = (): ChatMessage =>
+  createChatMessage({
+    text: chatConfig.initialMessage,
+    sender: "bot",
+    senderName: chatConfig.supportBotName,
+  });
 
 /**
  * Chat reducer to manage chat state transitions.
@@ -69,15 +86,17 @@ export const chatReducer = (state: ChatState, action: ChatAction): ChatState => 
     }
     case "conversation_reset": {
       return {
-        messages: [
-          createChatMessage({
-            text: chatConfig.initialMessage,
-            sender: "bot",
-            senderName: chatConfig.supportBotName,
-          }),
-        ],
+        messages: [createGreetingMessage()],
         inputValue: "",
         status: "idle",
+        isInitialized: true,
+      };
+    }
+    case "chat_initialized": {
+      return {
+        ...state,
+        messages: action.messages,
+        isInitialized: true,
       };
     }
     default: {
@@ -96,19 +115,33 @@ const useChatConversation = (): ChatConversationActions => {
   const greetingTimestampRef = useRef<Date>(new Date());
 
   const [state, dispatch] = useReducer(chatReducer, {
-    messages: [
-      createChatMessage({
-        text: chatConfig.initialMessage,
-        sender: "bot",
-        senderName: chatConfig.supportBotName,
-      }),
-    ],
+    messages: [createGreetingMessage()],
     inputValue: "",
     status: "idle",
+    isInitialized: false,
   });
 
   const stateRef = useRef(state);
   stateRef.current = state;
+
+  /**
+   * Initializes the chat by loading conversation history from IndexedDB.
+   */
+  const initializeChat = useCallback(async () => {
+    const storedMessages = await getStoredConversationMessages();
+    const messages = [createGreetingMessage(), ...storedMessages];
+    dispatch({ type: "chat_initialized", messages });
+  }, []);
+
+  useEffect(() => {
+    initializeChat();
+  }, [initializeChat]);
+
+  useEffect(() => {
+    if (state.isInitialized && state.messages.length > 0) {
+      storeConversationMessages(state.messages.slice(1));
+    }
+  }, [state.messages, state.isInitialized]);
 
   const activeRequestRef = useRef<{
     requestId: string;
@@ -304,6 +337,7 @@ const useChatConversation = (): ChatConversationActions => {
    */
   const endConversation = useCallback((): void => {
     clearStoredSessionId();
+    clearConversationMessages();
     activeRequestRef.current?.abortController.abort();
     activeRequestRef.current = null;
     greetingTimestampRef.current = new Date();

--- a/src/components/ChatBot/context/ChatConversationContext.tsx
+++ b/src/components/ChatBot/context/ChatConversationContext.tsx
@@ -150,6 +150,19 @@ const useChatConversation = (): ChatConversationActions => {
   }, []);
 
   /**
+   * Builds conversation history from messages for the API request.
+   * Excludes the initial greeting message.
+   */
+  const buildConversationHistory = useCallback(
+    (messages: ChatMessage[]): ConversationHistory[] =>
+      messages.slice(1).map((msg) => ({
+        role: msg.sender === "user" ? "user" : "assistant",
+        content: msg.text,
+      })),
+    []
+  );
+
+  /**
    * Executes the bot reply request with streaming support.
    */
   const runReply = useCallback(
@@ -163,10 +176,12 @@ const useChatConversation = (): ChatConversationActions => {
         let accumulatedText = "";
         const allCitations: ChatCitation[] = [];
         let firstChunkReceived = false;
+        const conversationHistory = buildConversationHistory(stateRef.current.messages);
 
         await askQuestion({
           question: userMessage,
           sessionId: getStoredSessionId(),
+          conversationHistory,
           signal: abortController.signal,
           url: knowledgeBaseUrl,
           onChunk: (chunk: string) => {
@@ -215,7 +230,7 @@ const useChatConversation = (): ChatConversationActions => {
         handleReplyError(error, requestId);
       }
     },
-    [knowledgeBaseUrl, handleReplyError]
+    [knowledgeBaseUrl, handleReplyError, buildConversationHistory]
   );
 
   /**

--- a/src/components/ChatBot/context/ChatDrawerContext.test.tsx
+++ b/src/components/ChatBot/context/ChatDrawerContext.test.tsx
@@ -1,5 +1,6 @@
 import { waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { render } from "@/test-utils";
@@ -16,6 +17,20 @@ vi.mock("../hooks/useChatDrawer", () => ({
 vi.mock("./ChatBotContext", () => ({
   useChatBotContext: vi.fn(() => ({
     isChatEnabled: true,
+  })),
+}));
+
+vi.mock("./ChatConversationContext", () => ({
+  ChatConversationProvider: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  useChatConversationContext: vi.fn(() => ({
+    messages: [],
+    inputValue: "",
+    isBotTyping: false,
+    setInputValue: vi.fn(),
+    sendMessage: vi.fn(),
+    handleKeyDown: vi.fn(),
+    endConversation: vi.fn(),
+    greetingTimestamp: new Date(),
   })),
 }));
 

--- a/src/components/ChatBot/utils/conversationStorageUtils.test.ts
+++ b/src/components/ChatBot/utils/conversationStorageUtils.test.ts
@@ -1,0 +1,363 @@
+import { chatMessageFactory } from "@/test-utils/factories/chatbot/ChatMessageFactory";
+import { Logger } from "@/utils";
+
+import * as utils from "./conversationStorageUtils";
+
+vi.mock("@/utils", () => ({
+  Logger: {
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+const createMockIndexedDB = () => {
+  let store: Record<string, unknown> = {};
+
+  const mockObjectStore = {
+    add: vi.fn((item: unknown) => {
+      const itemWithId = item as { id: string };
+      store[itemWithId.id] = item;
+      return { onsuccess: null, onerror: null };
+    }),
+    clear: vi.fn(() => {
+      store = {};
+      return { onsuccess: null, onerror: null };
+    }),
+    getAll: vi.fn(() => {
+      const request = {
+        result: Object.values(store),
+        onsuccess: null,
+        onerror: null,
+      };
+      setTimeout(() => request.onsuccess?.(), 0);
+      return request;
+    }),
+  };
+
+  const mockTransaction = {
+    objectStore: vi.fn(() => mockObjectStore),
+    oncomplete: null,
+    onerror: null,
+  };
+
+  const mockDb = {
+    transaction: vi.fn(() => {
+      setTimeout(() => mockTransaction.oncomplete?.(), 0);
+      return mockTransaction;
+    }),
+    createObjectStore: vi.fn(),
+    objectStoreNames: { contains: vi.fn(() => false) },
+    close: vi.fn(),
+  };
+
+  const mockRequest = {
+    result: mockDb,
+    onsuccess: null,
+    onerror: null,
+    onupgradeneeded: null,
+  };
+
+  const mockIndexedDB = {
+    open: vi.fn(() => {
+      setTimeout(() => {
+        mockRequest.onupgradeneeded?.({ target: { result: mockDb } });
+        mockRequest.onsuccess?.();
+      }, 0);
+      return mockRequest;
+    }),
+  };
+
+  return {
+    mockIndexedDB,
+    mockDb,
+    mockTransaction,
+    mockObjectStore,
+    store,
+    clearStore: () => {
+      store = {};
+    },
+  };
+};
+
+describe("storeConversationMessages", () => {
+  let mockIDB: ReturnType<typeof createMockIndexedDB>;
+  const originalIndexedDB = globalThis.indexedDB;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionStorage.clear();
+    mockIDB = createMockIndexedDB();
+    globalThis.indexedDB = mockIDB.mockIndexedDB as unknown as IDBFactory;
+  });
+
+  afterEach(() => {
+    globalThis.indexedDB = originalIndexedDB;
+  });
+
+  it("should store messages in IndexedDB", async () => {
+    const messages = [
+      chatMessageFactory.build({ id: "msg-1" }),
+      chatMessageFactory.build({ id: "msg-2" }),
+    ];
+
+    await utils.storeConversationMessages(messages);
+
+    expect(mockIDB.mockIndexedDB.open).toHaveBeenCalledWith("chatbot_conversation_db", 1);
+    expect(mockIDB.mockObjectStore.clear).toHaveBeenCalled();
+    expect(mockIDB.mockObjectStore.add).toHaveBeenCalledTimes(2);
+    expect(sessionStorage.getItem("chatbot_conversation_session")).toBe("active");
+  });
+
+  it("should mark session as active when storing messages", async () => {
+    const messages = [chatMessageFactory.build()];
+
+    await utils.storeConversationMessages(messages);
+
+    expect(sessionStorage.getItem("chatbot_conversation_session")).toBe("active");
+  });
+
+  it("should handle errors gracefully", async () => {
+    globalThis.indexedDB = {
+      open: vi.fn(() => {
+        const request = {
+          onerror: null,
+          onsuccess: null,
+          onupgradeneeded: null,
+        };
+        setTimeout(() => request.onerror?.(), 0);
+        return request;
+      }),
+    } as unknown as IDBFactory;
+
+    await utils.storeConversationMessages([chatMessageFactory.build()]);
+
+    expect(Logger.error).toHaveBeenCalled();
+  });
+
+  it("should close db and log error when transaction fails", async () => {
+    mockIDB.mockDb.transaction = vi.fn(() => {
+      setTimeout(() => mockIDB.mockTransaction.onerror?.(), 0);
+      return mockIDB.mockTransaction;
+    });
+
+    await utils.storeConversationMessages([chatMessageFactory.build()]);
+
+    expect(mockIDB.mockDb.close).toHaveBeenCalled();
+    expect(Logger.error).toHaveBeenCalledWith(
+      "conversationStorageUtils: Failed to store conversation messages in IndexedDB",
+      expect.any(Error)
+    );
+  });
+
+  it("should log error when markSessionActive fails", async () => {
+    const setItemSpy = vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("Storage error");
+    });
+
+    await utils.storeConversationMessages([chatMessageFactory.build()]);
+
+    expect(Logger.error).toHaveBeenCalledWith(
+      "conversationStorageUtils: Failed to mark session as active in sessionStorage"
+    );
+
+    setItemSpy.mockRestore();
+  });
+});
+
+describe("getStoredConversationMessages", () => {
+  let mockIDB: ReturnType<typeof createMockIndexedDB>;
+  const originalIndexedDB = globalThis.indexedDB;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionStorage.clear();
+    mockIDB = createMockIndexedDB();
+    globalThis.indexedDB = mockIDB.mockIndexedDB as unknown as IDBFactory;
+  });
+
+  afterEach(() => {
+    globalThis.indexedDB = originalIndexedDB;
+  });
+
+  it("should return empty array if session is not active", async () => {
+    const result = await utils.getStoredConversationMessages();
+
+    expect(result).toEqual([]);
+  });
+
+  it("should retrieve messages when session is active", async () => {
+    sessionStorage.setItem("chatbot_conversation_session", "active");
+
+    const storedMessage = chatMessageFactory.build({
+      id: "msg-1",
+      text: "Test",
+      sender: "user",
+      timestamp: new Date("2026-01-01T12:00:00.000Z"),
+      senderName: "User",
+      variant: "default",
+    });
+
+    mockIDB.mockObjectStore.getAll = vi.fn(() => {
+      const request = {
+        result: [storedMessage],
+        onsuccess: null,
+        onerror: null,
+      };
+      setTimeout(() => request.onsuccess?.(), 0);
+      return request;
+    });
+
+    const result = await utils.getStoredConversationMessages();
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("msg-1");
+    expect(result[0].timestamp).toBeInstanceOf(Date);
+  });
+
+  it("should clear messages and return empty array when session is invalid", async () => {
+    const result = await utils.getStoredConversationMessages();
+
+    expect(result).toEqual([]);
+  });
+
+  it("should handle errors gracefully and return empty array", async () => {
+    sessionStorage.setItem("chatbot_conversation_session", "active");
+    globalThis.indexedDB = {
+      open: vi.fn(() => {
+        const request = {
+          onerror: null,
+          onsuccess: null,
+          onupgradeneeded: null,
+        };
+        setTimeout(() => request.onerror?.(), 0);
+        return request;
+      }),
+    } as unknown as IDBFactory;
+
+    const result = await utils.getStoredConversationMessages();
+
+    expect(result).toEqual([]);
+    expect(Logger.error).toHaveBeenCalled();
+  });
+
+  it("should clear stored messages when browser session ends", async () => {
+    const result = await utils.getStoredConversationMessages();
+
+    expect(result).toEqual([]);
+  });
+
+  it("should close db and log error when request fails", async () => {
+    sessionStorage.setItem("chatbot_conversation_session", "active");
+
+    mockIDB.mockObjectStore.getAll = vi.fn(() => {
+      const request = {
+        result: [],
+        onsuccess: null,
+        onerror: null,
+      };
+      setTimeout(() => request.onerror?.(), 0);
+      return request;
+    });
+
+    const result = await utils.getStoredConversationMessages();
+
+    expect(result).toEqual([]);
+    expect(mockIDB.mockDb.close).toHaveBeenCalled();
+    expect(Logger.error).toHaveBeenCalledWith(
+      "conversationStorageUtils: Failed to retrieve conversation messages from IndexedDB",
+      expect.any(Error)
+    );
+  });
+
+  it("should return false and empty array when sessionStorage.getItem throws", async () => {
+    const getItemSpy = vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("Storage error");
+    });
+
+    const result = await utils.getStoredConversationMessages();
+
+    expect(result).toEqual([]);
+
+    getItemSpy.mockRestore();
+  });
+});
+
+describe("clearConversationMessages", () => {
+  let mockIDB: ReturnType<typeof createMockIndexedDB>;
+  const originalIndexedDB = globalThis.indexedDB;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionStorage.clear();
+    mockIDB = createMockIndexedDB();
+    globalThis.indexedDB = mockIDB.mockIndexedDB as unknown as IDBFactory;
+  });
+
+  afterEach(() => {
+    globalThis.indexedDB = originalIndexedDB;
+  });
+
+  it("should clear all messages from IndexedDB", async () => {
+    sessionStorage.setItem("chatbot_conversation_session", "active");
+
+    await utils.clearConversationMessages();
+
+    expect(mockIDB.mockObjectStore.clear).toHaveBeenCalled();
+    expect(sessionStorage.getItem("chatbot_conversation_session")).toBeNull();
+  });
+
+  it("should clear session marker", async () => {
+    sessionStorage.setItem("chatbot_conversation_session", "active");
+
+    await utils.clearConversationMessages();
+
+    expect(sessionStorage.getItem("chatbot_conversation_session")).toBeNull();
+  });
+
+  it("should handle errors gracefully", async () => {
+    globalThis.indexedDB = {
+      open: vi.fn(() => {
+        const request = {
+          onerror: null,
+          onsuccess: null,
+          onupgradeneeded: null,
+        };
+        setTimeout(() => request.onerror?.(), 0);
+        return request;
+      }),
+    } as unknown as IDBFactory;
+
+    await utils.clearConversationMessages();
+
+    expect(Logger.error).toHaveBeenCalled();
+  });
+
+  it("should close db and log error when transaction fails", async () => {
+    mockIDB.mockDb.transaction = vi.fn(() => {
+      setTimeout(() => mockIDB.mockTransaction.onerror?.(), 0);
+      return mockIDB.mockTransaction;
+    });
+
+    await utils.clearConversationMessages();
+
+    expect(mockIDB.mockDb.close).toHaveBeenCalled();
+    expect(Logger.error).toHaveBeenCalledWith(
+      "conversationStorageUtils: Failed to clear conversation messages from IndexedDB",
+      expect.any(Error)
+    );
+  });
+
+  it("should log error when clearSessionKey fails", async () => {
+    const removeItemSpy = vi.spyOn(Storage.prototype, "removeItem").mockImplementation(() => {
+      throw new Error("Storage error");
+    });
+
+    await utils.clearConversationMessages();
+
+    expect(Logger.error).toHaveBeenCalledWith(
+      "conversationStorageUtils: Failed to clear session key from sessionStorage"
+    );
+
+    removeItemSpy.mockRestore();
+  });
+});

--- a/src/components/ChatBot/utils/conversationStorageUtils.ts
+++ b/src/components/ChatBot/utils/conversationStorageUtils.ts
@@ -1,0 +1,173 @@
+import { Logger } from "@/utils";
+
+const DB_NAME = "chatbot_conversation_db";
+const DB_VERSION = 1;
+const STORE_NAME = "messages";
+const SESSION_KEY = "chatbot_conversation_session";
+
+/**
+ * Checks if the current session is valid by verifying the session key in sessionStorage.
+ *
+ * @returns {boolean} True if the session is valid, false otherwise.
+ */
+const isSessionValid = (): boolean => {
+  try {
+    return sessionStorage.getItem(SESSION_KEY) === "active";
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Marks the current session as active in sessionStorage.
+ */
+const markSessionActive = (): void => {
+  try {
+    sessionStorage.setItem(SESSION_KEY, "active");
+  } catch {
+    Logger.error("conversationStorageUtils: Failed to mark session as active in sessionStorage");
+  }
+};
+
+/**
+ * Clears the session key from sessionStorage.
+ */
+const clearSessionKey = (): void => {
+  try {
+    sessionStorage.removeItem(SESSION_KEY);
+  } catch {
+    Logger.error("conversationStorageUtils: Failed to clear session key from sessionStorage");
+  }
+};
+
+/**
+ * Opens the IndexedDB database, creating the object store if needed.
+ *
+ * @returns {Promise<IDBDatabase>} The opened database instance.
+ */
+const openDatabase = (): Promise<IDBDatabase> =>
+  new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+
+    request.onerror = () => {
+      reject(new Error("Failed to open IndexedDB"));
+    };
+
+    request.onsuccess = () => {
+      resolve(request.result);
+    };
+
+    // When a new version number higher than its current version is passed, it will create a new object store
+    request.onupgradeneeded = (event) => {
+      const db = (event.target as IDBOpenDBRequest).result;
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        db.createObjectStore(STORE_NAME, { keyPath: "id" });
+      }
+    };
+  });
+
+/**
+ * Stores all conversation messages in IndexedDB.
+ *
+ * @param {ChatMessage[]} messages - The messages to store.
+ * @returns {Promise<void>}
+ */
+export const storeConversationMessages = async (messages: ChatMessage[]): Promise<void> => {
+  try {
+    markSessionActive();
+    const db = await openDatabase();
+    const transaction = db.transaction(STORE_NAME, "readwrite");
+    const store = transaction.objectStore(STORE_NAME);
+
+    store.clear();
+    messages.forEach((message) => {
+      store.add(message);
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      transaction.oncomplete = () => {
+        db.close();
+        resolve();
+      };
+      transaction.onerror = () => {
+        db.close();
+        reject(new Error("Failed to store conversation messages"));
+      };
+    });
+  } catch (error) {
+    Logger.error(
+      "conversationStorageUtils: Failed to store conversation messages in IndexedDB",
+      error
+    );
+  }
+};
+
+/**
+ * Retrieves all stored conversation messages from IndexedDB.
+ *
+ * @returns {Promise<ChatMessage[]>} The stored messages, or empty array.
+ */
+export const getStoredConversationMessages = async (): Promise<ChatMessage[]> => {
+  try {
+    if (!isSessionValid()) {
+      await clearConversationMessages();
+      return [];
+    }
+
+    const db = await openDatabase();
+    const transaction = db.transaction(STORE_NAME, "readonly");
+    const store = transaction.objectStore(STORE_NAME);
+    const request = store.getAll();
+
+    return await new Promise<ChatMessage[]>((resolve, reject) => {
+      request.onsuccess = () => {
+        db.close();
+        const messages: ChatMessage[] = request.result;
+        messages.sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
+        resolve(messages);
+      };
+      request.onerror = () => {
+        db.close();
+        reject(new Error("Failed to retrieve conversation messages"));
+      };
+    });
+  } catch (error) {
+    Logger.error(
+      "conversationStorageUtils: Failed to retrieve conversation messages from IndexedDB",
+      error
+    );
+    return [];
+  }
+};
+
+/**
+ * Clears all stored conversation messages from IndexedDB.
+ *
+ * @returns {Promise<void>}
+ */
+export const clearConversationMessages = async (): Promise<void> => {
+  try {
+    clearSessionKey();
+
+    const db = await openDatabase();
+    const transaction = db.transaction(STORE_NAME, "readwrite");
+    const store = transaction.objectStore(STORE_NAME);
+    store.clear();
+
+    await new Promise<void>((resolve, reject) => {
+      transaction.oncomplete = () => {
+        db.close();
+        resolve();
+      };
+      transaction.onerror = () => {
+        db.close();
+        reject(new Error("Failed to clear conversation messages"));
+      };
+    });
+  } catch (error) {
+    Logger.error(
+      "conversationStorageUtils: Failed to clear conversation messages from IndexedDB",
+      error
+    );
+  }
+};

--- a/src/test-utils/factories/chatbot/ChatMessageFactory.ts
+++ b/src/test-utils/factories/chatbot/ChatMessageFactory.ts
@@ -1,0 +1,21 @@
+import { Factory } from "../Factory";
+
+/**
+ * Base chat message object
+ */
+export const baseChatMessage: ChatMessage = {
+  id: "",
+  text: "",
+  sender: "user",
+  timestamp: new Date(),
+  senderName: "",
+  variant: "default",
+};
+
+/**
+ * Chat message factory for creating chat message instances
+ */
+export const chatMessageFactory = new Factory<ChatMessage>((overrides) => ({
+  ...baseChatMessage,
+  ...overrides,
+}));

--- a/src/types/ChatBot.d.ts
+++ b/src/types/ChatBot.d.ts
@@ -19,3 +19,14 @@ type ChatMessage = {
   variant?: ChatMessageVariant;
   citations?: ChatCitation[];
 };
+
+type ConversationHistory = {
+  /**
+   * The role of the message sender.
+   */
+  role: "user" | "assistant";
+  /**
+   * The content of the message.
+   */
+  content: string;
+};


### PR DESCRIPTION
### Overview

Persist chat conversation by storing/retrieving the session conversation in IDB.

### Change Details (Specifics)

- Initialize chat by checking if active session, if active then attempt to retrieve existing conversation history from IDB
- As messages come in, store them in IDB
- Clear messages when conversation ends or session ends
- Send conversation history to chat API

### Related Ticket(s)

[CRDCDH-3516](https://tracker.nci.nih.gov/browse/CRDCDH-3516)