### PR TITLE
CRDCDH-3563 Add migration for repository otherDataTypes

### DIFF
--- a/src/classes/QuestionnaireDataMigrator.test.ts
+++ b/src/classes/QuestionnaireDataMigrator.test.ts
@@ -1,6 +1,7 @@
 import { v4 } from "uuid";
 import { vi } from "vitest";
 
+import DataTypes from "@/config/DataTypesConfig";
 import { contactFactory } from "@/factories/application/ContactFactory";
 import { fundingFactory } from "@/factories/application/FundingFactory";
 import { piFactory } from "@/factories/application/PIFactory";
@@ -1417,7 +1418,7 @@ describe("_migrateRepositoryOtherDataTypes", () => {
         repositories: repositoryFactory.build(1, {
           name: "GEO",
           studyID: "S001",
-          dataTypesSubmitted: ["Genomics"],
+          dataTypesSubmitted: [DataTypes.genomics.name],
           otherDataTypesSubmitted: "Custom Type",
         }),
       }),
@@ -1434,7 +1435,7 @@ describe("_migrateRepositoryOtherDataTypes", () => {
     const result = migrator.getData();
 
     expect(result.study.repositories[0].dataTypesSubmitted).toContain("Other");
-    expect(result.study.repositories[0].dataTypesSubmitted).toContain("Genomics");
+    expect(result.study.repositories[0].dataTypesSubmitted).toContain(DataTypes.genomics.name);
     expect(Logger.info).toHaveBeenCalledWith(
       "_migrateRepositoryOtherDataTypes: Adding 'Other' to dataTypesSubmitted",
       expect.any(Object)
@@ -1473,7 +1474,7 @@ describe("_migrateRepositoryOtherDataTypes", () => {
         repositories: repositoryFactory.build(1, {
           name: "GEO",
           studyID: "S001",
-          dataTypesSubmitted: ["Genomics"],
+          dataTypesSubmitted: [DataTypes.genomics.name],
           otherDataTypesSubmitted: "",
         }),
       }),
@@ -1489,7 +1490,7 @@ describe("_migrateRepositoryOtherDataTypes", () => {
     await migrator._migrateRepositoryOtherDataTypes();
     const result = migrator.getData();
 
-    expect(result.study.repositories[0].dataTypesSubmitted).toEqual(["Genomics"]);
+    expect(result.study.repositories[0].dataTypesSubmitted).toEqual([DataTypes.genomics.name]);
     expect(Logger.info).not.toHaveBeenCalled();
   });
 
@@ -1499,7 +1500,7 @@ describe("_migrateRepositoryOtherDataTypes", () => {
         repositories: repositoryFactory.build(1, {
           name: "GEO",
           studyID: "S001",
-          dataTypesSubmitted: ["Genomics"],
+          dataTypesSubmitted: [DataTypes.genomics.name],
           otherDataTypesSubmitted: "   ",
         }),
       }),
@@ -1515,7 +1516,7 @@ describe("_migrateRepositoryOtherDataTypes", () => {
     await migrator._migrateRepositoryOtherDataTypes();
     const result = migrator.getData();
 
-    expect(result.study.repositories[0].dataTypesSubmitted).toEqual(["Genomics"]);
+    expect(result.study.repositories[0].dataTypesSubmitted).toEqual([DataTypes.genomics.name]);
     expect(Logger.info).not.toHaveBeenCalled();
   });
 
@@ -1525,7 +1526,7 @@ describe("_migrateRepositoryOtherDataTypes", () => {
         repositories: repositoryFactory.build(1, {
           name: "GEO",
           studyID: "S001",
-          dataTypesSubmitted: ["Genomics"],
+          dataTypesSubmitted: [DataTypes.genomics.name],
         }),
       }),
     });
@@ -1540,7 +1541,7 @@ describe("_migrateRepositoryOtherDataTypes", () => {
     await migrator._migrateRepositoryOtherDataTypes();
     const result = migrator.getData();
 
-    expect(result.study.repositories[0].dataTypesSubmitted).toEqual(["Genomics"]);
+    expect(result.study.repositories[0].dataTypesSubmitted).toEqual([DataTypes.genomics.name]);
     expect(Logger.info).not.toHaveBeenCalled();
   });
 
@@ -1551,19 +1552,19 @@ describe("_migrateRepositoryOtherDataTypes", () => {
           repositoryFactory.build({
             name: "GEO",
             studyID: "S001",
-            dataTypesSubmitted: ["Genomics"],
+            dataTypesSubmitted: [DataTypes.genomics.name],
             otherDataTypesSubmitted: "Custom Type",
           }),
           repositoryFactory.build({
             name: "EGA",
             studyID: "S002",
-            dataTypesSubmitted: ["Imaging", "Other"],
+            dataTypesSubmitted: [DataTypes.imaging.name, "Other"],
             otherDataTypesSubmitted: "Already has Other",
           }),
           repositoryFactory.build({
             name: "SRA",
             studyID: "S003",
-            dataTypesSubmitted: ["Proteomics"],
+            dataTypesSubmitted: [DataTypes.proteomics.name],
             otherDataTypesSubmitted: "",
           }),
         ],
@@ -1581,9 +1582,12 @@ describe("_migrateRepositoryOtherDataTypes", () => {
     const result = migrator.getData();
 
     expect(result.study.repositories[0].dataTypesSubmitted).toContain("Other");
-    expect(result.study.repositories[0].dataTypesSubmitted).toContain("Genomics");
-    expect(result.study.repositories[1].dataTypesSubmitted).toEqual(["Imaging", "Other"]);
-    expect(result.study.repositories[2].dataTypesSubmitted).toEqual(["Proteomics"]);
+    expect(result.study.repositories[0].dataTypesSubmitted).toContain(DataTypes.genomics.name);
+    expect(result.study.repositories[1].dataTypesSubmitted).toEqual([
+      DataTypes.imaging.name,
+      "Other",
+    ]);
+    expect(result.study.repositories[2].dataTypesSubmitted).toEqual([DataTypes.proteomics.name]);
     expect(Logger.info).toHaveBeenCalledTimes(1);
   });
 

--- a/src/classes/QuestionnaireDataMigrator.test.ts
+++ b/src/classes/QuestionnaireDataMigrator.test.ts
@@ -5,6 +5,7 @@ import { contactFactory } from "@/factories/application/ContactFactory";
 import { fundingFactory } from "@/factories/application/FundingFactory";
 import { piFactory } from "@/factories/application/PIFactory";
 import { questionnaireDataFactory } from "@/factories/application/QuestionnaireDataFactory";
+import { repositoryFactory } from "@/factories/application/RepositoryFactory";
 import { studyFactory } from "@/factories/application/StudyFactory";
 import { institutionFactory } from "@/factories/institution/InstitutionFactory";
 import { Logger } from "@/utils/logger";
@@ -1406,5 +1407,236 @@ describe("_migrateGPA", () => {
     expect(result.study.funding[0]).not.toHaveProperty("nciGPA");
     expect(result.study.funding[0].agency).toBe("NCI");
     expect(result.study.funding[0].grantNumbers).toBe("1a0x35b");
+  });
+});
+
+describe("_migrateRepositoryOtherDataTypes", () => {
+  it("should add 'Other' to dataTypesSubmitted when otherDataTypesSubmitted has a value", async () => {
+    const data = questionnaireDataFactory.build({
+      study: studyFactory.build({
+        repositories: repositoryFactory.build(1, {
+          name: "GEO",
+          studyID: "S001",
+          dataTypesSubmitted: ["Genomics"],
+          otherDataTypesSubmitted: "Custom Type",
+        }),
+      }),
+    });
+
+    const migrator = new QuestionnaireDataMigrator(data, {
+      getInstitutions: mockGetInstitutions,
+      newInstitutions: [],
+      getLastApplication: mockGetLastApplication,
+    });
+
+    // @ts-expect-error Calling private helper function
+    await migrator._migrateRepositoryOtherDataTypes();
+    const result = migrator.getData();
+
+    expect(result.study.repositories[0].dataTypesSubmitted).toContain("Other");
+    expect(result.study.repositories[0].dataTypesSubmitted).toContain("Genomics");
+    expect(Logger.info).toHaveBeenCalledWith(
+      "_migrateRepositoryOtherDataTypes: Adding 'Other' to dataTypesSubmitted",
+      expect.any(Object)
+    );
+  });
+
+  it("should not modify dataTypesSubmitted when 'Other' is already selected", async () => {
+    const data = questionnaireDataFactory.build({
+      study: studyFactory.build({
+        repositories: repositoryFactory.build(1, {
+          name: "GEO",
+          studyID: "S001",
+          dataTypesSubmitted: ["Genomics", "Other"],
+          otherDataTypesSubmitted: "Custom Type",
+        }),
+      }),
+    });
+
+    const migrator = new QuestionnaireDataMigrator(data, {
+      getInstitutions: mockGetInstitutions,
+      newInstitutions: [],
+      getLastApplication: mockGetLastApplication,
+    });
+
+    // @ts-expect-error Calling private helper function
+    await migrator._migrateRepositoryOtherDataTypes();
+    const result = migrator.getData();
+
+    expect(result.study.repositories[0].dataTypesSubmitted).toEqual(["Genomics", "Other"]);
+    expect(Logger.info).not.toHaveBeenCalled();
+  });
+
+  it("should not modify dataTypesSubmitted when otherDataTypesSubmitted is empty", async () => {
+    const data = questionnaireDataFactory.build({
+      study: studyFactory.build({
+        repositories: repositoryFactory.build(1, {
+          name: "GEO",
+          studyID: "S001",
+          dataTypesSubmitted: ["Genomics"],
+          otherDataTypesSubmitted: "",
+        }),
+      }),
+    });
+
+    const migrator = new QuestionnaireDataMigrator(data, {
+      getInstitutions: mockGetInstitutions,
+      newInstitutions: [],
+      getLastApplication: mockGetLastApplication,
+    });
+
+    // @ts-expect-error Calling private helper function
+    await migrator._migrateRepositoryOtherDataTypes();
+    const result = migrator.getData();
+
+    expect(result.study.repositories[0].dataTypesSubmitted).toEqual(["Genomics"]);
+    expect(Logger.info).not.toHaveBeenCalled();
+  });
+
+  it("should not modify dataTypesSubmitted when otherDataTypesSubmitted is whitespace only", async () => {
+    const data = questionnaireDataFactory.build({
+      study: studyFactory.build({
+        repositories: repositoryFactory.build(1, {
+          name: "GEO",
+          studyID: "S001",
+          dataTypesSubmitted: ["Genomics"],
+          otherDataTypesSubmitted: "   ",
+        }),
+      }),
+    });
+
+    const migrator = new QuestionnaireDataMigrator(data, {
+      getInstitutions: mockGetInstitutions,
+      newInstitutions: [],
+      getLastApplication: mockGetLastApplication,
+    });
+
+    // @ts-expect-error Calling private helper function
+    await migrator._migrateRepositoryOtherDataTypes();
+    const result = migrator.getData();
+
+    expect(result.study.repositories[0].dataTypesSubmitted).toEqual(["Genomics"]);
+    expect(Logger.info).not.toHaveBeenCalled();
+  });
+
+  it("should not modify dataTypesSubmitted when otherDataTypesSubmitted is undefined", async () => {
+    const data = questionnaireDataFactory.build({
+      study: studyFactory.build({
+        repositories: repositoryFactory.build(1, {
+          name: "GEO",
+          studyID: "S001",
+          dataTypesSubmitted: ["Genomics"],
+        }),
+      }),
+    });
+
+    const migrator = new QuestionnaireDataMigrator(data, {
+      getInstitutions: mockGetInstitutions,
+      newInstitutions: [],
+      getLastApplication: mockGetLastApplication,
+    });
+
+    // @ts-expect-error Calling private helper function
+    await migrator._migrateRepositoryOtherDataTypes();
+    const result = migrator.getData();
+
+    expect(result.study.repositories[0].dataTypesSubmitted).toEqual(["Genomics"]);
+    expect(Logger.info).not.toHaveBeenCalled();
+  });
+
+  it("should handle multiple repositories and only migrate those needing it", async () => {
+    const data = questionnaireDataFactory.build({
+      study: studyFactory.build({
+        repositories: [
+          repositoryFactory.build({
+            name: "GEO",
+            studyID: "S001",
+            dataTypesSubmitted: ["Genomics"],
+            otherDataTypesSubmitted: "Custom Type",
+          }),
+          repositoryFactory.build({
+            name: "EGA",
+            studyID: "S002",
+            dataTypesSubmitted: ["Imaging", "Other"],
+            otherDataTypesSubmitted: "Already has Other",
+          }),
+          repositoryFactory.build({
+            name: "SRA",
+            studyID: "S003",
+            dataTypesSubmitted: ["Proteomics"],
+            otherDataTypesSubmitted: "",
+          }),
+        ],
+      }),
+    });
+
+    const migrator = new QuestionnaireDataMigrator(data, {
+      getInstitutions: mockGetInstitutions,
+      newInstitutions: [],
+      getLastApplication: mockGetLastApplication,
+    });
+
+    // @ts-expect-error Calling private helper function
+    await migrator._migrateRepositoryOtherDataTypes();
+    const result = migrator.getData();
+
+    expect(result.study.repositories[0].dataTypesSubmitted).toContain("Other");
+    expect(result.study.repositories[0].dataTypesSubmitted).toContain("Genomics");
+    expect(result.study.repositories[1].dataTypesSubmitted).toEqual(["Imaging", "Other"]);
+    expect(result.study.repositories[2].dataTypesSubmitted).toEqual(["Proteomics"]);
+    expect(Logger.info).toHaveBeenCalledTimes(1);
+  });
+
+  it("should do nothing when repositories array is empty", async () => {
+    const data = questionnaireDataFactory.build({
+      study: studyFactory.build({ repositories: [] }),
+    });
+
+    const migrator = new QuestionnaireDataMigrator(data, {
+      getInstitutions: mockGetInstitutions,
+      newInstitutions: [],
+      getLastApplication: mockGetLastApplication,
+    });
+
+    // @ts-expect-error Calling private helper function
+    await migrator._migrateRepositoryOtherDataTypes();
+    const result = migrator.getData();
+
+    expect(result).toEqual(data);
+    expect(Logger.info).not.toHaveBeenCalled();
+  });
+
+  it("should do nothing when study is null", async () => {
+    const data = questionnaireDataFactory.build({ study: null });
+
+    const migrator = new QuestionnaireDataMigrator(data, {
+      getInstitutions: mockGetInstitutions,
+      newInstitutions: [],
+      getLastApplication: mockGetLastApplication,
+    });
+
+    // @ts-expect-error Calling private helper function
+    await migrator._migrateRepositoryOtherDataTypes();
+    const result = migrator.getData();
+
+    expect(result).toEqual(data);
+    expect(Logger.info).not.toHaveBeenCalled();
+  });
+
+  it("should do nothing when study is undefined", async () => {
+    const data = questionnaireDataFactory.build({ study: undefined });
+
+    const migrator = new QuestionnaireDataMigrator(data, {
+      getInstitutions: mockGetInstitutions,
+      newInstitutions: [],
+      getLastApplication: mockGetLastApplication,
+    });
+
+    // @ts-expect-error Calling private helper function
+    await migrator._migrateRepositoryOtherDataTypes();
+    const result = migrator.getData();
+
+    expect(result).toEqual(data);
+    expect(Logger.info).not.toHaveBeenCalled();
   });
 });

--- a/src/classes/QuestionnaireDataMigrator.ts
+++ b/src/classes/QuestionnaireDataMigrator.ts
@@ -52,6 +52,7 @@ export class QuestionnaireDataMigrator {
     await this._migrateInstitutionsToID();
     await this._migrateInstitutionNames();
     await this._migrateGPA();
+    await this._migrateRepositoryOtherDataTypes();
 
     return this.data;
   }
@@ -201,6 +202,34 @@ export class QuestionnaireDataMigrator {
       if (newInstitution && apiData && apiData._id !== institutionID) {
         Logger.info("_migrateExistingInstitutions: Migrating to API ID", { ...contact }, apiData);
         contact.institutionID = apiData._id;
+      }
+    });
+  }
+
+  /**
+   * Migrates repositories that have otherDataTypesSubmitted values
+   * but are missing "Other" in their dataTypesSubmitted array.
+   *
+   * This ensures the "Other" option is selected so the otherDataTypesSubmitted
+   * field remains visible and editable.
+   */
+  private async _migrateRepositoryOtherDataTypes(): Promise<void> {
+    const repositories = this.data?.study?.repositories;
+    if (!repositories?.length) {
+      return;
+    }
+
+    repositories.forEach((repo) => {
+      const hasOtherText =
+        typeof repo.otherDataTypesSubmitted === "string" &&
+        repo.otherDataTypesSubmitted?.trim()?.length > 0;
+      const hasOtherSelected = repo.dataTypesSubmitted?.includes("Other");
+
+      if (hasOtherText && !hasOtherSelected) {
+        Logger.info("_migrateRepositoryOtherDataTypes: Adding 'Other' to dataTypesSubmitted", {
+          ...repo,
+        });
+        repo.dataTypesSubmitted = [...(repo.dataTypesSubmitted || []), "Other"];
       }
     });
   }


### PR DESCRIPTION
### Overview

Added migration for repository otherDataTypes.

### Change Details (Specifics)

- Previously user's could add otherDataTypes unrestricted, but we now require "Other" option to be included within their dataTypes for the otherDataTypes field to be enabled. The migration adds "Other" to their existing dataTypes if they have a value in otherDataTypes.

### Related Ticket(s)

[CRDCDH-3512](https://tracker.nci.nih.gov/browse/CRDCDH-3512) (US)
[CRDCDH-3563](https://tracker.nci.nih.gov/browse/CRDCDH-3563) (Task)