### PR TITLE
CRDCDH-3643 Repository field is required when 'Other' is selected

### DIFF
--- a/src/components/Questionnaire/Repository.test.tsx
+++ b/src/components/Questionnaire/Repository.test.tsx
@@ -245,6 +245,45 @@ describe("Implementation Requirements", () => {
     expect(otherOption.label).toBe("Other");
   });
 
+  it("should not require Other Data Type(s) field when 'Other' is not selected", () => {
+    const mockRepository = repositoryFactory.build({
+      dataTypesSubmitted: ["genomics"],
+    });
+
+    const { getByTestId } = render(
+      <Repository index={0} repository={mockRepository} onDelete={vi.fn()} />,
+      { wrapper: TestParent }
+    );
+
+    expect(getFormElements({ getByTestId }, 0).otherDataTypesInput()).not.toBeRequired();
+  });
+
+  it("should require Other Data Type(s) field when 'Other' is selected", () => {
+    const mockRepository = repositoryFactory.build({
+      dataTypesSubmitted: ["Other"],
+    });
+
+    const { getByTestId } = render(
+      <Repository index={0} repository={mockRepository} onDelete={vi.fn()} />,
+      { wrapper: TestParent }
+    );
+
+    expect(getFormElements({ getByTestId }, 0).otherDataTypesInput()).toBeRequired();
+  });
+
+  it("should require Other Data Type(s) field when 'Other' is among multiple selected types", () => {
+    const mockRepository = repositoryFactory.build({
+      dataTypesSubmitted: ["genomics", "Other", "imaging"],
+    });
+
+    const { getByTestId } = render(
+      <Repository index={0} repository={mockRepository} onDelete={vi.fn()} />,
+      { wrapper: TestParent }
+    );
+
+    expect(getFormElements({ getByTestId }, 0).otherDataTypesInput()).toBeRequired();
+  });
+
   it("should disable Other Data Type(s) field when 'Other' is not selected", () => {
     const mockRepository = repositoryFactory.build({
       dataTypesSubmitted: ["genomics"],

--- a/src/components/Questionnaire/Repository.tsx
+++ b/src/components/Questionnaire/Repository.tsx
@@ -117,6 +117,7 @@ const Repository: FC<Props> = ({ idPrefix = "", index, repository, readOnly, onD
           placeholder="Other, specify as free text"
           maxLength={100}
           gridWidth={6}
+          required={isOtherSelected}
           readOnly={!isOtherSelected || readOnly}
           onChange={(e) => setOtherDataTypes(e.target.value)}
           data-testid={idPrefix.concat(`repository-${index}-other-data-types-submitted`)}

--- a/src/content/questionnaire/FormView.tsx
+++ b/src/content/questionnaire/FormView.tsx
@@ -568,12 +568,13 @@ const FormView: FC<Props> = ({ section }: Props) => {
       return;
     }
 
-    blocker.proceed?.();
-    if (res?.status === "success" && res.id) {
+    if (res?.status === "success" && res?.id && res.id !== data._id && data._id === "new") {
       // NOTE: This currently triggers a form data refetch, which is not ideal
       navigate(blocker.location.pathname.replace("new", res.id), {
         replace: true,
       });
+    } else {
+      blocker.proceed?.();
     }
   };
 

--- a/src/content/questionnaire/FormView.tsx
+++ b/src/content/questionnaire/FormView.tsx
@@ -546,14 +546,7 @@ const FormView: FC<Props> = ({ section }: Props) => {
       return;
     }
 
-    if (res?.status === "success" && res?.id && res.id !== data._id && data._id === "new") {
-      // NOTE: This currently triggers a form data refetch, which is not ideal
-      navigate(blocker.location.pathname.replace("new", res.id), {
-        replace: true,
-      });
-    } else {
-      blocker.proceed?.();
-    }
+    blocker.proceed?.();
   };
 
   /**


### PR DESCRIPTION
### Overview

Updated Submission Request Form within the Repository section to require a field based on another field's value.

### Change Details (Specifics)

- Updated "Other Data Type(s)" field in Repository to be required when "Data Type(s) Submitted" contains "Other"
- Added test coverage

### Related Ticket(s)

[CRDCDH-3643](https://tracker.nci.nih.gov/browse/CRDCDH-3643)
