### PR TITLE
CRDCDH-3719 [Bug]: Remove status field when creating study

### DIFF
--- a/src/components/CreateApplicationButton/index.stories.tsx
+++ b/src/components/CreateApplicationButton/index.stories.tsx
@@ -87,7 +87,7 @@ export const ConfirmAndCreate: Story = {
     const button = await canvas.findByTestId("create-application-button");
     await userEvent.click(button);
 
-    const confirmButton = await screen.findByRole("button", { name: "I Read and Accept" });
+    const confirmButton = await screen.findByText("I Read and Accept");
     await userEvent.click(confirmButton);
 
     await expect(args.onCreate).toHaveBeenCalledWith("new");

--- a/src/components/DataSubmissions/CreateDataSubmissionDialog.stories.tsx
+++ b/src/components/DataSubmissions/CreateDataSubmissionDialog.stories.tsx
@@ -25,6 +25,7 @@ const partialStudyProperties = [
   "pendingModelChange",
   "isPendingGPA",
   "pendingImageDeIdentification",
+  "status",
 ] satisfies (keyof ApprovedStudy)[];
 
 const baseStudies: GetMyUserResp["getMyUser"]["studies"] = [
@@ -35,6 +36,7 @@ const baseStudies: GetMyUserResp["getMyUser"]["studies"] = [
     dbGaPID: "phsTEST",
     controlledAccess: null,
     pendingModelChange: false,
+    status: "Active",
   }),
   approvedStudyFactory.pick(partialStudyProperties).build({
     _id: "study2",
@@ -43,6 +45,7 @@ const baseStudies: GetMyUserResp["getMyUser"]["studies"] = [
     dbGaPID: "phsTEST",
     controlledAccess: true,
     pendingModelChange: false,
+    status: "Active",
   }),
   approvedStudyFactory.pick(partialStudyProperties).build({
     _id: "no-dbGaP-ID",
@@ -51,6 +54,7 @@ const baseStudies: GetMyUserResp["getMyUser"]["studies"] = [
     dbGaPID: null,
     controlledAccess: true,
     pendingModelChange: false,
+    status: "Active",
   }),
   approvedStudyFactory.pick(partialStudyProperties).build({
     _id: "pending-model-changes",
@@ -59,6 +63,7 @@ const baseStudies: GetMyUserResp["getMyUser"]["studies"] = [
     dbGaPID: "phsTEST",
     controlledAccess: null,
     pendingModelChange: true,
+    status: "Active",
   }),
   approvedStudyFactory.pick(partialStudyProperties).build({
     _id: "pending-GPA-condition",
@@ -68,6 +73,7 @@ const baseStudies: GetMyUserResp["getMyUser"]["studies"] = [
     controlledAccess: true,
     pendingModelChange: false,
     isPendingGPA: true,
+    status: "Active",
   }),
   approvedStudyFactory.pick(partialStudyProperties).build({
     _id: "pending-conditions",
@@ -77,6 +83,7 @@ const baseStudies: GetMyUserResp["getMyUser"]["studies"] = [
     controlledAccess: true,
     pendingModelChange: true,
     isPendingGPA: true,
+    status: "Active",
   }),
   approvedStudyFactory.pick(partialStudyProperties).build({
     _id: "pending-image-de-identification",
@@ -86,6 +93,7 @@ const baseStudies: GetMyUserResp["getMyUser"]["studies"] = [
     controlledAccess: null,
     pendingModelChange: false,
     pendingImageDeIdentification: true,
+    status: "Active",
   }),
 ];
 

--- a/src/content/studies/StudyView.test.tsx
+++ b/src/content/studies/StudyView.test.tsx
@@ -417,7 +417,6 @@ describe("StudyView Component", () => {
           pendingImageDeIdentification: false,
           GPAName: "Test GPA Name",
           isPendingGPA: false,
-          status: "Active",
         },
       },
       result: {
@@ -619,7 +618,6 @@ describe("StudyView Component", () => {
           pendingImageDeIdentification: false,
           GPAName: "",
           isPendingGPA: false,
-          status: "Active",
         },
       },
       error: new Error("Unable to create approved study."),
@@ -805,7 +803,6 @@ describe("StudyView Component", () => {
           pendingImageDeIdentification: false,
           GPAName: "",
           isPendingGPA: false,
-          status: "Active",
         },
       },
       result: {
@@ -996,7 +993,6 @@ describe("StudyView Component", () => {
           pendingImageDeIdentification: false,
           GPAName: "",
           isPendingGPA: false,
-          status: "Active",
         },
       },
       error: new ApolloError({ errorMessage: null }),
@@ -1250,7 +1246,6 @@ describe("StudyView Component", () => {
           pendingImageDeIdentification: true,
           GPAName: "",
           isPendingGPA: false,
-          status: "Active",
         },
       },
       result: {
@@ -1603,6 +1598,151 @@ describe("Implementation Requirements", () => {
 
     await waitFor(() => {
       expect(programAutocomplete.value).toBe("Not Applicable");
+    });
+  });
+
+  it("should not pass status when creating a new study", async () => {
+    const variableMatcher = vi.fn().mockReturnValue(true);
+
+    const createApprovedStudyMock: MockedResponse<
+      CreateApprovedStudyResp,
+      CreateApprovedStudyInput
+    > = {
+      request: {
+        query: CREATE_APPROVED_STUDY,
+      },
+      variableMatcher,
+      result: {
+        data: {
+          createApprovedStudy: {
+            _id: "new-study-id",
+          },
+        },
+      },
+    };
+
+    const { getByTestId, queryByTestId, getByText } = render(
+      <TestParent mocks={[listActiveDCPsMock, listProgramsMock, createApprovedStudyMock]}>
+        <StudyView _id="new" />
+      </TestParent>
+    );
+
+    await waitFor(async () => {
+      expect(queryByTestId("study-view-suspense-loader")).not.toBeInTheDocument();
+    });
+
+    const studyNameInput = getByTestId("studyName-input") as HTMLInputElement;
+    const openAccessCheckbox = getByTestId("openAccess-checkbox");
+    const programAutocomplete = getByTestId("program-input") as HTMLInputElement;
+    const saveButton = getByTestId("save-button");
+
+    userEvent.type(programAutocomplete, "Not Appl");
+    await waitFor(() => {
+      expect(getByText("Not Applicable")).toBeInTheDocument();
+    });
+    userEvent.click(getByText("Not Applicable"));
+
+    userEvent.type(studyNameInput, "Test Study Name");
+    userEvent.click(openAccessCheckbox);
+    userEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(global.mockEnqueue).toHaveBeenCalledWith("This study has been successfully added.", {
+        variant: "default",
+      });
+    });
+
+    expect(variableMatcher).toHaveBeenCalledWith(
+      expect.not.objectContaining({ status: expect.anything() })
+    );
+  });
+
+  it("should pass status when updating an existing study", async () => {
+    const studyId = "existing-study-id";
+    const variableMatcher = vi.fn().mockReturnValue(true);
+
+    const getApprovedStudyMock: MockedResponse<GetApprovedStudyResp, GetApprovedStudyInput> = {
+      request: {
+        query: GET_APPROVED_STUDY,
+        variables: { _id: studyId, partial: false },
+      },
+      result: {
+        data: {
+          getApprovedStudy: approvedStudyFactory.build({
+            _id: studyId,
+            studyName: "Existing Study",
+            studyAbbreviation: "ES",
+            PI: "Jane Smith",
+            dbGaPID: "phs654321",
+            ORCID: "0000-0002-3456-7890",
+            openAccess: false,
+            controlledAccess: true,
+            program: organizationFactory.build({ _id: "NA" }),
+            primaryContact: null,
+            useProgramPC: true,
+            createdAt: "",
+            pendingModelChange: false,
+            pendingImageDeIdentification: false,
+            GPAName: "Test GPA Name",
+            status: "Active",
+          }),
+        },
+      },
+    };
+
+    const updateApprovedStudyMock: MockedResponse<
+      UpdateApprovedStudyResp,
+      UpdateApprovedStudyInput
+    > = {
+      request: {
+        query: UPDATE_APPROVED_STUDY,
+      },
+      variableMatcher,
+      result: {
+        data: {
+          updateApprovedStudy: {
+            _id: studyId,
+          },
+        },
+      },
+    };
+
+    const { getByTestId, queryByTestId } = render(
+      <TestParent
+        mocks={[
+          listActiveDCPsMock,
+          listProgramsMock,
+          getApprovedStudyMock,
+          updateApprovedStudyMock,
+        ]}
+      >
+        <StudyView _id={studyId} />
+      </TestParent>
+    );
+
+    await waitFor(async () => {
+      expect(queryByTestId("study-view-suspense-loader")).not.toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect((getByTestId("studyName-input") as HTMLInputElement).value).toBe("Existing Study");
+    });
+
+    const studyNameInput = getByTestId("studyName-input") as HTMLInputElement;
+    userEvent.clear(studyNameInput);
+    userEvent.type(studyNameInput, "Updated Study Name");
+
+    const saveButton = getByTestId("save-button");
+    userEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(global.mockEnqueue).toHaveBeenCalledWith("All changes have been saved.", {
+        variant: "default",
+      });
+    });
+
+    await waitFor(() => {
+      expect(variableMatcher).toHaveBeenCalledWith(expect.objectContaining({ status: "Active" }));
     });
   });
 });

--- a/src/content/studies/StudyView.test.tsx
+++ b/src/content/studies/StudyView.test.tsx
@@ -1652,9 +1652,9 @@ describe("Implementation Requirements", () => {
       });
     });
 
-    expect(variableMatcher).toHaveBeenCalledWith(
-      expect.not.objectContaining({ status: expect.anything() })
-    );
+    expect(variableMatcher).toHaveBeenCalled();
+    const calledVariables = variableMatcher.mock.calls[0][0];
+    expect(calledVariables).not.toHaveProperty("status");
   });
 
   it("should pass status when updating an existing study", async () => {

--- a/src/content/studies/StudyView.tsx
+++ b/src/content/studies/StudyView.tsx
@@ -440,9 +440,9 @@ const StudyView: FC<Props> = ({ _id }: Props) => {
   const onSubmit = async (data: FormInput) => {
     setSaving(true);
 
-    const { studyName, studyAbbreviation, program, ...rest } = data;
+    const { studyName, studyAbbreviation, program, status, ...rest } = data;
 
-    const variables: CreateApprovedStudyInput | UpdateApprovedStudyInput = {
+    const variables: Omit<CreateApprovedStudyInput, "status"> | UpdateApprovedStudyInput = {
       ...rest,
       name: studyName,
       acronym: studyAbbreviation,
@@ -470,7 +470,7 @@ const StudyView: FC<Props> = ({ _id }: Props) => {
       });
     } else {
       const { data: d, errors } = await updateApprovedStudy({
-        variables: { studyID: _id, ...variables },
+        variables: { studyID: _id, status, ...variables },
       }).catch((e) => ({ errors: e?.message, data: null }));
       setSaving(false);
 

--- a/src/content/studies/StudyView.tsx
+++ b/src/content/studies/StudyView.tsx
@@ -470,7 +470,7 @@ const StudyView: FC<Props> = ({ _id }: Props) => {
       });
     } else {
       const { data: d, errors } = await updateApprovedStudy({
-        variables: { studyID: _id, status, ...variables },
+        variables: { studyID: _id, ...variables, status },
       }).catch((e) => ({ errors: e?.message, data: null }));
       setSaving(false);
 

--- a/src/graphql/createApprovedStudy.ts
+++ b/src/graphql/createApprovedStudy.ts
@@ -17,7 +17,6 @@ export const mutation: TypedDocumentNode<Response, Input> = gql`
     $pendingImageDeIdentification: Boolean
     $GPAName: String
     $isPendingGPA: Boolean
-    $status: String
   ) {
     createApprovedStudy(
       name: $name
@@ -34,7 +33,6 @@ export const mutation: TypedDocumentNode<Response, Input> = gql`
       pendingImageDeIdentification: $pendingImageDeIdentification
       GPAName: $GPAName
       isPendingGPA: $isPendingGPA
-      status: $status
     ) {
       _id
     }
@@ -56,7 +54,6 @@ export type Input = {
   pendingImageDeIdentification: boolean;
   GPAName: string;
   isPendingGPA: boolean;
-  status: string;
 };
 
 export type Response = {


### PR DESCRIPTION
### Overview

Removed status field when creating a study.

### Change Details (Specifics)

- Removed status field from createApprovedStudy mutation
- Removed status from being passed when creating an approved study
- Added test coverage to make sure the status param is/not passed
- Fixed failing storybook tests

### Related Ticket(s)

[CRDCDH-3719](https://tracker.nci.nih.gov/browse/CRDCDH-3719) (Bug)
