### PR TITLE
Bump nginx to 1.29.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN NODE_OPTIONS="--max-old-space-size=4096" npm ci
 
 RUN NODE_OPTIONS="--max-old-space-size=4096" npm run build
 
-FROM nginx:1.29.4-alpine3.23-slim as fnl_base_image
+FROM nginx:1.29.5-alpine3.23-slim as fnl_base_image
 
 COPY --from=build /usr/src/app/build /usr/share/nginx/html
 COPY --from=build /usr/src/app/conf/inject.template.js /usr/share/nginx/html/inject.template.js


### PR DESCRIPTION
### Overview

Reduces the CVE count. There's still 1 medium.

### Change Details (Specifics)

N/A

### Related Ticket(s)

N/A
