### PR TITLE
CRDCDH-3575 Utilize separate Data Submission "Admin Submit" action

### DIFF
--- a/src/content/dataSubmissions/DataSubmission.tsx
+++ b/src/content/dataSubmissions/DataSubmission.tsx
@@ -20,7 +20,7 @@ import ValidationControls from "../../components/DataSubmissions/ValidationContr
 import ValidationStatistics from "../../components/DataSubmissions/ValidationStatistics";
 import DbGaPSheetExport from "../../components/DbGaPSheetExport";
 import { hasPermission } from "../../config/AuthPermissions";
-import { SUBMISSION_ACTION, SubmissionActionResp } from "../../graphql";
+import { SUBMISSION_ACTION, SubmissionActionInput, SubmissionActionResp } from "../../graphql";
 import usePageTitle from "../../hooks/usePageTitle";
 import { Logger } from "../../utils";
 
@@ -188,10 +188,13 @@ const DataSubmission: FC<Props> = ({ submissionId, tab = URLTabs.UPLOAD_ACTIVITY
     Object.values(URLTabs).includes(tab) &&
     (tab !== URLTabs.CROSS_VALIDATION_RESULTS || crossValidationVisible);
 
-  const [submissionAction] = useMutation<SubmissionActionResp>(SUBMISSION_ACTION, {
-    context: { clientName: "backend" },
-    fetchPolicy: "no-cache",
-  });
+  const [submissionAction] = useMutation<SubmissionActionResp, SubmissionActionInput>(
+    SUBMISSION_ACTION,
+    {
+      context: { clientName: "backend" },
+      fetchPolicy: "no-cache",
+    }
+  );
 
   const updateSubmissionAction = async (action: SubmissionAction, reviewComment?: string) => {
     if (!submissionId) {

--- a/src/content/dataSubmissions/DataSubmissionActions.test.tsx
+++ b/src/content/dataSubmissions/DataSubmissionActions.test.tsx
@@ -211,6 +211,49 @@ describe("Implementation Requirements - Submit", () => {
   );
 });
 
+describe("Implementation Requirements - Admin Submit", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should call onAction with 'Admin Submit' when admin override is confirmed", async () => {
+    shouldEnableSubmitMock.mockReturnValue({
+      enabled: true,
+      isAdminOverride: true,
+      tooltip: "mock-tooltip-text",
+    });
+
+    const onAction = vi.fn(() => new Promise<void>(() => {}));
+
+    const { getByRole } = render(
+      <TestParent
+        user={{
+          _id: "admin-user",
+          role: "Admin",
+          permissions: ["data_submission:view", "data_submission:admin_submit"],
+        }}
+        submission={{
+          _id: "submission-id",
+          status: "In Progress",
+          submitterID: "submission-owner",
+        }}
+      >
+        <DataSubmissionActions onAction={onAction} />
+      </TestParent>
+    );
+
+    userEvent.click(getByRole("button", { name: "Admin Submit" }));
+    userEvent.type(
+      getByRole("textbox", { name: "Admin override justification" }),
+      "some reason for override"
+    );
+    userEvent.click(getByRole("button", { name: "Confirm to Submit" }));
+
+    expect(onAction).toHaveBeenCalledTimes(1);
+    expect(onAction).toHaveBeenCalledWith("Admin Submit", "some reason for override");
+  });
+});
+
 describe("Implementation Requirements - Withdraw", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/src/content/dataSubmissions/DataSubmissionActions.tsx
+++ b/src/content/dataSubmissions/DataSubmissionActions.tsx
@@ -106,6 +106,9 @@ type ActionKey =
   | "Complete"
   | "Cancel";
 
+const isSubmitAction = (action: SubmissionAction | null) =>
+  action === "Submit" || action === "Admin Submit";
+
 const actionConfig: Record<ActionKey, ActionConfig> = {
   Submit: {
     hasPermission: (user, submission) =>
@@ -228,15 +231,15 @@ const DataSubmissionActions = ({ onAction }: Props) => {
           placement="top"
           title={submitActionButton?.tooltip}
           open={undefined}
-          disableHoverListener={!submitActionButton?.tooltip || (action && action !== "Submit")}
+          disableHoverListener={!submitActionButton?.tooltip || (action && !isSubmitAction(action))}
         >
           <span>
             <StyledLoadingButton
               variant="contained"
               color="primary"
               onClick={() => onOpenDialog("Submit")}
-              loading={action === "Submit"}
-              disabled={!submitActionButton?.enabled || (action && action !== "Submit")}
+              loading={isSubmitAction(action)}
+              disabled={!submitActionButton?.enabled || (action && !isSubmitAction(action))}
             >
               {submitActionButton?.isAdminOverride ? "Admin Submit" : "Submit"}
             </StyledLoadingButton>
@@ -339,7 +342,7 @@ const DataSubmissionActions = ({ onAction }: Props) => {
               Cancel
             </Button>
             <LoadingButton
-              onClick={() => handleOnAction("Submit")}
+              onClick={() => handleOnAction("Admin Submit")}
               loading={!!action}
               disabled={reviewComment?.trim()?.length <= 0}
               autoFocus

--- a/src/graphql/index.ts
+++ b/src/graphql/index.ts
@@ -66,8 +66,8 @@ export type {
   Response as ListSubmissionsResp,
 } from "./listSubmissions";
 
-export { mutation as SUBMISSION_ACTION } from "./submissionAction";
-export type { Response as SubmissionActionResp } from "./submissionAction";
+export { SUBMISSION_ACTION } from "./submissionAction";
+export type { SubmissionActionResp, SubmissionActionInput } from "./submissionAction";
 
 export { mutation as CREATE_BATCH } from "./createBatch";
 export type { Input as CreateBatchInput, Response as CreateBatchResp } from "./createBatch";

--- a/src/graphql/submissionAction.ts
+++ b/src/graphql/submissionAction.ts
@@ -1,14 +1,21 @@
+import { TypedDocumentNode } from "@apollo/client";
 import gql from "graphql-tag";
 
-// action in [Submit, Release, Withdraw, Reject, Complete, Cancel]
-export const mutation = gql`
-  mutation submissionAction($submissionID: ID!, $action: String!, $comment: String) {
-    submissionAction(submissionID: $submissionID, action: $action, comment: $comment) {
-      _id
+export const SUBMISSION_ACTION: TypedDocumentNode<SubmissionActionResp, SubmissionActionInput> =
+  gql`
+    mutation submissionAction($submissionID: ID!, $action: String!, $comment: String) {
+      submissionAction(submissionID: $submissionID, action: $action, comment: $comment) {
+        _id
+      }
     }
-  }
-`;
+  `;
 
-export type Response = {
+export type SubmissionActionResp = {
   submissionAction: Pick<Submission, "_id">;
+};
+
+export type SubmissionActionInput = {
+  submissionID: string;
+  action: SubmissionAction;
+  comment?: string;
 };

--- a/src/types/Submissions.d.ts
+++ b/src/types/Submissions.d.ts
@@ -136,6 +136,7 @@ type SubmissionStatus =
 
 type SubmissionAction =
   | "Submit"
+  | "Admin Submit"
   | "Release"
   | "Withdraw"
   | "Reject"


### PR DESCRIPTION
### Overview

This PR implements the separate "Admin Submit" action for when submissions are admin submitted, and includes some related cleanup.

### Change Details (Specifics)

- Call submissionAction with `Admin Submit` instead of `Submit` when the admin submit button is present
- Update tests to cover new scenario
- Add typing to the submissionAction GQL query

### Related Ticket(s)

CRDCDH-3575 (Task)
CRDCDH-3495 (US)
