### PR TITLE
CRDCDH-3566 Display Active Institutions by default

### DIFF
--- a/src/components/InstitutionListFilters/index.test.tsx
+++ b/src/components/InstitutionListFilters/index.test.tsx
@@ -165,13 +165,15 @@ describe("InstitutionListFilters Component", () => {
 });
 
 describe("Implementation Requirements", () => {
-  it("should default the status filter to Active", () => {
+  it("should default the status filter to Active", async () => {
     const { getByTestId } = render(
       <TestParent>
         <InstitutionListFilters />
       </TestParent>
     );
 
-    expect(getByTestId("status-select-input")).toHaveValue("Active");
+    await waitFor(() => {
+      expect(getByTestId("status-select-input")).toHaveValue("Active");
+    });
   });
 });

--- a/src/components/InstitutionListFilters/index.test.tsx
+++ b/src/components/InstitutionListFilters/index.test.tsx
@@ -95,7 +95,7 @@ describe("InstitutionListFilters Component", () => {
     );
 
     await waitFor(() => {
-      expect(mockOnChange).toHaveBeenCalledWith({ name: "", status: "All" });
+      expect(mockOnChange).toHaveBeenCalledWith({ name: "", status: "Active" });
     });
   });
 
@@ -134,7 +134,7 @@ describe("InstitutionListFilters Component", () => {
     vi.advanceTimersByTime(500);
 
     await waitFor(() => {
-      expect(mockOnChange).toHaveBeenCalledWith({ name: "Test", status: "All" });
+      expect(mockOnChange).toHaveBeenCalledWith({ name: "Test", status: "Active" });
     });
     vi.useRealTimers();
   });
@@ -152,14 +152,26 @@ describe("InstitutionListFilters Component", () => {
     userEvent.type(nameInput, "TestName");
     vi.advanceTimersByTime(500);
     await waitFor(() => {
-      expect(mockOnChange).toHaveBeenCalledWith({ name: "TestName", status: "All" });
+      expect(mockOnChange).toHaveBeenCalledWith({ name: "TestName", status: "Active" });
     });
 
     userEvent.clear(nameInput);
     vi.advanceTimersByTime(500);
     await waitFor(() => {
-      expect(mockOnChange).toHaveBeenCalledWith({ name: "", status: "All" });
+      expect(mockOnChange).toHaveBeenCalledWith({ name: "", status: "Active" });
     });
     vi.useRealTimers();
+  });
+});
+
+describe("Implementation Requirements", () => {
+  it("should default the status filter to Active", () => {
+    const { getByTestId } = render(
+      <TestParent>
+        <InstitutionListFilters />
+      </TestParent>
+    );
+
+    expect(getByTestId("status-select-input")).toHaveValue("Active");
   });
 });

--- a/src/components/InstitutionListFilters/index.tsx
+++ b/src/components/InstitutionListFilters/index.tsx
@@ -52,7 +52,7 @@ const InstitutionListFilters = ({ onChange }: Props) => {
   const { watch, register, control, setValue, getValues } = useForm<FilterForm>({
     defaultValues: {
       name: "",
-      status: "All",
+      status: "Active",
     },
   });
 

--- a/src/content/users/ProfileView.test.tsx
+++ b/src/content/users/ProfileView.test.tsx
@@ -287,9 +287,7 @@ describe("Implementation Requirements", () => {
     userEvent.type(input, "a");
     userEvent.clear(input);
 
-    await waitFor(async () => {
-      const options = await findAllByRole("option");
-      expect(options).toHaveLength(2);
-    });
+    const options = await findAllByRole("option");
+    expect(options).toHaveLength(2);
   });
 });

--- a/src/content/users/ProfileView.test.tsx
+++ b/src/content/users/ProfileView.test.tsx
@@ -246,4 +246,50 @@ describe("Implementation Requirements", () => {
       expect(await findByText("Beta Oncology Institute")).toBeInTheDocument();
     });
   });
+
+  it("should only display active institutions", async () => {
+    const activeInstitutionsMock: MockedResponse<ListInstitutionsResp, ListInstitutionsInput> = {
+      request: {
+        query: LIST_INSTITUTIONS,
+      },
+      variableMatcher: (variables) => variables.status === "Active",
+      result: {
+        data: {
+          listInstitutions: {
+            total: 2,
+            institutions: [
+              institutionFactory.build({ name: "Active Institute A", status: "Active" }),
+              institutionFactory.build({ name: "Active Institute B", status: "Active" }),
+            ],
+          },
+        },
+      },
+      maxUsageCount: Infinity,
+    };
+
+    const { findByLabelText, findAllByRole } = render(
+      <TestParent
+        mocks={[
+          getUserMock,
+          activeInstitutionsMock,
+          listApprovedStudiesMock,
+          retrievePBACDefaults,
+          getTooltipsMock,
+        ]}
+      >
+        <ProfileView _id="test-id" viewType="users" />
+      </TestParent>
+    );
+
+    const input = await findByLabelText(/Institution/i);
+    userEvent.click(input);
+    userEvent.clear(input);
+    userEvent.type(input, "a");
+    userEvent.clear(input);
+
+    await waitFor(async () => {
+      const options = await findAllByRole("option");
+      expect(options).toHaveLength(2);
+    });
+  });
 });


### PR DESCRIPTION
### Overview

Updated Institution list page to display Active institution by default.

### Change Details (Specifics)

- Changed Institution list "status" filter to filter "Active" institutions by default
- Added test coverage in Edit User page to ensure only active institutions are listed

### Related Ticket(s)

[CRDCDH-3471](https://tracker.nci.nih.gov/browse/CRDCDH-3471) (US)
[CRDCDH-3566](https://tracker.nci.nih.gov/browse/CRDCDH-3566) (Task)
