### PR TITLE
Bump nginx to 1.29.6 and force upgrade zlib

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,10 @@ RUN NODE_OPTIONS="--max-old-space-size=4096" npm ci
 
 RUN NODE_OPTIONS="--max-old-space-size=4096" npm run build
 
-FROM nginx:1.29.5-alpine3.23-slim as fnl_base_image
+FROM nginx:1.29.6-alpine3.23-slim AS fnl_base_image
+
+# zlib: CVE-2026-22184
+RUN apk update && apk add --no-cache --upgrade zlib=1.3.2-r0
 
 COPY --from=build /usr/src/app/build /usr/share/nginx/html
 COPY --from=build /usr/src/app/conf/inject.template.js /usr/share/nginx/html/inject.template.js


### PR DESCRIPTION
### Overview

This PR hopefully fixes the auto build on merge failing due to CVEs detected by Trivy.

### Change Details (Specifics)

N/A

### Related Ticket(s)

N/A
