### PR TITLE
CRDCDH-3562 Change SR List default sort key

### DIFF
--- a/src/content/questionnaire/ListView.test.tsx
+++ b/src/content/questionnaire/ListView.test.tsx
@@ -592,4 +592,41 @@ describe("ListView Component", () => {
       expect(getByText("1/2/2021")).toBeInTheDocument();
     });
   });
+
+  it("uses Last Updated Date as the default sort key", async () => {
+    const variableMatcher = vi.fn().mockReturnValue(true);
+
+    const listApplicationsMock: MockedResponse<ListApplicationsResp, ListApplicationsInput> = {
+      request: {
+        query: LIST_APPLICATIONS,
+      },
+      variableMatcher,
+      result: {
+        data: {
+          listApplications: {
+            total: 0,
+            applications: [],
+            programs: [],
+            studies: [],
+          },
+        },
+      },
+    };
+
+    render(
+      <TestParent role="Submitter" mocks={[listApplicationsMock]}>
+        <ListView />
+      </TestParent>
+    );
+
+    await waitFor(() => {
+      expect(variableMatcher).toHaveBeenCalled();
+    });
+
+    expect(variableMatcher).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orderBy: "updatedAt",
+      })
+    );
+  });
 });

--- a/src/content/questionnaire/ListView.tsx
+++ b/src/content/questionnaire/ListView.tsx
@@ -175,7 +175,6 @@ const columns: Column<T>[] = [
         ""
       ),
     field: "submittedDate",
-    default: true,
     sx: {
       width: "161px",
     },
@@ -190,6 +189,7 @@ const columns: Column<T>[] = [
       ) : (
         ""
       ),
+    default: true,
     field: "updatedAt",
     sx: {
       width: "181px",


### PR DESCRIPTION
### Overview

Change the default sort key from "Submitted Date" to "Last Updated Date" on the Submission Request List

### Change Details (Specifics)

- Add unit tests for the new default sort key
- Swap the default sort column

### Related Ticket(s)

CRDCDH-3562 (Task)
CRDCDH-3526 (US)
