### PR TITLE
CRDCDH-3563 Add "Other" Repository data type option

### DIFF
--- a/src/classes/Excel/B/SectionB.ts
+++ b/src/classes/Excel/B/SectionB.ts
@@ -168,6 +168,24 @@ export class SectionB extends SectionBase<BKeys, SectionBDeps> {
       ],
     });
 
+    ws.addConditionalFormatting({
+      ref: "S2:S100",
+      rules: [
+        {
+          type: "expression",
+          formulae: ['AND($R2<>"",ISERROR(SEARCH("|Other|","|"&SUBSTITUTE($R2," ","")&"|")))'],
+          style: {
+            fill: {
+              type: "pattern",
+              pattern: "solid",
+              bgColor: { argb: "000000" },
+            },
+          },
+          priority: 1,
+        },
+      ],
+    });
+
     // Program
     A2.dataValidation = {
       type: "list",

--- a/src/classes/Excel/B/SectionB.ts
+++ b/src/classes/Excel/B/SectionB.ts
@@ -507,12 +507,12 @@ export class SectionB extends SectionBase<BKeys, SectionBDeps> {
           return dataTypes.includes(item);
         }) as Repository["dataTypesSubmitted"];
 
-      let otherDataTypesSubmitted = "";
-      if (dataTypesSubmitted.includes("Other")) {
-        otherDataTypesSubmitted = toString(repositoryOtherDataTypesSubmitted?.[i]).trim();
-      }
+      const rawOtherDataTypesSubmitted = toString(repositoryOtherDataTypesSubmitted?.[i]).trim();
+      const otherDataTypesSubmitted = dataTypesSubmitted.includes("Other")
+        ? rawOtherDataTypesSubmitted
+        : "";
 
-      if (name || studyID || dataTypesSubmitted.length || otherDataTypesSubmitted) {
+      if (name || studyID || dataTypesSubmitted.length || rawOtherDataTypesSubmitted) {
         repositories.push({ name, studyID, dataTypesSubmitted, otherDataTypesSubmitted });
       }
     });

--- a/src/classes/Excel/B/SectionB.ts
+++ b/src/classes/Excel/B/SectionB.ts
@@ -501,11 +501,16 @@ export class SectionB extends SectionBase<BKeys, SectionBDeps> {
             DataTypes.genomics.name,
             DataTypes.imaging.name,
             DataTypes.proteomics.name,
+            "Other",
           ];
 
           return dataTypes.includes(item);
         }) as Repository["dataTypesSubmitted"];
-      const otherDataTypesSubmitted = toString(repositoryOtherDataTypesSubmitted?.[i]).trim();
+
+      let otherDataTypesSubmitted = "";
+      if (dataTypesSubmitted.includes("Other")) {
+        otherDataTypesSubmitted = toString(repositoryOtherDataTypesSubmitted?.[i]).trim();
+      }
 
       if (name || studyID || dataTypesSubmitted.length || otherDataTypesSubmitted) {
         repositories.push({ name, studyID, dataTypesSubmitted, otherDataTypesSubmitted });

--- a/src/classes/QuestionnaireExcelMiddleware.test.ts
+++ b/src/classes/QuestionnaireExcelMiddleware.test.ts
@@ -1068,6 +1068,60 @@ describe("Serialization", () => {
       }
     });
 
+    it("should serialize repositories with 'Other' data type correctly", async () => {
+      const mockForm = questionnaireDataFactory.build({
+        study: studyFactory.build({
+          name: "",
+          abbreviation: "",
+          description: "",
+          funding: [],
+          publications: [],
+          plannedPublications: [],
+          repositories: [
+            repositoryFactory.build({
+              name: "Repo With Other Selected",
+              studyID: "RWO-001",
+              dataTypesSubmitted: ["clinicalTrial", "Other"],
+              otherDataTypesSubmitted: "metabolomics | transcriptomics",
+            }),
+            repositoryFactory.build({
+              name: "Repo Without Other Selected",
+              studyID: "RWNO-002",
+              dataTypesSubmitted: ["genomics", "imaging"],
+              otherDataTypesSubmitted: "should be in sheet but ignored on parse",
+            }),
+          ],
+        }),
+      });
+      const middleware = new QuestionnaireExcelMiddleware(mockForm, {});
+
+      // @ts-expect-error Private member
+      const sheet = await middleware.serializeSectionB();
+
+      // @ts-expect-error Private member
+      const wb = middleware.workbook;
+      expect(wb.getWorksheet("Program and Study")).toEqual(sheet);
+
+      expect(sheet.getColumn("P").values).toEqual([
+        undefined,
+        expect.any(String),
+        "Repo With Other Selected",
+        "Repo Without Other Selected",
+      ]);
+      expect(sheet.getColumn("R").values).toEqual([
+        undefined,
+        expect.any(String),
+        "clinicalTrial | Other",
+        "genomics | imaging",
+      ]);
+      expect(sheet.getColumn("S").values).toEqual([
+        undefined,
+        expect.any(String),
+        "metabolomics | transcriptomics",
+        "should be in sheet but ignored on parse",
+      ]);
+    });
+
     it("should generate SectionB sheet with partial data (all null)", async () => {
       const mockForm = questionnaireDataFactory.build({
         program: {
@@ -2263,7 +2317,7 @@ describe("Parsing", () => {
           repositoryFactory.build({
             name: "Repository 1",
             studyID: "02ec12d2-12c2-45b6-b12d-9fd954f696b8",
-            dataTypesSubmitted: ["clinicalTrial", "genomics", "imaging", "proteomics"],
+            dataTypesSubmitted: ["clinicalTrial", "genomics", "imaging", "proteomics", "Other"],
             otherDataTypesSubmitted: "other 1 | other 2 | other 3",
           }),
           repositoryFactory.build({
@@ -2358,16 +2412,92 @@ describe("Parsing", () => {
         expect.objectContaining({
           name: "Repository 1",
           studyID: "02ec12d2-12c2-45b6-b12d-9fd954f696b8",
-          dataTypesSubmitted: ["clinicalTrial", "genomics", "imaging", "proteomics"],
+          dataTypesSubmitted: ["clinicalTrial", "genomics", "imaging", "proteomics", "Other"],
           otherDataTypesSubmitted: "other 1 | other 2 | other 3",
         }),
         expect.objectContaining({
           name: "Repository 2",
           studyID: "03ec12d2-12c2-45b6-b12d-9fd954f696b8",
           dataTypesSubmitted: [],
-          otherDataTypesSubmitted: "other 1",
+          // otherDataTypesSubmitted is ignored when "Other" is not in dataTypesSubmitted
+          otherDataTypesSubmitted: "",
         }),
       ])
+    );
+  });
+
+  it("should ignore otherDataTypesSubmitted when 'Other' is not in dataTypesSubmitted", async () => {
+    const mockForm = questionnaireDataFactory.build({
+      study: studyFactory.build({
+        name: "Test Study",
+        abbreviation: "",
+        description: "",
+        funding: [],
+        publications: [],
+        plannedPublications: [],
+        repositories: [
+          repositoryFactory.build({
+            name: "Repo With Other",
+            studyID: "REPO-001",
+            dataTypesSubmitted: ["genomics", "Other"],
+            otherDataTypesSubmitted: "custom data type",
+          }),
+          repositoryFactory.build({
+            name: "Repo Without Other",
+            studyID: "REPO-002",
+            dataTypesSubmitted: ["genomics", "imaging"],
+            otherDataTypesSubmitted: "should be ignored",
+          }),
+          repositoryFactory.build({
+            name: "Repo Empty Types",
+            studyID: "REPO-003",
+            dataTypesSubmitted: [],
+            otherDataTypesSubmitted: "also should be ignored",
+          }),
+        ],
+      }),
+    });
+
+    const middleware = new QuestionnaireExcelMiddleware(mockForm, {});
+
+    // @ts-expect-error Private member
+    await middleware.serializeSectionB();
+
+    // @ts-expect-error Private member
+    middleware.data = { ...InitialQuestionnaire, sections: [...InitialSections] };
+
+    // @ts-expect-error Private member
+    const result = await middleware.parseSectionB();
+
+    // @ts-expect-error Private member
+    const output = middleware.data;
+
+    expect(result).toEqual(true);
+    expect(output.study.repositories).toHaveLength(3);
+
+    expect(output.study.repositories[0]).toEqual(
+      expect.objectContaining({
+        name: "Repo With Other",
+        studyID: "REPO-001",
+        dataTypesSubmitted: ["genomics", "Other"],
+        otherDataTypesSubmitted: "custom data type",
+      })
+    );
+    expect(output.study.repositories[1]).toEqual(
+      expect.objectContaining({
+        name: "Repo Without Other",
+        studyID: "REPO-002",
+        dataTypesSubmitted: ["genomics", "imaging"],
+        otherDataTypesSubmitted: "",
+      })
+    );
+    expect(output.study.repositories[2]).toEqual(
+      expect.objectContaining({
+        name: "Repo Empty Types",
+        studyID: "REPO-003",
+        dataTypesSubmitted: [],
+        otherDataTypesSubmitted: "",
+      })
     );
   });
 

--- a/src/classes/QuestionnaireExcelMiddleware.ts
+++ b/src/classes/QuestionnaireExcelMiddleware.ts
@@ -692,6 +692,7 @@ export class QuestionnaireExcelMiddleware {
         DataTypes.genomics.name,
         DataTypes.imaging.name,
         DataTypes.proteomics.name,
+        "Other",
       ];
       repositoryDataTypeOptions.forEach((file, index) => {
         sheet.getCell(`A${index + 1}`).value = file;

--- a/src/components/Questionnaire/FundingAgency.tsx
+++ b/src/components/Questionnaire/FundingAgency.tsx
@@ -35,7 +35,7 @@ const FundingAgency: FC<Props> = ({ idPrefix = "", index, funding, readOnly, onD
   const { agency, grantNumbers, nciProgramOfficer } = funding || {};
 
   return (
-    <GridContainer container>
+    <GridContainer container data-testid={idPrefix.concat(`funding-agency-${index}`)}>
       <Grid container item xs={12} rowSpacing={0} columnSpacing={1.5}>
         <Autocomplete
           id={idPrefix.concat(`funding-agency-${index}-organization`)}

--- a/src/components/Questionnaire/PlannedPublication.tsx
+++ b/src/components/Questionnaire/PlannedPublication.tsx
@@ -40,7 +40,7 @@ const PlannedPublication: FC<Props> = ({
   const { title, expectedDate } = plannedPublication;
 
   return (
-    <GridContainer container>
+    <GridContainer container data-testid={idPrefix.concat(`planned-publication-${index}`)}>
       <Grid container item xs={12} rowSpacing={0} columnSpacing={1.5}>
         <TextInput
           id={idPrefix.concat(`planned-publication-${index}-title`)}

--- a/src/components/Questionnaire/Publication.tsx
+++ b/src/components/Questionnaire/Publication.tsx
@@ -39,7 +39,7 @@ const Publication: FC<Props> = ({
   const { title, pubmedID, DOI } = publication;
 
   return (
-    <GridContainer container>
+    <GridContainer container data-testid={idPrefix.concat(`publication-${index}`)}>
       <Grid container item xs={12} rowSpacing={0} columnSpacing={1.5}>
         <TextInput
           id={idPrefix.concat(`publication-${index}-title`)}

--- a/src/components/Questionnaire/Repository.test.tsx
+++ b/src/components/Questionnaire/Repository.test.tsx
@@ -1,0 +1,373 @@
+import userEvent from "@testing-library/user-event";
+import { FC, useMemo } from "react";
+import { axe } from "vitest-axe";
+
+import { formContextStateFactory } from "@/factories/application/FormContextStateFactory";
+import { repositoryFactory } from "@/factories/application/RepositoryFactory";
+
+import { render, RenderResult, waitFor, within } from "../../test-utils";
+import {
+  ContextState as FormContextState,
+  Context as FormContext,
+  Status as FormStatus,
+} from "../Contexts/FormContext";
+
+import Repository, { repositoryDataTypesOptions } from "./Repository";
+
+/**
+ * Helper to get form elements by their test IDs
+ */
+const getFormElements = (
+  { getByTestId }: Pick<RenderResult, "getByTestId">,
+  index: number,
+  idPrefix = ""
+) => {
+  const testIdPrefix = `${idPrefix}repository-${index}`;
+  return {
+    container: () => getByTestId(testIdPrefix),
+    repositoryName: () => getByTestId(`${testIdPrefix}-name`),
+    studyId: () => getByTestId(`${testIdPrefix}-study-id`),
+    dataTypesSubmitted: () => getByTestId(`${testIdPrefix}-data-types-submitted`),
+    otherDataTypes: () => getByTestId(`${testIdPrefix}-other-data-types-submitted`),
+    otherDataTypesInput: () =>
+      within(getByTestId(`${testIdPrefix}-other-data-types-submitted`)).getByRole("textbox", {
+        hidden: true,
+      }),
+    removeButton: () => getByTestId(`${testIdPrefix}-remove-button`),
+  };
+};
+
+/**
+ * Helper to open the data types select dropdown
+ */
+const openDataTypesSelect = async (
+  { getByTestId }: Pick<RenderResult, "getByTestId">,
+  index: number,
+  idPrefix = ""
+) => {
+  const testIdPrefix = `${idPrefix}repository-${index}`;
+  const selectWrapper = getByTestId(`${testIdPrefix}-data-types-submitted`);
+  const selectButton = within(selectWrapper).getByRole("button");
+  userEvent.click(selectButton);
+};
+
+/**
+ * Helper to get the MUI listbox (not the native select element)
+ */
+const getMuiListbox = ({ getAllByRole }: Pick<RenderResult, "getAllByRole">) => {
+  const listboxes = getAllByRole("listbox", { hidden: true });
+  return listboxes.find((el) => el.tagName === "UL");
+};
+
+type TestParentProps = {
+  formStatus?: FormStatus;
+  children: React.ReactNode;
+};
+
+const TestParent: FC<TestParentProps> = ({
+  formStatus = FormStatus.LOADED,
+  children,
+}: TestParentProps) => {
+  const formValue = useMemo<FormContextState>(
+    () =>
+      formContextStateFactory.build({
+        status: formStatus,
+      }),
+    [formStatus]
+  );
+
+  return <FormContext.Provider value={formValue}>{children}</FormContext.Provider>;
+};
+
+describe("Accessibility", () => {
+  it("should not have any violations", async () => {
+    const mockRepository = repositoryFactory.build({
+      name: "GEO",
+      studyID: "GSE123456",
+      dataTypesSubmitted: ["genomics"],
+    });
+
+    const { container } = render(
+      <Repository index={0} repository={mockRepository} onDelete={vi.fn()} />,
+      { wrapper: TestParent }
+    );
+
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});
+
+describe("Basic Functionality", () => {
+  it("should render without crashing", () => {
+    const mockRepository = repositoryFactory.build();
+
+    expect(() =>
+      render(<Repository index={0} repository={mockRepository} onDelete={vi.fn()} />, {
+        wrapper: TestParent,
+      })
+    ).not.toThrow();
+  });
+
+  it("should render all required form fields", () => {
+    const mockRepository = repositoryFactory.build({
+      name: "GEO",
+      studyID: "GSE123456",
+      dataTypesSubmitted: ["genomics"],
+    });
+
+    const { getByTestId } = render(
+      <Repository index={0} repository={mockRepository} onDelete={vi.fn()} />,
+      { wrapper: TestParent }
+    );
+
+    const elements = getFormElements({ getByTestId }, 0);
+    expect(elements.repositoryName()).toBeInTheDocument();
+    expect(elements.studyId()).toBeInTheDocument();
+    expect(elements.dataTypesSubmitted()).toBeInTheDocument();
+    expect(elements.otherDataTypes()).toBeInTheDocument();
+  });
+
+  it("should display the repository name value", () => {
+    const mockRepository = repositoryFactory.build({
+      name: "Test Repository",
+      studyID: "TEST-001",
+      dataTypesSubmitted: [],
+    });
+
+    const { getByDisplayValue } = render(
+      <Repository index={0} repository={mockRepository} onDelete={vi.fn()} />,
+      { wrapper: TestParent }
+    );
+
+    expect(getByDisplayValue("Test Repository")).toBeInTheDocument();
+    expect(getByDisplayValue("TEST-001")).toBeInTheDocument();
+  });
+
+  it("should render the Remove Repository button", () => {
+    const mockRepository = repositoryFactory.build();
+
+    const { getByTestId } = render(
+      <Repository index={0} repository={mockRepository} onDelete={vi.fn()} />,
+      { wrapper: TestParent }
+    );
+
+    expect(getFormElements({ getByTestId }, 0).removeButton()).toBeInTheDocument();
+  });
+
+  it("should call onDelete when Remove Repository button is clicked", async () => {
+    const mockRepository = repositoryFactory.build();
+    const mockOnDelete = vi.fn();
+
+    const { getByTestId } = render(
+      <Repository index={0} repository={mockRepository} onDelete={mockOnDelete} />,
+      { wrapper: TestParent }
+    );
+
+    userEvent.click(getFormElements({ getByTestId }, 0).removeButton());
+
+    expect(mockOnDelete).toHaveBeenCalledTimes(1);
+  });
+
+  it("should disable Remove Repository button when readOnly is true", () => {
+    const mockRepository = repositoryFactory.build();
+
+    const { getByTestId } = render(
+      <Repository index={0} repository={mockRepository} onDelete={vi.fn()} readOnly />,
+      { wrapper: TestParent }
+    );
+
+    expect(getFormElements({ getByTestId }, 0).removeButton()).toBeDisabled();
+  });
+
+  it("should disable Remove Repository button when form status is SAVING", () => {
+    const mockRepository = repositoryFactory.build();
+
+    const { getByTestId } = render(
+      <Repository index={0} repository={mockRepository} onDelete={vi.fn()} />,
+      { wrapper: (p) => <TestParent {...p} formStatus={FormStatus.SAVING} /> }
+    );
+
+    expect(getFormElements({ getByTestId }, 0).removeButton()).toBeDisabled();
+  });
+
+  it("should use idPrefix in element IDs when provided", () => {
+    const mockRepository = repositoryFactory.build();
+
+    const { container } = render(
+      <Repository
+        idPrefix="test-prefix-"
+        index={0}
+        repository={mockRepository}
+        onDelete={vi.fn()}
+      />,
+      { wrapper: TestParent }
+    );
+
+    expect(container.querySelector("#test-prefix-repository-0-name")).toBeInTheDocument();
+    expect(container.querySelector("#test-prefix-repository-0-study-id")).toBeInTheDocument();
+  });
+
+  it("should handle null repository prop gracefully", () => {
+    expect(() =>
+      render(<Repository index={0} repository={null} onDelete={vi.fn()} />, {
+        wrapper: TestParent,
+      })
+    ).not.toThrow();
+  });
+
+  it("should render correct data type options in the select", async () => {
+    const mockRepository = repositoryFactory.build();
+
+    const { getByTestId, getAllByRole } = render(
+      <Repository index={0} repository={mockRepository} onDelete={vi.fn()} />,
+      { wrapper: TestParent }
+    );
+
+    await openDataTypesSelect({ getByTestId }, 0);
+
+    await waitFor(() => {
+      const listbox = getMuiListbox({ getAllByRole });
+      expect(listbox).toBeInTheDocument();
+    });
+
+    const listbox = within(getMuiListbox({ getAllByRole }));
+
+    repositoryDataTypesOptions.forEach((option) => {
+      expect(listbox.getByText(option.label)).toBeInTheDocument();
+    });
+  });
+});
+
+describe("Implementation Requirements", () => {
+  it("should have 'Other' as a data type option", () => {
+    const otherOption = repositoryDataTypesOptions.find((opt) => opt.name === "Other");
+
+    expect(otherOption).toBeDefined();
+    expect(otherOption.label).toBe("Other");
+  });
+
+  it("should disable Other Data Type(s) field when 'Other' is not selected", () => {
+    const mockRepository = repositoryFactory.build({
+      dataTypesSubmitted: ["genomics"],
+    });
+
+    const { getByTestId } = render(
+      <Repository index={0} repository={mockRepository} onDelete={vi.fn()} />,
+      { wrapper: TestParent }
+    );
+
+    expect(getFormElements({ getByTestId }, 0).otherDataTypesInput()).toHaveAttribute("readonly");
+  });
+
+  it("should enable Other Data Type(s) field when 'Other' is selected", () => {
+    const mockRepository = repositoryFactory.build({
+      dataTypesSubmitted: ["Other"],
+    });
+
+    const { getByTestId } = render(
+      <Repository index={0} repository={mockRepository} onDelete={vi.fn()} />,
+      { wrapper: TestParent }
+    );
+
+    expect(getFormElements({ getByTestId }, 0).otherDataTypesInput()).not.toHaveAttribute(
+      "readonly"
+    );
+  });
+
+  it("should enable Other Data Type(s) field when 'Other' is among multiple selected types", () => {
+    const mockRepository = repositoryFactory.build({
+      dataTypesSubmitted: ["genomics", "Other", "imaging"],
+    });
+
+    const { getByTestId } = render(
+      <Repository index={0} repository={mockRepository} onDelete={vi.fn()} />,
+      { wrapper: TestParent }
+    );
+
+    expect(getFormElements({ getByTestId }, 0).otherDataTypesInput()).not.toHaveAttribute(
+      "readonly"
+    );
+  });
+
+  it("should display otherDataTypesSubmitted value when provided", () => {
+    const mockRepository = repositoryFactory.build({
+      dataTypesSubmitted: ["Other"],
+      otherDataTypesSubmitted: "customType1 | customType2",
+    });
+
+    const { getByDisplayValue } = render(
+      <Repository index={0} repository={mockRepository} onDelete={vi.fn()} />,
+      { wrapper: TestParent }
+    );
+
+    expect(getByDisplayValue("customType1 | customType2")).toBeInTheDocument();
+  });
+
+  it("should disable Other Data Type(s) field when readOnly is true even if 'Other' is selected", () => {
+    const mockRepository = repositoryFactory.build({
+      dataTypesSubmitted: ["Other"],
+    });
+
+    const { getByTestId } = render(
+      <Repository index={0} repository={mockRepository} onDelete={vi.fn()} readOnly />,
+      { wrapper: TestParent }
+    );
+
+    expect(getFormElements({ getByTestId }, 0).otherDataTypesInput()).toHaveAttribute("readonly");
+  });
+
+  it("should update Other Data Type(s) field state when selecting 'Other' option", async () => {
+    const mockRepository = repositoryFactory.build({
+      dataTypesSubmitted: [],
+    });
+
+    const { getByTestId, getAllByRole } = render(
+      <Repository index={0} repository={mockRepository} onDelete={vi.fn()} />,
+      { wrapper: TestParent }
+    );
+
+    const elements = getFormElements({ getByTestId }, 0);
+    expect(elements.otherDataTypesInput()).toHaveAttribute("readonly");
+
+    await openDataTypesSelect({ getByTestId }, 0);
+
+    await waitFor(() => {
+      const listbox = getMuiListbox({ getAllByRole });
+      expect(listbox).toBeInTheDocument();
+    });
+
+    const listbox = within(getMuiListbox({ getAllByRole }));
+    userEvent.click(listbox.getByText("Other"));
+
+    await waitFor(() => {
+      expect(elements.otherDataTypesInput()).not.toHaveAttribute("readonly");
+    });
+  });
+
+  it("should disable Other Data Type(s) field state when deselecting 'Other' option", async () => {
+    const mockRepository = repositoryFactory.build({
+      dataTypesSubmitted: ["Other"],
+    });
+
+    const { getByTestId, getAllByRole } = render(
+      <Repository index={0} repository={mockRepository} onDelete={vi.fn()} />,
+      { wrapper: TestParent }
+    );
+
+    const elements = getFormElements({ getByTestId }, 0);
+    expect(elements.otherDataTypesInput()).not.toHaveAttribute("readonly");
+
+    await openDataTypesSelect({ getByTestId }, 0);
+
+    await waitFor(() => {
+      const listbox = getMuiListbox({ getAllByRole });
+      expect(listbox).toBeInTheDocument();
+    });
+
+    const listbox = within(getMuiListbox({ getAllByRole }));
+    userEvent.click(listbox.getByText("Other"));
+
+    await waitFor(() => {
+      expect(elements.otherDataTypesInput()).toHaveAttribute("readonly");
+    });
+  });
+});

--- a/src/components/Questionnaire/Repository.tsx
+++ b/src/components/Questionnaire/Repository.tsx
@@ -1,6 +1,6 @@
 import RemoveCircleIcon from "@mui/icons-material/RemoveCircle";
 import { Grid, styled } from "@mui/material";
-import React, { FC } from "react";
+import React, { FC, useMemo, useState } from "react";
 
 import DataTypes from "../../config/DataTypesConfig";
 import AddRemoveButton from "../AddRemoveButton";
@@ -20,6 +20,7 @@ export const repositoryDataTypesOptions = [
   DataTypes.genomics,
   DataTypes.imaging,
   DataTypes.proteomics,
+  { name: "Other", label: "Other" },
 ];
 
 type Props = {
@@ -40,9 +41,12 @@ const Repository: FC<Props> = ({ idPrefix = "", index, repository, readOnly, onD
   const { status } = useFormContext();
 
   const { name, studyID, dataTypesSubmitted, otherDataTypesSubmitted } = repository || {};
+  const [dataTypes, setDataTypes] = useState<string[]>(dataTypesSubmitted || []);
+
+  const isOtherSelected = useMemo(() => dataTypes?.includes("Other"), [dataTypes]);
 
   return (
-    <GridContainer container>
+    <GridContainer container data-testid={idPrefix.concat(`repository-${index}`)}>
       <Grid container item xs={12} rowSpacing={0} columnSpacing={1.5}>
         <TextInput
           id={idPrefix.concat(`repository-${index}-name`)}
@@ -55,6 +59,7 @@ const Repository: FC<Props> = ({ idPrefix = "", index, repository, readOnly, onD
           tooltipText="Name of the repository (e.g., GEO, EGA, etc.)"
           required
           readOnly={readOnly}
+          data-testid={idPrefix.concat(`repository-${index}-name`)}
         />
         <TextInput
           id={idPrefix.concat(`repository-${index}-study-id`)}
@@ -67,6 +72,7 @@ const Repository: FC<Props> = ({ idPrefix = "", index, repository, readOnly, onD
           tooltipText="Associated repository study identifier"
           required
           readOnly={readOnly}
+          data-testid={idPrefix.concat(`repository-${index}-study-id`)}
         />
         <SelectInput
           id={idPrefix.concat(`repository-${index}-data-types-submitted`)}
@@ -82,6 +88,8 @@ const Repository: FC<Props> = ({ idPrefix = "", index, repository, readOnly, onD
           tooltipText="Data type(s) submitted"
           required
           readOnly={readOnly}
+          onChange={(value) => setDataTypes(value as string[])}
+          data-testid={idPrefix.concat(`repository-${index}-data-types-submitted`)}
         />
         <TextInput
           id={idPrefix.concat(`repository-${index}-other-data-types-submitted`)}
@@ -92,7 +100,8 @@ const Repository: FC<Props> = ({ idPrefix = "", index, repository, readOnly, onD
           placeholder="Other, specify as free text"
           maxLength={100}
           gridWidth={6}
-          readOnly={readOnly}
+          readOnly={!isOtherSelected || readOnly}
+          data-testid={idPrefix.concat(`repository-${index}-other-data-types-submitted`)}
         />
       </Grid>
       <Grid item xs={12}>
@@ -104,6 +113,7 @@ const Repository: FC<Props> = ({ idPrefix = "", index, repository, readOnly, onD
           startIcon={<RemoveCircleIcon />}
           iconColor="#E74040"
           disabled={readOnly || status === FormStatus.SAVING}
+          data-testid={idPrefix.concat(`repository-${index}-remove-button`)}
         />
       </Grid>
     </GridContainer>

--- a/src/components/Questionnaire/Repository.tsx
+++ b/src/components/Questionnaire/Repository.tsx
@@ -42,8 +42,17 @@ const Repository: FC<Props> = ({ idPrefix = "", index, repository, readOnly, onD
 
   const { name, studyID, dataTypesSubmitted, otherDataTypesSubmitted } = repository || {};
   const [dataTypes, setDataTypes] = useState<string[]>(dataTypesSubmitted || []);
+  const [otherDataTypes, setOtherDataTypes] = useState<string>(otherDataTypesSubmitted || "");
 
   const isOtherSelected = useMemo(() => dataTypes?.includes("Other"), [dataTypes]);
+
+  const handleDataTypesChange = (value: string[]) => {
+    setDataTypes(value);
+
+    if (!value?.includes("Other")) {
+      setOtherDataTypes("");
+    }
+  };
 
   return (
     <GridContainer container data-testid={idPrefix.concat(`repository-${index}`)}>
@@ -88,7 +97,7 @@ const Repository: FC<Props> = ({ idPrefix = "", index, repository, readOnly, onD
           tooltipText="Data type(s) submitted"
           required
           readOnly={readOnly}
-          onChange={(value) => setDataTypes(value as string[])}
+          onChange={handleDataTypesChange}
           data-testid={idPrefix.concat(`repository-${index}-data-types-submitted`)}
         />
         <TextInput
@@ -96,11 +105,12 @@ const Repository: FC<Props> = ({ idPrefix = "", index, repository, readOnly, onD
           label="Other Data Type(s)"
           tooltipText='Enter additional Data Types, separated by pipes ("|").'
           name={`study[repositories][${index}][otherDataTypesSubmitted]`}
-          value={otherDataTypesSubmitted}
+          value={otherDataTypes}
           placeholder="Other, specify as free text"
           maxLength={100}
           gridWidth={6}
           readOnly={!isOtherSelected || readOnly}
+          onChange={(e) => setOtherDataTypes(e.target.value)}
           data-testid={idPrefix.concat(`repository-${index}-other-data-types-submitted`)}
         />
       </Grid>

--- a/src/config/SectionMetadata.tsx
+++ b/src/config/SectionMetadata.tsx
@@ -56,7 +56,8 @@ const sectionMetadata = {
       },
       REPOSITORY: {
         title: "REPOSITORY",
-        description: "Add repository if your data has been submitted to another repository",
+        description:
+          "Add repository if your data has been submitted to another non-CRDC repository.",
       },
     },
   },

--- a/src/content/questionnaire/sections/B.test.tsx
+++ b/src/content/questionnaire/sections/B.test.tsx
@@ -1,0 +1,1156 @@
+import { LocalizationProvider } from "@mui/x-date-pickers";
+import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
+import userEvent from "@testing-library/user-event";
+import { FC, useMemo, useRef } from "react";
+import { axe } from "vitest-axe";
+
+import { applicationFactory } from "@/factories/application/ApplicationFactory";
+import { questionnaireDataFactory } from "@/factories/application/QuestionnaireDataFactory";
+import { studyFactory } from "@/factories/application/StudyFactory";
+import { organizationFactory } from "@/factories/auth/OrganizationFactory";
+
+import {
+  ContextState as FormContextState,
+  Context as FormContext,
+  Status as FormStatus,
+} from "../../../components/Contexts/FormContext";
+import {
+  Context as OrganizationContext,
+  ContextState as OrganizationContextState,
+  Status as OrganizationStatus,
+} from "../../../components/Contexts/OrganizationListContext";
+import { render, RenderResult, waitFor, within } from "../../../test-utils";
+
+import FormSectionB from "./B";
+
+Element.prototype.scrollIntoView = vi.fn();
+
+const mockUseFormMode = vi.fn();
+vi.mock("../../../hooks/useFormMode", () => ({
+  default: () => mockUseFormMode(),
+}));
+
+/**
+ * Helper to get form elements
+ */
+const getFormElements = ({ getByTestId }: Pick<RenderResult, "getByTestId">) => ({
+  programSelect: () => getByTestId("section-b-program"),
+  programTitle: () => getByTestId("section-b-program-title"),
+  programAbbreviation: () => getByTestId("section-b-program-abbreviation"),
+  programDescription: () => getByTestId("section-b-program-description"),
+  studyTitle: () => getByTestId("section-b-study-title"),
+  studyAbbreviation: () => getByTestId("section-b-study-abbreviation-or-acronym"),
+  studyDescription: () => getByTestId("section-b-study-description"),
+  addFundingButton: () => getByTestId("section-b-add-funding-agency-button"),
+  addPublicationButton: () => getByTestId("section-b-add-publication-button"),
+  addPlannedPublicationButton: () => getByTestId("section-b-add-planned-publication-button"),
+  addRepositoryButton: () => getByTestId("section-b-add-repository-button"),
+});
+
+const mockPrograms = [
+  organizationFactory.build({
+    _id: "program-1",
+    name: "Test Program 1",
+    abbreviation: "TP1",
+    description: "Test Program 1 Description",
+  }),
+  organizationFactory.build({
+    _id: "program-2",
+    name: "Test Program 2",
+    abbreviation: "TP2",
+    description: "Test Program 2 Description",
+  }),
+];
+
+const defaultQuestionnaireData = questionnaireDataFactory.build({
+  study: studyFactory.build(),
+});
+
+type TestParentProps = {
+  formStatus?: FormStatus;
+  questionnaireData?: QuestionnaireData;
+  organizationStatus?: OrganizationStatus;
+  programs?: OrganizationContextState["data"];
+  formRef?: React.RefObject<HTMLFormElement>;
+  children: React.ReactNode;
+};
+
+const TestParent: FC<TestParentProps> = ({
+  formStatus = FormStatus.LOADED,
+  questionnaireData = defaultQuestionnaireData,
+  organizationStatus = OrganizationStatus.LOADED,
+  programs = mockPrograms,
+  formRef,
+  children,
+}: TestParentProps) => {
+  const defaultFormRef = useRef<HTMLFormElement>(null);
+  const actualFormRef = formRef || defaultFormRef;
+
+  const formValue = useMemo<FormContextState>(
+    () => ({
+      status: formStatus,
+      formRef: actualFormRef,
+      data: applicationFactory.build({
+        questionnaireData,
+      }),
+    }),
+    [formStatus, questionnaireData, actualFormRef]
+  );
+
+  const organizationValue = useMemo<OrganizationContextState>(
+    () => ({
+      status: organizationStatus,
+      data: programs,
+      activeOrganizations: programs.filter((p) => p.status === "Active"),
+    }),
+    [organizationStatus, programs]
+  );
+
+  return (
+    <LocalizationProvider dateAdapter={AdapterDayjs}>
+      <OrganizationContext.Provider value={organizationValue}>
+        <FormContext.Provider value={formValue}>{children}</FormContext.Provider>
+      </OrganizationContext.Provider>
+    </LocalizationProvider>
+  );
+};
+
+/**
+ * Creates default FormSectionProps
+ */
+const createSectionProps = (): FormSectionProps => ({
+  SectionOption: {
+    title: "Program and Study",
+    id: "B",
+    component: FormSectionB,
+  },
+  refs: {
+    getFormObjectRef: { current: null },
+  },
+});
+
+describe("Accessibility", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseFormMode.mockReturnValue({ formMode: "EDIT", readOnlyInputs: false });
+  });
+
+  it("should not have any violations", async () => {
+    const props = createSectionProps();
+
+    const { container } = render(<FormSectionB {...props} />, { wrapper: TestParent });
+
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});
+
+describe("Basic Functionality", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseFormMode.mockReturnValue({ formMode: "EDIT", readOnlyInputs: false });
+  });
+
+  it("should render without crashing", () => {
+    const props = createSectionProps();
+
+    expect(() => render(<FormSectionB {...props} />, { wrapper: TestParent })).not.toThrow();
+  });
+
+  it("should render all program information fields", () => {
+    const props = createSectionProps();
+
+    const { getByTestId } = render(<FormSectionB {...props} />, { wrapper: TestParent });
+
+    const elements = getFormElements({ getByTestId });
+    expect(elements.programSelect()).toBeInTheDocument();
+    expect(elements.programTitle()).toBeInTheDocument();
+    expect(elements.programAbbreviation()).toBeInTheDocument();
+    expect(elements.programDescription()).toBeInTheDocument();
+  });
+
+  it("should render all study information fields", () => {
+    const props = createSectionProps();
+
+    const { getByTestId } = render(<FormSectionB {...props} />, { wrapper: TestParent });
+
+    const elements = getFormElements({ getByTestId });
+    expect(elements.studyTitle()).toBeInTheDocument();
+    expect(elements.studyAbbreviation()).toBeInTheDocument();
+    expect(elements.studyDescription()).toBeInTheDocument();
+  });
+
+  it("should render all add buttons for repeating sections", () => {
+    const props = createSectionProps();
+
+    const { getByTestId } = render(<FormSectionB {...props} />, { wrapper: TestParent });
+
+    const elements = getFormElements({ getByTestId });
+    expect(elements.addFundingButton()).toBeInTheDocument();
+    expect(elements.addPublicationButton()).toBeInTheDocument();
+    expect(elements.addPlannedPublicationButton()).toBeInTheDocument();
+    expect(elements.addRepositoryButton()).toBeInTheDocument();
+  });
+
+  it("should display study name value when provided", () => {
+    const props = createSectionProps();
+
+    const { getByDisplayValue } = render(<FormSectionB {...props} />, {
+      wrapper: (p) => (
+        <TestParent
+          {...p}
+          questionnaireData={questionnaireDataFactory.build({
+            study: studyFactory.build({
+              name: "My Test Study",
+              abbreviation: "MTS",
+              description: "A description of my test study",
+            }),
+          })}
+        />
+      ),
+    });
+
+    expect(getByDisplayValue("My Test Study")).toBeInTheDocument();
+    expect(getByDisplayValue("MTS")).toBeInTheDocument();
+  });
+
+  it("should add a funding agency when Add Agency button is clicked", async () => {
+    const props = createSectionProps();
+
+    const { getByTestId } = render(<FormSectionB {...props} />, {
+      wrapper: TestParent,
+    });
+
+    const elements = getFormElements({ getByTestId });
+    userEvent.click(elements.addFundingButton());
+
+    await waitFor(() => {
+      expect(getByTestId("section-b-funding-agency-0")).toBeInTheDocument();
+    });
+  });
+
+  it("should add a publication when Add Existing Publication button is clicked", async () => {
+    const props = createSectionProps();
+
+    const { getByTestId } = render(<FormSectionB {...props} />, {
+      wrapper: TestParent,
+    });
+
+    const elements = getFormElements({ getByTestId });
+    userEvent.click(elements.addPublicationButton());
+
+    await waitFor(() => {
+      expect(getByTestId("section-b-publication-0")).toBeInTheDocument();
+    });
+  });
+
+  it("should add a planned publication when Add Planned Publication button is clicked", async () => {
+    const props = createSectionProps();
+
+    const { getByTestId } = render(<FormSectionB {...props} />, {
+      wrapper: TestParent,
+    });
+
+    const elements = getFormElements({ getByTestId });
+    userEvent.click(elements.addPlannedPublicationButton());
+
+    await waitFor(() => {
+      expect(getByTestId("section-b-planned-publication-0")).toBeInTheDocument();
+    });
+  });
+
+  it("should add a repository when Add Repository button is clicked", async () => {
+    const props = createSectionProps();
+
+    const { getByTestId } = render(<FormSectionB {...props} />, {
+      wrapper: TestParent,
+    });
+
+    const elements = getFormElements({ getByTestId });
+    userEvent.click(elements.addRepositoryButton());
+
+    await waitFor(() => {
+      expect(getByTestId("section-b-repository-0")).toBeInTheDocument();
+    });
+  });
+
+  it("should disable add buttons when form status is SAVING", () => {
+    const props = createSectionProps();
+
+    const { getByTestId } = render(<FormSectionB {...props} />, {
+      wrapper: (p) => <TestParent {...p} formStatus={FormStatus.SAVING} />,
+    });
+
+    const elements = getFormElements({ getByTestId });
+    expect(elements.addFundingButton()).toBeDisabled();
+    expect(elements.addPublicationButton()).toBeDisabled();
+    expect(elements.addPlannedPublicationButton()).toBeDisabled();
+    expect(elements.addRepositoryButton()).toBeDisabled();
+  });
+
+  it("should disable add buttons when readOnly is true", () => {
+    mockUseFormMode.mockReturnValue({ formMode: "VIEW", readOnlyInputs: true });
+    const props = createSectionProps();
+
+    const { getByTestId } = render(<FormSectionB {...props} />, {
+      wrapper: TestParent,
+    });
+
+    const elements = getFormElements({ getByTestId });
+    expect(elements.addFundingButton()).toBeDisabled();
+    expect(elements.addPublicationButton()).toBeDisabled();
+    expect(elements.addPlannedPublicationButton()).toBeDisabled();
+    expect(elements.addRepositoryButton()).toBeDisabled();
+  });
+
+  it("should assign getFormObject to the ref when component mounts", () => {
+    const getFormObjectRef = { current: null };
+    const props: FormSectionProps = {
+      ...createSectionProps(),
+      refs: { getFormObjectRef },
+    };
+
+    render(<FormSectionB {...props} />, { wrapper: TestParent });
+
+    expect(getFormObjectRef.current).toBeInstanceOf(Function);
+  });
+
+  it("should render existing funding agencies from data", () => {
+    const props = createSectionProps();
+
+    const { getByTestId } = render(<FormSectionB {...props} />, {
+      wrapper: (p) => (
+        <TestParent
+          {...p}
+          questionnaireData={questionnaireDataFactory.build({
+            study: studyFactory.build({
+              funding: [
+                { agency: "NIH", grantNumbers: "R01", nciProgramOfficer: "John Doe" },
+                { agency: "NCI", grantNumbers: "P01", nciProgramOfficer: "Jane Smith" },
+              ],
+            }),
+          })}
+        />
+      ),
+    });
+
+    expect(getByTestId("section-b-funding-agency-0")).toBeInTheDocument();
+    expect(getByTestId("section-b-funding-agency-1")).toBeInTheDocument();
+  });
+
+  it("should render existing publications from data", () => {
+    const props = createSectionProps();
+
+    const { getByTestId } = render(<FormSectionB {...props} />, {
+      wrapper: (p) => (
+        <TestParent
+          {...p}
+          questionnaireData={questionnaireDataFactory.build({
+            study: studyFactory.build({
+              publications: [{ title: "Publication 1", pubmedID: "12345", DOI: "10.1234" }],
+            }),
+          })}
+        />
+      ),
+    });
+
+    expect(getByTestId("section-b-publication-0")).toBeInTheDocument();
+  });
+
+  it("should render existing repositories from data", () => {
+    const props = createSectionProps();
+
+    const { getByTestId } = render(<FormSectionB {...props} />, {
+      wrapper: (p) => (
+        <TestParent
+          {...p}
+          questionnaireData={questionnaireDataFactory.build({
+            study: studyFactory.build({
+              repositories: [
+                {
+                  name: "GEO",
+                  studyID: "GSE123",
+                  dataTypesSubmitted: ["genomics"],
+                  otherDataTypesSubmitted: "",
+                },
+              ],
+            }),
+          })}
+        />
+      ),
+    });
+
+    expect(getByTestId("section-b-repository-0")).toBeInTheDocument();
+  });
+
+  it("should render existing planned publications from data", () => {
+    const props = createSectionProps();
+
+    const { getByTestId } = render(<FormSectionB {...props} />, {
+      wrapper: (p) => (
+        <TestParent
+          {...p}
+          questionnaireData={questionnaireDataFactory.build({
+            study: studyFactory.build({
+              plannedPublications: [{ title: "Planned Pub 1", expectedDate: "12/31/2026" }],
+            }),
+          })}
+        />
+      ),
+    });
+
+    expect(getByTestId("section-b-planned-publication-0")).toBeInTheDocument();
+  });
+
+  it("should handle empty programs array gracefully", () => {
+    const props = createSectionProps();
+
+    expect(() =>
+      render(<FormSectionB {...props} />, {
+        wrapper: (p) => <TestParent {...p} programs={[]} />,
+      })
+    ).not.toThrow();
+  });
+
+  it("should change program when selecting a different program", async () => {
+    const props = createSectionProps();
+
+    const { getByTestId, getAllByRole, getByText } = render(<FormSectionB {...props} />, {
+      wrapper: (p) => (
+        <TestParent
+          {...p}
+          questionnaireData={questionnaireDataFactory.build({
+            program: {
+              _id: "program-1",
+              name: "Test Program 1",
+              abbreviation: "TP1",
+              description: "Test Program 1 Description",
+            },
+          })}
+        />
+      ),
+    });
+
+    const programSelectContainer = getByTestId("section-b-program");
+    const programSelectButton = within(programSelectContainer).getByRole("button");
+    userEvent.click(programSelectButton);
+
+    await waitFor(() => {
+      const listboxes = getAllByRole("listbox", { hidden: true });
+      const listbox = listboxes.find((el) => el.tagName === "UL");
+      expect(listbox).toBeInTheDocument();
+    });
+
+    const program2Option = getByText("Test Program 2 (TP2)");
+    userEvent.click(program2Option);
+
+    await waitFor(() => {
+      expect(programSelectButton).toHaveTextContent("Test Program 2 (TP2)");
+    });
+  });
+
+  it("should change to 'Not Applicable' program when selected", async () => {
+    const props = createSectionProps();
+
+    const { getByTestId, getAllByRole, getByText } = render(<FormSectionB {...props} />, {
+      wrapper: (p) => (
+        <TestParent
+          {...p}
+          questionnaireData={questionnaireDataFactory.build({
+            program: {
+              _id: "program-1",
+              name: "Test Program 1",
+              abbreviation: "TP1",
+              description: "Test Program 1 Description",
+            },
+          })}
+        />
+      ),
+    });
+
+    const programSelectContainer = getByTestId("section-b-program");
+    const programSelectButton = within(programSelectContainer).getByRole("button");
+    userEvent.click(programSelectButton);
+
+    await waitFor(() => {
+      const listboxes = getAllByRole("listbox", { hidden: true });
+      const listbox = listboxes.find((el) => el.tagName === "UL");
+      expect(listbox).toBeInTheDocument();
+    });
+
+    const notApplicableOption = getByText("Not Applicable");
+    userEvent.click(notApplicableOption);
+
+    await waitFor(() => {
+      expect(programSelectButton).toHaveTextContent("Not Applicable");
+    });
+  });
+
+  it("should change to 'Other' program when selected", async () => {
+    const props = createSectionProps();
+
+    const { getByTestId, getAllByRole, getByText } = render(<FormSectionB {...props} />, {
+      wrapper: (p) => (
+        <TestParent
+          {...p}
+          questionnaireData={questionnaireDataFactory.build({
+            program: {
+              _id: "program-1",
+              name: "Test Program 1",
+              abbreviation: "TP1",
+              description: "Test Program 1 Description",
+            },
+          })}
+        />
+      ),
+    });
+
+    const programSelectContainer = getByTestId("section-b-program");
+    const programSelectButton = within(programSelectContainer).getByRole("button");
+    userEvent.click(programSelectButton);
+
+    await waitFor(() => {
+      const listboxes = getAllByRole("listbox", { hidden: true });
+      const listbox = listboxes.find((el) => el.tagName === "UL");
+      expect(listbox).toBeInTheDocument();
+    });
+
+    const otherOption = getByText("Other");
+    userEvent.click(otherOption);
+
+    await waitFor(() => {
+      expect(programSelectButton).toHaveTextContent("Other");
+    });
+  });
+
+  it("should return form data when getFormObject is called", async () => {
+    const getFormObjectRef = { current: null };
+    const props: FormSectionProps = {
+      ...createSectionProps(),
+      refs: { getFormObjectRef },
+    };
+
+    render(<FormSectionB {...props} />, {
+      wrapper: (p) => (
+        <TestParent
+          {...p}
+          questionnaireData={questionnaireDataFactory.build({
+            program: {
+              _id: "program-1",
+              name: "Test Program 1",
+              abbreviation: "TP1",
+              description: "Test Program 1 Description",
+            },
+            study: studyFactory.build({
+              name: "Test Study",
+              abbreviation: "TS",
+              description: "A test study",
+            }),
+          })}
+        />
+      ),
+    });
+
+    await waitFor(() => {
+      expect(getFormObjectRef.current).toBeInstanceOf(Function);
+    });
+
+    const formObject = getFormObjectRef.current();
+
+    expect(formObject).not.toBeNull();
+    expect(formObject.data).toBeDefined();
+    expect(formObject.ref).toBeDefined();
+  });
+
+  it("should handle planned publications with invalid expectedDate", async () => {
+    const getFormObjectRef = { current: null };
+    const props: FormSectionProps = {
+      ...createSectionProps(),
+      refs: { getFormObjectRef },
+    };
+
+    render(<FormSectionB {...props} />, {
+      wrapper: (p) => (
+        <TestParent
+          {...p}
+          questionnaireData={questionnaireDataFactory.build({
+            study: studyFactory.build({
+              plannedPublications: [
+                { title: "Planned Pub 1", expectedDate: "invalid-date" },
+                { title: "Planned Pub 2", expectedDate: "12/31/2026" },
+              ],
+            }),
+          })}
+        />
+      ),
+    });
+
+    await waitFor(() => {
+      expect(getFormObjectRef.current).toBeInstanceOf(Function);
+    });
+
+    const formObject = getFormObjectRef.current();
+
+    expect(formObject).not.toBeNull();
+    expect(formObject.data.study.plannedPublications).toBeDefined();
+    expect(formObject.data.study.plannedPublications[0].expectedDate).toBe("");
+  });
+
+  it("should initialize program state from context data", () => {
+    const props = createSectionProps();
+
+    const { getByTestId } = render(<FormSectionB {...props} />, {
+      wrapper: (p) => (
+        <TestParent
+          {...p}
+          questionnaireData={questionnaireDataFactory.build({
+            program: {
+              _id: "program-2",
+              name: "Test Program 2",
+              abbreviation: "TP2",
+              description: "Test Program 2 Description",
+            },
+          })}
+        />
+      ),
+    });
+
+    const programSelectContainer = getByTestId("section-b-program");
+    const programSelectButton = within(programSelectContainer).getByRole("button");
+    expect(programSelectButton).toHaveTextContent("Test Program 2 (TP2)");
+  });
+
+  it("should initialize study state from context data", () => {
+    const props = createSectionProps();
+
+    const { getByDisplayValue } = render(<FormSectionB {...props} />, {
+      wrapper: (p) => (
+        <TestParent
+          {...p}
+          questionnaireData={questionnaireDataFactory.build({
+            study: studyFactory.build({
+              name: "Custom Study Name",
+              abbreviation: "CSN",
+              description: "Custom study description",
+            }),
+          })}
+        />
+      ),
+    });
+
+    expect(getByDisplayValue("Custom Study Name")).toBeInTheDocument();
+    expect(getByDisplayValue("CSN")).toBeInTheDocument();
+  });
+
+  it("should display program name without abbreviation when abbreviation is empty", async () => {
+    const props = createSectionProps();
+
+    const programsWithoutAbbreviation = [
+      organizationFactory.build({
+        _id: "program-no-abbr",
+        name: "Program Without Abbreviation",
+        abbreviation: "",
+        description: "A program without abbreviation",
+      }),
+    ];
+
+    const { getByTestId, getAllByRole, getByText } = render(<FormSectionB {...props} />, {
+      wrapper: (p) => <TestParent {...p} programs={programsWithoutAbbreviation} />,
+    });
+
+    const programSelectContainer = getByTestId("section-b-program");
+    const programSelectButton = within(programSelectContainer).getByRole("button");
+    userEvent.click(programSelectButton);
+
+    await waitFor(() => {
+      const listboxes = getAllByRole("listbox", { hidden: true });
+      const listbox = listboxes.find((el) => el.tagName === "UL");
+      expect(listbox).toBeInTheDocument();
+    });
+
+    expect(getByText("Program Without Abbreviation")).toBeInTheDocument();
+  });
+
+  it("should not change program when selecting the same program", async () => {
+    const props = createSectionProps();
+
+    const { getByTestId, getAllByRole } = render(<FormSectionB {...props} />, {
+      wrapper: (p) => (
+        <TestParent
+          {...p}
+          questionnaireData={questionnaireDataFactory.build({
+            program: {
+              _id: "program-1",
+              name: "Test Program 1",
+              abbreviation: "TP1",
+              description: "Test Program 1 Description",
+            },
+          })}
+        />
+      ),
+    });
+
+    const programSelectContainer = getByTestId("section-b-program");
+    const programSelectButton = within(programSelectContainer).getByRole("button");
+
+    await waitFor(() => {
+      expect(programSelectButton).toHaveTextContent("Test Program 1 (TP1)");
+    });
+
+    userEvent.click(programSelectButton);
+
+    await waitFor(() => {
+      const listboxes = getAllByRole("listbox", { hidden: true });
+      const listbox = listboxes.find((el) => el.tagName === "UL");
+      expect(listbox).toBeInTheDocument();
+    });
+
+    const listboxes = getAllByRole("listbox", { hidden: true });
+    const listbox = listboxes.find((el) => el.tagName === "UL");
+    const options = within(listbox).getAllByRole("option", { hidden: true });
+    const sameOption = options.find((o) => o.textContent?.includes("Test Program 1"));
+    userEvent.click(sameOption);
+
+    await waitFor(() => {
+      expect(listbox).not.toBeVisible();
+    });
+
+    await waitFor(() => {
+      expect(programSelectButton).toHaveTextContent("Test Program 1 (TP1)");
+    });
+  });
+
+  it("should filter out readOnly programs from options", () => {
+    const props = createSectionProps();
+
+    const programsWithReadOnly = [
+      organizationFactory.build({
+        _id: "program-normal",
+        name: "Normal Program",
+        abbreviation: "NP",
+        description: "A normal program",
+        readOnly: false,
+      }),
+      organizationFactory.build({
+        _id: "program-readonly",
+        name: "ReadOnly Program",
+        abbreviation: "RP",
+        description: "A readonly program",
+        readOnly: true,
+      }),
+    ];
+
+    const { queryByText } = render(<FormSectionB {...props} />, {
+      wrapper: (p) => <TestParent {...p} programs={programsWithReadOnly} />,
+    });
+
+    expect(queryByText("ReadOnly Program (RP)")).not.toBeInTheDocument();
+  });
+
+  it("should convert program abbreviation to uppercase when typing", async () => {
+    const props = createSectionProps();
+
+    const { getByTestId } = render(<FormSectionB {...props} />, {
+      wrapper: (p) => (
+        <TestParent
+          {...p}
+          questionnaireData={questionnaireDataFactory.build({
+            program: {
+              _id: "Other",
+              name: "",
+              abbreviation: "",
+              description: "",
+            },
+          })}
+        />
+      ),
+    });
+
+    const programAbbreviation = within(getByTestId("section-b-program-abbreviation")).getByRole(
+      "textbox"
+    );
+    userEvent.type(programAbbreviation, "abc");
+
+    await waitFor(() => {
+      expect(programAbbreviation).toHaveValue("ABC");
+    });
+    userEvent.clear(programAbbreviation);
+  });
+
+  it("should convert study abbreviation to uppercase when typing", async () => {
+    const props = createSectionProps();
+
+    const { getByTestId } = render(<FormSectionB {...props} />, { wrapper: TestParent });
+
+    const studyAbbreviation = within(
+      getByTestId("section-b-study-abbreviation-or-acronym")
+    ).getByRole("textbox");
+    userEvent.clear(studyAbbreviation);
+    userEvent.type(studyAbbreviation, "xyz");
+
+    await waitFor(() => {
+      expect(studyAbbreviation).toHaveValue("XYZ");
+    });
+    userEvent.clear(studyAbbreviation);
+  });
+
+  it("should remove a funding agency when remove button is clicked", async () => {
+    const props = createSectionProps();
+    const dataWithFunding = questionnaireDataFactory.build({
+      study: studyFactory.build({
+        funding: [
+          { agency: "Funding 1", grantNumbers: "123", nciProgramOfficer: "", nciGPA: "" },
+          { agency: "Funding 2", grantNumbers: "456", nciProgramOfficer: "", nciGPA: "" },
+        ],
+      }),
+    });
+
+    const { getByTestId, queryByTestId, getByRole } = render(<FormSectionB {...props} />, {
+      wrapper: (p) => <TestParent {...p} questionnaireData={dataWithFunding} />,
+    });
+
+    expect(getByTestId("section-b-funding-agency-0")).toBeInTheDocument();
+    expect(getByTestId("section-b-funding-agency-1")).toBeInTheDocument();
+
+    const removeButtons = getByRole("button", { name: "Remove Agency" });
+    userEvent.click(removeButtons);
+
+    await waitFor(() => {
+      expect(queryByTestId("section-b-funding-agency-1")).not.toBeInTheDocument();
+    });
+  });
+
+  it("should remove a publication when remove button is clicked", async () => {
+    const props = createSectionProps();
+
+    const { getByTestId, queryByTestId, getAllByRole } = render(<FormSectionB {...props} />, {
+      wrapper: (p) => (
+        <TestParent
+          {...p}
+          questionnaireData={questionnaireDataFactory.build({
+            study: studyFactory.build({
+              publications: [
+                { title: "Publication 1", pubmedID: "12345", DOI: "10.1234" },
+                { title: "Publication 2", pubmedID: "67890", DOI: "10.5678" },
+              ],
+            }),
+          })}
+        />
+      ),
+    });
+
+    expect(getByTestId("section-b-publication-0")).toBeInTheDocument();
+    expect(getByTestId("section-b-publication-1")).toBeInTheDocument();
+
+    const removeButtons = getAllByRole("button", { name: "Remove Existing Publication" });
+    expect(removeButtons.length).toBe(2);
+
+    userEvent.click(removeButtons[1]);
+
+    await waitFor(() => {
+      expect(getByTestId("section-b-publication-0")).toBeInTheDocument();
+      expect(queryByTestId("section-b-publication-1")).not.toBeInTheDocument();
+    });
+  });
+
+  it("should remove a planned publication when remove button is clicked", async () => {
+    const props = createSectionProps();
+    const dataWithPlannedPubs = questionnaireDataFactory.build({
+      study: studyFactory.build({
+        plannedPublications: [
+          { title: "Planned Pub 1", expectedDate: "06/01/2024" },
+          { title: "Planned Pub 2", expectedDate: "01/01/2025" },
+        ],
+      }),
+    });
+
+    const { getByTestId, queryByTestId, getAllByRole } = render(<FormSectionB {...props} />, {
+      wrapper: (p) => <TestParent {...p} questionnaireData={dataWithPlannedPubs} />,
+    });
+
+    expect(getByTestId("section-b-planned-publication-0")).toBeInTheDocument();
+    expect(getByTestId("section-b-planned-publication-1")).toBeInTheDocument();
+
+    const removeButtons = getAllByRole("button", { name: "Remove Planned Publication" });
+    expect(removeButtons.length).toBe(2);
+
+    userEvent.click(removeButtons[1]);
+
+    await waitFor(() => {
+      expect(getByTestId("section-b-planned-publication-0")).toBeInTheDocument();
+      expect(queryByTestId("section-b-planned-publication-1")).not.toBeInTheDocument();
+    });
+  });
+
+  it("should remove a repository when remove button is clicked", async () => {
+    const props = createSectionProps();
+    const dataWithRepos = questionnaireDataFactory.build({
+      study: studyFactory.build({
+        repositories: [
+          {
+            name: "Repository 1",
+            studyID: "R001",
+            dataTypesSubmitted: [],
+            otherDataTypesSubmitted: "",
+          },
+          {
+            name: "Repository 2",
+            studyID: "R002",
+            dataTypesSubmitted: [],
+            otherDataTypesSubmitted: "",
+          },
+        ],
+      }),
+    });
+
+    const { getByTestId, queryByTestId, getAllByRole } = render(<FormSectionB {...props} />, {
+      wrapper: (p) => <TestParent {...p} questionnaireData={dataWithRepos} />,
+    });
+
+    expect(getByTestId("section-b-repository-0")).toBeInTheDocument();
+    expect(getByTestId("section-b-repository-1")).toBeInTheDocument();
+
+    const removeButtons = getAllByRole("button", { name: "Remove Repository" });
+    expect(removeButtons.length).toBe(2);
+
+    userEvent.click(removeButtons[1]);
+
+    await waitFor(() => {
+      expect(getByTestId("section-b-repository-0")).toBeInTheDocument();
+      expect(queryByTestId("section-b-repository-1")).not.toBeInTheDocument();
+    });
+  });
+
+  it("should add a funding agency when add button is clicked", async () => {
+    const props = createSectionProps();
+    const dataWithFunding = questionnaireDataFactory.build({
+      study: studyFactory.build({
+        funding: [{ agency: "Funding 1", grantNumbers: "123", nciProgramOfficer: "", nciGPA: "" }],
+      }),
+    });
+
+    const { getByTestId, queryByTestId } = render(<FormSectionB {...props} />, {
+      wrapper: (p) => <TestParent {...p} questionnaireData={dataWithFunding} />,
+    });
+
+    expect(getByTestId("section-b-funding-agency-0")).toBeInTheDocument();
+    expect(queryByTestId("section-b-funding-agency-1")).not.toBeInTheDocument();
+
+    const addButton = getByTestId("section-b-add-funding-agency-button");
+    userEvent.click(addButton);
+
+    await waitFor(() => {
+      expect(getByTestId("section-b-funding-agency-1")).toBeInTheDocument();
+    });
+  });
+
+  it("should add a publication when add button is clicked", async () => {
+    const props = createSectionProps();
+    const dataWithPubs = questionnaireDataFactory.build({
+      study: studyFactory.build({
+        publications: [{ title: "Publication 1", pubmedID: "PUB001", DOI: "10.1234" }],
+      }),
+    });
+
+    const { getByTestId, queryByTestId } = render(<FormSectionB {...props} />, {
+      wrapper: (p) => <TestParent {...p} questionnaireData={dataWithPubs} />,
+    });
+
+    expect(getByTestId("section-b-publication-0")).toBeInTheDocument();
+    expect(queryByTestId("section-b-publication-1")).not.toBeInTheDocument();
+
+    const addButton = getByTestId("section-b-add-publication-button");
+    userEvent.click(addButton);
+
+    await waitFor(() => {
+      expect(getByTestId("section-b-publication-1")).toBeInTheDocument();
+    });
+  });
+
+  it("should add a planned publication when add button is clicked", async () => {
+    const props = createSectionProps();
+    const dataWithPlannedPubs = questionnaireDataFactory.build({
+      study: studyFactory.build({
+        plannedPublications: [{ title: "Planned Pub 1", expectedDate: "06/01/2024" }],
+      }),
+    });
+
+    const { getByTestId, queryByTestId } = render(<FormSectionB {...props} />, {
+      wrapper: (p) => <TestParent {...p} questionnaireData={dataWithPlannedPubs} />,
+    });
+
+    expect(getByTestId("section-b-planned-publication-0")).toBeInTheDocument();
+    expect(queryByTestId("section-b-planned-publication-1")).not.toBeInTheDocument();
+
+    const addButton = getByTestId("section-b-add-planned-publication-button");
+    userEvent.click(addButton);
+
+    await waitFor(() => {
+      expect(getByTestId("section-b-planned-publication-1")).toBeInTheDocument();
+    });
+  });
+
+  it("should add a repository when add button is clicked", async () => {
+    const props = createSectionProps();
+    const dataWithRepos = questionnaireDataFactory.build({
+      study: studyFactory.build({
+        repositories: [
+          {
+            name: "Repository 1",
+            studyID: "R001",
+            dataTypesSubmitted: [],
+            otherDataTypesSubmitted: "",
+          },
+        ],
+      }),
+    });
+
+    const { getByTestId, queryByTestId } = render(<FormSectionB {...props} />, {
+      wrapper: (p) => <TestParent {...p} questionnaireData={dataWithRepos} />,
+    });
+
+    expect(getByTestId("section-b-repository-0")).toBeInTheDocument();
+    expect(queryByTestId("section-b-repository-1")).not.toBeInTheDocument();
+
+    const addButton = getByTestId("section-b-add-repository-button");
+    userEvent.click(addButton);
+
+    await waitFor(() => {
+      expect(getByTestId("section-b-repository-1")).toBeInTheDocument();
+    });
+  });
+
+  it("should render program label from initial data without abbreviation", () => {
+    const props = createSectionProps();
+    const programWithoutAbbreviation = organizationFactory.build({
+      _id: "program-no-abbrev",
+      name: "Program Without Abbreviation",
+      abbreviation: "",
+      description: "Description",
+    });
+
+    const { getByTestId } = render(<FormSectionB {...props} />, {
+      wrapper: (p) => (
+        <TestParent
+          {...p}
+          questionnaireData={questionnaireDataFactory.build({
+            program: programWithoutAbbreviation,
+          })}
+          programs={[programWithoutAbbreviation]}
+        />
+      ),
+    });
+
+    const programSelect = getByTestId("section-b-program");
+    expect(within(programSelect).getByRole("button")).toHaveTextContent(
+      "Program Without Abbreviation"
+    );
+    expect(within(programSelect).getByRole("button").textContent).not.toContain("()");
+  });
+});
+
+describe("Implementation Requirements", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseFormMode.mockReturnValue({ formMode: "EDIT", readOnlyInputs: false });
+  });
+
+  it("should include 'Not Applicable' as a program option", async () => {
+    const props = createSectionProps();
+
+    const { getByTestId, getAllByRole } = render(<FormSectionB {...props} />, {
+      wrapper: TestParent,
+    });
+
+    const programSelectContainer = getByTestId("section-b-program");
+    const programSelectButton = within(programSelectContainer).getByRole("button");
+    userEvent.click(programSelectButton);
+
+    await waitFor(() => {
+      const listboxes = getAllByRole("listbox", { hidden: true });
+      const listbox = listboxes.find((el) => el.tagName === "UL");
+      expect(listbox).toBeInTheDocument();
+    });
+
+    expect(getAllByRole("option", { hidden: true, name: "Not Applicable" })[0]).toBeInTheDocument();
+  });
+
+  it("should include 'Other' as a program option", async () => {
+    const props = createSectionProps();
+
+    const { getByTestId, getAllByRole } = render(<FormSectionB {...props} />, {
+      wrapper: TestParent,
+    });
+
+    const programSelectContainer = getByTestId("section-b-program");
+    const programSelectButton = within(programSelectContainer).getByRole("button");
+    userEvent.click(programSelectButton);
+
+    await waitFor(() => {
+      const listboxes = getAllByRole("listbox", { hidden: true });
+      const listbox = listboxes.find((el) => el.tagName === "UL");
+      expect(listbox).toBeInTheDocument();
+    });
+
+    expect(getAllByRole("option", { hidden: true, name: "Other" })[0]).toBeInTheDocument();
+  });
+
+  it("should make program title and abbreviation editable when 'Other' is selected", () => {
+    const props = createSectionProps();
+
+    const { getByTestId } = render(<FormSectionB {...props} />, {
+      wrapper: (p) => (
+        <TestParent
+          {...p}
+          questionnaireData={questionnaireDataFactory.build({
+            program: {
+              _id: "Other",
+              name: "",
+              abbreviation: "",
+              description: "",
+            },
+          })}
+        />
+      ),
+    });
+
+    const elements = getFormElements({ getByTestId });
+    expect(within(elements.programTitle()).getByRole("textbox")).not.toHaveAttribute("readonly");
+    expect(within(elements.programAbbreviation()).getByRole("textbox")).not.toHaveAttribute(
+      "readonly"
+    );
+    expect(within(elements.programDescription()).getByRole("textbox")).not.toHaveAttribute(
+      "readonly"
+    );
+  });
+
+  it("should make program title and abbreviation readOnly when a standard program is selected", async () => {
+    const props = createSectionProps();
+
+    const { getByTestId } = render(<FormSectionB {...props} />, {
+      wrapper: (p) => (
+        <TestParent
+          {...p}
+          questionnaireData={questionnaireDataFactory.build({
+            program: {
+              _id: "program-1",
+              name: "Test Program 1",
+              abbreviation: "TP1",
+              description: "Test Program 1 Description",
+            },
+          })}
+        />
+      ),
+    });
+
+    await waitFor(() => {
+      const elements = getFormElements({ getByTestId });
+      expect(within(elements.programTitle()).getByRole("textbox")).toHaveAttribute("readonly");
+      expect(within(elements.programAbbreviation()).getByRole("textbox")).toHaveAttribute(
+        "readonly"
+      );
+      expect(within(elements.programDescription()).getByRole("textbox")).toHaveAttribute(
+        "readonly"
+      );
+    });
+  });
+});

--- a/src/content/questionnaire/sections/B.tsx
+++ b/src/content/questionnaire/sections/B.tsx
@@ -377,6 +377,7 @@ const FormSectionB: FC<FormSectionProps> = ({ SectionOption, refs }: FormSection
           tooltipText="The name of the broad administrative group that manages the data collection.  Example - Clinical Proteomic Tumor Analysis Consortium."
           required
           readOnly={readOnlyInputs}
+          data-testid="section-b-program"
         />
         <TextInput
           key={`program-name-${program?.name}_${programKeyRef.current}`}
@@ -390,6 +391,7 @@ const FormSectionB: FC<FormSectionProps> = ({ SectionOption, refs }: FormSection
           hideValidation={readOnlyProgram}
           required
           readOnly={readOnlyProgram}
+          data-testid="section-b-program-title"
         />
         <TextInput
           key={`program-abbreviation-${program?.abbreviation}_${programKeyRef.current}`}
@@ -406,6 +408,7 @@ const FormSectionB: FC<FormSectionProps> = ({ SectionOption, refs }: FormSection
           hideValidation={readOnlyProgram}
           required
           readOnly={readOnlyProgram}
+          data-testid="section-b-program-abbreviation"
         />
         <TextInput
           key={`program-description-${program?.description}_${programKeyRef.current}`}
@@ -422,6 +425,7 @@ const FormSectionB: FC<FormSectionProps> = ({ SectionOption, refs }: FormSection
           resize
           required
           readOnly={readOnlyProgram}
+          data-testid="section-b-program-description"
         />
       </SectionGroup>
 
@@ -442,6 +446,7 @@ const FormSectionB: FC<FormSectionProps> = ({ SectionOption, refs }: FormSection
           hideValidation={readOnlyInputs}
           tooltipText="A descriptive name that will be used to identify the study."
           required
+          data-testid="section-b-study-title"
         />
         <TextInput
           id="section-b-study-abbreviation-or-acronym"
@@ -457,6 +462,7 @@ const FormSectionB: FC<FormSectionProps> = ({ SectionOption, refs }: FormSection
           readOnly={readOnlyInputs}
           hideValidation={readOnlyInputs}
           tooltipText="Provide a short abbreviation or acronym (e.g., NCI-MATCH) for the study."
+          data-testid="section-b-study-abbreviation-or-acronym"
         />
         <TextInput
           id="section-b-study-description"
@@ -473,6 +479,7 @@ const FormSectionB: FC<FormSectionProps> = ({ SectionOption, refs }: FormSection
           multiline
           resize
           tooltipText="Describe your study and the data being submitted. Include objectives of the study and provide a brief description of the scientific value of the study."
+          data-testid="section-b-study-description"
         />
       </SectionGroup>
 
@@ -487,6 +494,7 @@ const FormSectionB: FC<FormSectionProps> = ({ SectionOption, refs }: FormSection
             startIcon={<AddCircleIcon />}
             onClick={addFunding}
             disabled={readOnlyInputs || status === FormStatus.SAVING}
+            data-testid="section-b-add-funding-agency-button"
           />
         }
       >
@@ -523,6 +531,7 @@ const FormSectionB: FC<FormSectionProps> = ({ SectionOption, refs }: FormSection
             startIcon={<AddCircleIcon />}
             onClick={addPublication}
             disabled={readOnlyInputs || status === FormStatus.SAVING}
+            data-testid="section-b-add-publication-button"
           />
         }
       >
@@ -559,6 +568,7 @@ const FormSectionB: FC<FormSectionProps> = ({ SectionOption, refs }: FormSection
             startIcon={<AddCircleIcon />}
             onClick={addPlannedPublication}
             disabled={readOnlyInputs || status === FormStatus.SAVING}
+            data-testid="section-b-add-planned-publication-button"
           />
         }
       >
@@ -595,6 +605,7 @@ const FormSectionB: FC<FormSectionProps> = ({ SectionOption, refs }: FormSection
             startIcon={<AddCircleIcon />}
             onClick={addRepository}
             disabled={readOnlyInputs || status === FormStatus.SAVING}
+            data-testid="section-b-add-repository-button"
           />
         }
       >


### PR DESCRIPTION
### Overview

Added "Other" data type option when defining a Repository in a Submission Request form.

### Change Details (Specifics)

- Added "Other" Repository data type option
- Disabled Other Data Type(s) when "Other" is not one of the selected options. Also, cleared existing value in field
- Updated helper text
- Updated SR Excel form to reflect same changes
- Bumped SR Excel form version
- Added test coverage for Repository and Section B of SR form

### Related Ticket(s)

[CRDCDH-3512](https://tracker.nci.nih.gov/browse/CRDCDH-3512) (US)
[CRDCDH-3563](https://tracker.nci.nih.gov/browse/CRDCDH-3563) (Task)
