### PR TITLE
CRDCDH-3602 Data Submissions List – Use `study`.`dbGaPID` instead of root `dbGaPID`

### DIFF
--- a/src/components/ExportSubmissionsButton/index.stories.tsx
+++ b/src/components/ExportSubmissionsButton/index.stories.tsx
@@ -4,6 +4,7 @@ import { userEvent, within, screen } from "@storybook/test";
 
 import { Context as AuthContext } from "@/components/Contexts/AuthContext";
 import { Column } from "@/components/GenericTable";
+import { approvedStudyFactory } from "@/factories/approved-study/ApprovedStudyFactory";
 import { authCtxStateFactory } from "@/factories/auth/AuthCtxStateFactory";
 import { organizationFactory } from "@/factories/auth/OrganizationFactory";
 import { userFactory } from "@/factories/auth/UserFactory";
@@ -27,8 +28,12 @@ const baseSubmissions = submissionFactory.build(2, (idx) => ({
     name: `Test Organization ${idx}`,
     abbreviation: `ORG-${idx}`,
   }),
+  study: approvedStudyFactory.pick(["studyName", "studyAbbreviation", "dbGaPID"]).build({
+    studyName: `TEST-NAME-${idx}`,
+    studyAbbreviation: `TEST-${idx}`,
+    dbGaPID: `phs00000${idx}`,
+  }),
   studyAbbreviation: `TEST-${idx}`,
-  dbGaPID: `phs00000${idx}`,
   status: "In Progress",
   conciergeName: `Test Concierge ${idx}`,
   nodeCount: 1000 + idx,
@@ -118,9 +123,9 @@ const defaultColumns: Column<Submission>[] = [
   },
   {
     label: "dbGaP ID",
-    renderValue: (a) => a.dbGaPID,
-    field: "dbGaPID",
-    exportValue: (a) => ({ label: "dbGaP ID", value: a.dbGaPID }),
+    renderValue: (a) => a.study.dbGaPID,
+    fieldKey: "study.dbGaPID",
+    exportValue: (a) => ({ label: "dbGaP ID", value: a.study.dbGaPID }),
   },
   {
     label: "Status",

--- a/src/components/ExportSubmissionsButton/index.test.tsx
+++ b/src/components/ExportSubmissionsButton/index.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { FC } from "react";
 import { axe } from "vitest-axe";
 
+import { approvedStudyFactory } from "@/factories/approved-study/ApprovedStudyFactory";
 import { authCtxStateFactory } from "@/factories/auth/AuthCtxStateFactory";
 import { organizationFactory } from "@/factories/auth/OrganizationFactory";
 import { userFactory } from "@/factories/auth/UserFactory";
@@ -45,8 +46,11 @@ const baseSubmissions = submissionFactory.build(10, (idx) => ({
     name: `Organization ${idx}`,
     abbreviation: `ORG-${idx}`,
   }),
-  studyAbbreviation: `STUDY-${idx}`,
-  dbGaPID: `phs00${idx}`,
+  study: approvedStudyFactory.pick(["studyName", "studyAbbreviation", "dbGaPID"]).build({
+    studyName: `Study ${idx}`,
+    studyAbbreviation: `STUDY-${idx}`,
+    dbGaPID: `phs00${idx}`,
+  }),
   status: "In Progress",
   conciergeName: `Concierge ${idx}`,
   nodeCount: 100 + idx,
@@ -145,9 +149,9 @@ const defaultColumns: Column<Submission>[] = [
   },
   {
     label: "dbGaP ID",
-    renderValue: (a) => a.dbGaPID,
-    field: "dbGaPID",
-    exportValue: (a) => ({ label: "dbGaP ID", value: a.dbGaPID }),
+    renderValue: (a) => a.study?.dbGaPID,
+    fieldKey: "study.dbGaPID",
+    exportValue: (a) => ({ label: "dbGaP ID", value: a.study?.dbGaPID }),
   },
   {
     label: "Status",

--- a/src/content/dataSubmissions/DataSubmissionsListView.tsx
+++ b/src/content/dataSubmissions/DataSubmissionsListView.tsx
@@ -181,10 +181,10 @@ const columns: Column<T>[] = [
   },
   {
     label: "dbGaP ID",
-    renderValue: (a) => <TruncatedText text={a.dbGaPID} maxCharacters={15} />,
-    field: "dbGaPID",
+    renderValue: (a) => <TruncatedText text={a?.study?.dbGaPID} maxCharacters={15} />,
+    fieldKey: "study.dbGaPID",
     hideable: true,
-    exportValue: (a) => ({ label: "dbGaP ID", value: a.dbGaPID }),
+    exportValue: (a) => ({ label: "dbGaP ID", value: a.study?.dbGaPID || "" }),
   },
 
   {

--- a/src/graphql/listSubmissions.ts
+++ b/src/graphql/listSubmissions.ts
@@ -38,8 +38,8 @@ export const query: TypedDocumentNode<Response, Input> = gql`
         study {
           studyName
           studyAbbreviation
+          dbGaPID
         }
-        dbGaPID
         modelVersion
         status
         archived

--- a/src/graphql/listSubmissions.ts
+++ b/src/graphql/listSubmissions.ts
@@ -92,7 +92,6 @@ export type Response = {
       | "dataCommonsDisplayName"
       | "organization"
       | "study"
-      | "dbGaPID"
       | "modelVersion"
       | "status"
       | "archived"

--- a/src/types/Submissions.d.ts
+++ b/src/types/Submissions.d.ts
@@ -23,8 +23,13 @@ type Submission = {
   /**
    * The study associated with the submission.
    */
-  study: Pick<ApprovedStudy, "studyName" | "studyAbbreviation">;
-  dbGaPID: string; // # aka. phs number
+  study: Pick<ApprovedStudy, "studyName" | "studyAbbreviation" | "dbGaPID">;
+  /**
+   * The dbGaP PHS Accession number associated with the submission's study.
+   *
+   * @deprecated Use `study.dbGaPID` instead.
+   */
+  dbGaPID: string;
   bucketName: string; // # populated from organization
   rootPath: string; // # a submission folder will be created under this path, default is / or "" meaning root folder
   status: SubmissionStatus;


### PR DESCRIPTION
### Overview

This PR addresses a request from the BE team to use `study.dbGaPID` instead of `submission.dbGaPID`, since `study.dbGaPID` is used for the filters. Technically they should always be identical

### Change Details (Specifics)

- Switch the Data Submission List view from reading the root dbGaPID object to the nested study dbGaPID
- Mark the root dbGaPID property as deprecated – It's still technically populated though

### Related Ticket(s)

CRDCDH-3602 (Task)