### PR TITLE
CRDCDH-3734 [Bug]: Update date validation for planned publication expected date

### DIFF
--- a/src/classes/Excel/PersistentColumns.ts
+++ b/src/classes/Excel/PersistentColumns.ts
@@ -26,6 +26,10 @@ export const PERSISTENT_COLUMNS: PersistenceRule[] = [
     key: "targetedReleaseDate",
     shouldPersist: (value: string) => dayjs(value, "MM/DD/YYYY", true)?.isValid(),
   },
+  {
+    key: "study.plannedPublications.expectedDate",
+    shouldPersist: (value: string) => dayjs(value, "MM/DD/YYYY", true)?.isValid(),
+  },
 ];
 
 /**

--- a/src/classes/QuestionnaireExcelMiddleware.test.ts
+++ b/src/classes/QuestionnaireExcelMiddleware.test.ts
@@ -2727,6 +2727,101 @@ describe("Parsing", () => {
     expect(pp2.expectedDate).toEqual("12/31/2031");
   });
 
+  it("should allow current date for planned publication expected date", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2000, 0, 1, 4, 4, 4));
+
+    const mockForm = questionnaireDataFactory.build({
+      program: programInputFactory.build({
+        _id: "Other",
+        name: "Program A",
+        abbreviation: "PA",
+        description: "Program A Desc",
+      }),
+      study: studyFactory.build({
+        name: "Date Parsing Study",
+        abbreviation: "DPS",
+        description: "Testing date parsing.",
+        funding: [],
+        publications: [],
+        plannedPublications: [
+          plannedPublicationFactory.build({
+            title: "DateTest #1",
+            expectedDate: "01/01/2000",
+          }),
+        ],
+        repositories: [],
+      }),
+    });
+
+    const middleware = new QuestionnaireExcelMiddleware(mockForm, {});
+
+    // @ts-expect-error Private member
+    await middleware.serializeSectionB();
+
+    // @ts-expect-error Private member
+    middleware.data = { ...InitialQuestionnaire, sections: [...InitialSections] };
+
+    // @ts-expect-error Private member
+    const result = await middleware.parseSectionB();
+
+    // @ts-expect-error Private member
+    const output = middleware.data;
+
+    expect(result).toEqual(true);
+
+    const pp1 = output.study.plannedPublications.find((p) => p.title === "DateTest #1");
+    expect(pp1).toBeDefined();
+    expect(pp1.expectedDate).toEqual("01/01/2000");
+
+    vi.useRealTimers();
+  });
+
+  it("should not allow past dates for planned publication expected date and persist value", async () => {
+    const mockForm = questionnaireDataFactory.build({
+      program: programInputFactory.build({
+        _id: "Other",
+        name: "Program A",
+        abbreviation: "PA",
+        description: "Program A Desc",
+      }),
+      study: studyFactory.build({
+        name: "Date Parsing Study",
+        abbreviation: "DPS",
+        description: "Testing date parsing.",
+        funding: [],
+        publications: [],
+        plannedPublications: [
+          plannedPublicationFactory.build({
+            title: "DateTest #1",
+            expectedDate: "01/01/2000",
+          }),
+        ],
+        repositories: [],
+      }),
+    });
+
+    const middleware = new QuestionnaireExcelMiddleware(mockForm, {});
+
+    // @ts-expect-error Private member
+    await middleware.serializeSectionB();
+
+    // @ts-expect-error Private member
+    middleware.data = { ...InitialQuestionnaire, sections: [...InitialSections] };
+
+    // @ts-expect-error Private member
+    const result = await middleware.parseSectionB();
+
+    // @ts-expect-error Private member
+    const output = middleware.data;
+
+    expect(result).toEqual(true);
+
+    const pp1 = output.study.plannedPublications.find((p) => p.title === "DateTest #1");
+    expect(pp1).toBeDefined();
+    expect(pp1.expectedDate).toEqual("01/01/2000");
+  });
+
   it("should convert repository data types to an array of only valid options", async () => {
     const mockForm = questionnaireDataFactory.build({
       program: programInputFactory.build({

--- a/src/schemas/Application.ts
+++ b/src/schemas/Application.ts
@@ -264,10 +264,15 @@ export const plannedPublicationSchema = z
      */
     title: z.string().max(500).nonempty(),
     /**
-     * Target date for publication release.
-     * Stored as MM/DD/YYYY.
+     * Target date for publication release. Stored as MM/DD/YYYY.
+     * Must be a future date.
      */
-    expectedDate: z.string().refine((val) => dayjs(val, "MM/DD/YYYY", true)?.isValid()),
+    expectedDate: z.string().refine((val) => {
+      const date = dayjs(val, "MM/DD/YYYY", true)?.startOf("day");
+      const dateIsTodayOrAfter =
+        date?.isSame(dayjs().startOf("day")) || date?.isAfter(dayjs().startOf("day"));
+      return date?.isValid() && dateIsTodayOrAfter;
+    }),
   })
   .strict();
 


### PR DESCRIPTION
### Overview

Within the SRF within the planned publications, the expected date was not properly validating future dates when importing a form. Updated to properly validate, but still persist value if validation fails

### Change Details (Specifics)

- Updated Zod schema for planned publications expected date to only allow same day or future dates
- Added planned publication expected date field to persist the value even if fails past date validation. Without this it would not update the SRF with the invalid date

### Related Ticket(s)

[CRDCDH-3734](https://tracker.nci.nih.gov/browse/CRDCDH-3734) (Bug)
