### PR TITLE
CRDCDH-3735 Change form save confirmation verbiage

### DIFF
--- a/src/content/questionnaire/FormView.test.tsx
+++ b/src/content/questionnaire/FormView.test.tsx
@@ -389,8 +389,13 @@ describe("Implementation Requirements", () => {
       { name: "D", status: "Not Started" },
     ];
 
+    const mockFormElement = document.createElement("form");
+    Object.defineProperty(mockFormElement, "checkValidity", {
+      value: vi.fn(() => false),
+    });
+
     mockFormObject = {
-      ref: { current: document.createElement("form") },
+      ref: { current: mockFormElement },
       data: { sections: mockSections } as QuestionnaireData,
     };
 
@@ -425,16 +430,13 @@ describe("Implementation Requirements", () => {
       { name: "D", status: "Not Started" },
     ];
 
-    // NOTE: This is somewhat hacky to prevent reportValidity from succeeding
-    const { container } = render(
-      <form>
-        <input type="text" required minLength={5} />
-      </form>
-    );
-    const renderedForm = container.querySelector("form") as HTMLFormElement;
+    const mockFormElement = document.createElement("form");
+    Object.defineProperty(mockFormElement, "checkValidity", {
+      value: vi.fn(() => false),
+    });
 
     mockFormObject = {
-      ref: { current: renderedForm },
+      ref: { current: mockFormElement },
       data: { sections: mockSections } as QuestionnaireData,
     };
 

--- a/src/content/questionnaire/FormView.test.tsx
+++ b/src/content/questionnaire/FormView.test.tsx
@@ -339,4 +339,127 @@ describe("Implementation Requirements", () => {
     });
     expect(getByText("Confirm to move to Inquired")).toBeInTheDocument();
   });
+
+  it("should indicate that changes were saved if any portion of the form has data", async () => {
+    mockUseFormMode.mockReturnValue({ formMode: "Edit", readOnlyInputs: false });
+
+    const mockSections: Section[] = [
+      { name: "A", status: "Not Started" },
+      { name: "B", status: "Not Started" },
+      { name: "C", status: "In Progress" }, // Triggers the specific message
+      { name: "D", status: "Not Started" },
+    ];
+
+    mockFormObject = {
+      ref: { current: document.createElement("form") },
+      data: { sections: mockSections } as QuestionnaireData,
+    };
+
+    const setDataMock = vi
+      .fn()
+      .mockResolvedValue({ status: "success", id: baseFormCtxState.data._id });
+
+    const formCtxState: FormContextState = {
+      ...baseFormCtxState,
+      setData: setDataMock,
+    };
+
+    const { getByText } = render(<TestParent section="A" formCtxState={formCtxState} />);
+
+    userEvent.click(getByText("Save"));
+
+    await waitFor(() => {
+      expect(setDataMock).toHaveBeenCalled();
+    });
+
+    expect(global.mockEnqueue).toHaveBeenCalledWith(
+      "Your changes for the Principal Investigator and Contact section have been successfully saved.",
+      { variant: "success" }
+    );
+  });
+
+  // NOTE: This is a slight variant of the above scenario, but testing for "new" UUIDs
+  it("should indicate that changes were saved if any portion of the form has data (new UUID)", async () => {
+    mockUseFormMode.mockReturnValue({ formMode: "Edit", readOnlyInputs: false });
+
+    const mockSections: Section[] = [
+      { name: "A", status: "Not Started" },
+      { name: "B", status: "In Progress" }, // Triggers the specific message
+      { name: "C", status: "Not Started" },
+      { name: "D", status: "Not Started" },
+    ];
+
+    mockFormObject = {
+      ref: { current: document.createElement("form") },
+      data: { sections: mockSections } as QuestionnaireData,
+    };
+
+    const setDataMock = vi.fn().mockResolvedValue({ status: "success", id: "new" });
+
+    const formCtxState: FormContextState = {
+      ...baseFormCtxState,
+      setData: setDataMock,
+    };
+
+    const { getByText } = render(<TestParent section="A" formCtxState={formCtxState} />);
+
+    userEvent.click(getByText("Save"));
+
+    await waitFor(() => {
+      expect(setDataMock).toHaveBeenCalled();
+    });
+
+    expect(global.mockEnqueue).toHaveBeenCalledWith(
+      "Your changes for the Principal Investigator and Contact section have been successfully saved.",
+      { variant: "success" }
+    );
+  });
+
+  it("should show new success snackbar when saving a section for a form with no data", async () => {
+    mockUseFormMode.mockReturnValue({ formMode: "Edit", readOnlyInputs: false });
+
+    const mockSections: Section[] = [
+      { name: "A", status: "Not Started" },
+      { name: "B", status: "Not Started" },
+      { name: "C", status: "Not Started" },
+      { name: "D", status: "Not Started" },
+    ];
+
+    // NOTE: This is somewhat hacky to prevent reportValidity from succeeding
+    const { container } = render(
+      <form>
+        <input type="text" required minLength={5} />
+      </form>
+    );
+    const renderedForm = container.querySelector("form") as HTMLFormElement;
+
+    mockFormObject = {
+      ref: { current: renderedForm },
+      data: { sections: mockSections } as QuestionnaireData,
+    };
+
+    const setDataMock = vi.fn().mockResolvedValue({ status: "success", id: "new" });
+
+    const newFormState: FormContextState = {
+      ...baseFormCtxState,
+      data: applicationFactory.build({
+        ...baseFormCtxState.data,
+        _id: "new",
+      }),
+      setData: setDataMock,
+    };
+
+    const { getByText } = render(<TestParent section="A" formCtxState={newFormState} />);
+
+    userEvent.click(getByText("Save"));
+
+    await waitFor(() => {
+      expect(setDataMock).toHaveBeenCalled();
+    });
+
+    expect(global.mockEnqueue).toHaveBeenCalledWith(
+      "The Principal Investigator and Contact section has been successfully saved.",
+      { variant: "success" }
+    );
+  });
 });

--- a/src/content/questionnaire/FormView.tsx
+++ b/src/content/questionnaire/FormView.tsx
@@ -454,12 +454,10 @@ const FormView: FC<Props> = ({ section }: Props) => {
         variant: "error",
       });
     } else {
-      enqueueSnackbar(
-        `Your changes for the ${map[activeSection].title} section have been successfully saved.`,
-        {
-          variant: "success",
-        }
-      );
+      const saveMessage = newData?.sections?.every((section) => section.status === "Not Started")
+        ? `The ${map[activeSection].title} section has been successfully saved.`
+        : `Your changes for the ${map[activeSection].title} section have been successfully saved.`;
+      enqueueSnackbar(saveMessage, { variant: "success" });
     }
 
     if (saveResult?.status === "success") {


### PR DESCRIPTION
### Overview

This PR changes the verbiage of the message that appears when saving a SRF. Specifically, by altering the message when the SRF has no data at all, vs when it has something filled out.

> [!Note]
> The expected behavior in the bug is completely wrong, and was a mis-interpretation of a Slack convo. The actual requirements being implemented here are reflected in the user story CRDCDH-3588

### Change Details (Specifics)

N/A

### Related Ticket(s)

CRDCDH-3735