### PR TITLE
CRDCDH-3735 Fix logic when determining if Section A is started

### DIFF
--- a/src/components/Contexts/FormContext.tsx
+++ b/src/components/Contexts/FormContext.tsx
@@ -143,7 +143,7 @@ export const FormProvider: FC<ProviderProps> = ({ children, id }: ProviderProps)
 
   const [lastApp] = useLazyQuery<LastAppResp>(LAST_APP, {
     context: { clientName: "backend" },
-    fetchPolicy: "no-cache",
+    fetchPolicy: "cache-first",
   });
 
   const [getApp] = useLazyQuery<GetAppResp>(GET_APP, {

--- a/src/content/questionnaire/FormView.test.tsx
+++ b/src/content/questionnaire/FormView.test.tsx
@@ -1,3 +1,4 @@
+import { MockedProvider, MockedResponse } from "@apollo/client/testing";
 import userEvent from "@testing-library/user-event";
 import { FC } from "react";
 import { MemoryRouterProps } from "react-router-dom";
@@ -13,6 +14,7 @@ import {
   ContextState as FormContextState,
   Status as FormStatus,
 } from "@/components/Contexts/FormContext";
+import { query as GET_LAST_APP } from "@/graphql/getMyLastApplication";
 import { render, waitFor, within } from "@/test-utils";
 import { applicationFactory } from "@/test-utils/factories/application/ApplicationFactory";
 import { authCtxStateFactory } from "@/test-utils/factories/auth/AuthCtxStateFactory";
@@ -106,6 +108,19 @@ const baseAuthCtxState: AuthContextState = authCtxStateFactory.build({
   }),
 });
 
+const baseMocks: MockedResponse[] = [
+  {
+    request: {
+      query: GET_LAST_APP,
+    },
+    result: {
+      data: {
+        getMyLastApplication: null,
+      },
+    },
+  },
+];
+
 type ParentProps = {
   formCtxState?: FormContextState;
   authCtxState?: AuthContextState;
@@ -120,11 +135,13 @@ const TestParent: FC<ParentProps> = ({
   initialEntries = [`/submission-request/test-app-id/${section}`],
 }) => (
   <TestRouter initialEntries={initialEntries}>
-    <AuthContext.Provider value={authCtxState}>
-      <FormContext.Provider value={formCtxState}>
-        <FormView section={section} />
-      </FormContext.Provider>
-    </AuthContext.Provider>
+    <MockedProvider mocks={baseMocks}>
+      <AuthContext.Provider value={authCtxState}>
+        <FormContext.Provider value={formCtxState}>
+          <FormView section={section} />
+        </FormContext.Provider>
+      </AuthContext.Provider>
+    </MockedProvider>
   </TestRouter>
 );
 
@@ -251,6 +268,44 @@ describe("Basic Functionality", () => {
         preventScrollReset: true,
       });
     });
+  });
+
+  it("should handle getMyLastApplication returning null when saving Section A", async () => {
+    mockUseFormMode.mockReturnValue({ formMode: "Edit", readOnlyInputs: false });
+
+    const mockSections: Section[] = [
+      { name: "A", status: "Not Started" },
+      { name: "B", status: "Not Started" },
+      { name: "C", status: "In Progress" },
+      { name: "D", status: "Not Started" },
+    ];
+
+    mockFormObject = {
+      ref: { current: document.createElement("form") },
+      data: { sections: mockSections } as QuestionnaireData,
+    };
+
+    const setDataMock = vi
+      .fn()
+      .mockResolvedValue({ status: "success", id: baseFormCtxState.data._id });
+
+    const formCtxState: FormContextState = {
+      ...baseFormCtxState,
+      setData: setDataMock,
+    };
+
+    const { getByText } = render(<TestParent section="A" formCtxState={formCtxState} />);
+
+    userEvent.click(getByText("Save"));
+
+    await waitFor(() => {
+      expect(setDataMock).toHaveBeenCalled();
+    });
+
+    expect(global.mockEnqueue).toHaveBeenCalledWith(
+      "Your changes for the Principal Investigator and Contact section have been successfully saved.",
+      { variant: "success" }
+    );
   });
 });
 

--- a/src/content/questionnaire/FormView.tsx
+++ b/src/content/questionnaire/FormView.tsx
@@ -1,3 +1,4 @@
+import { useLazyQuery } from "@apollo/client";
 import { LoadingButton } from "@mui/lab";
 import {
   Checkbox,
@@ -12,6 +13,9 @@ import { isEqual, cloneDeep } from "lodash";
 import { useSnackbar } from "notistack";
 import { FC, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useBlocker, Blocker, Navigate, useLocation } from "react-router-dom";
+
+import { LastAppResp, LAST_APP } from "@/graphql";
+import { determineSectionStatus, Logger, safeParse, sectionHasData } from "@/utils";
 
 import bannerPng from "../../assets/banner/submission_banner.png";
 import CheckboxCheckedIconSvg from "../../assets/icons/checkbox_checked.svg?url";
@@ -32,7 +36,6 @@ import { hasPermission } from "../../config/AuthPermissions";
 import map, { InitialSections } from "../../config/SectionConfig";
 import useFormMode from "../../hooks/useFormMode";
 import usePageTitle from "../../hooks/usePageTitle";
-import { determineSectionStatus, Logger, sectionHasData } from "../../utils";
 
 import Section from "./sections";
 
@@ -188,13 +191,13 @@ const FormView: FC<Props> = ({ section }: Props) => {
   const {
     status,
     data,
+    error,
     setData,
     submitData,
     approveForm,
     inquireForm,
     rejectForm,
     reopenForm,
-    error,
   } = useFormContext();
   const { user, status: authStatus } = useAuthContext();
   const { formMode, readOnlyInputs } = useFormMode();
@@ -232,6 +235,11 @@ const FormView: FC<Props> = ({ section }: Props) => {
   };
 
   usePageTitle(`Submission Request${data?._id && data?._id !== "new" ? ` - ${data._id}` : ""}`);
+
+  const [lastApp] = useLazyQuery<LastAppResp>(LAST_APP, {
+    context: { clientName: "backend" },
+    fetchPolicy: "cache-first",
+  });
 
   /**
    * Determines if the form has unsaved changes.
@@ -437,9 +445,25 @@ const FormView: FC<Props> = ({ section }: Props) => {
       newData.sections = cloneDeep(InitialSections);
     }
 
+    // NOTE: This provides additional context for validating the current status of Section A
+    // The current requirements dictate that auto-filled PI info alone should not change the status
+    // of Section A to In Progress.
+    const additionalContext: RecursivePartial<QuestionnaireData> = {};
+    if (activeSection === "A") {
+      try {
+        const { data: lastAppData } = await lastApp();
+        const { getMyLastApplication: lastAppResp } = lastAppData || {};
+        const parsedLastAppData = safeParse<QuestionnaireData>(lastAppResp?.questionnaireData);
+
+        additionalContext.pi = parsedLastAppData?.pi;
+      } catch (err) {
+        Logger.error("Error occurred while building additional context", err);
+      }
+    }
+
     const newStatus: SectionStatus = determineSectionStatus(
       ref.current.checkValidity(),
-      sectionHasData(activeSection, newData)
+      sectionHasData(activeSection, newData, additionalContext)
     );
     const currentSection: Section = newData.sections.find((s) => s.name === activeSection);
     if (currentSection) {

--- a/src/content/questionnaire/FormView.tsx
+++ b/src/content/questionnaire/FormView.tsx
@@ -1,4 +1,4 @@
-import { useLazyQuery } from "@apollo/client";
+import { useQuery } from "@apollo/client";
 import { LoadingButton } from "@mui/lab";
 import {
   Checkbox,
@@ -236,10 +236,21 @@ const FormView: FC<Props> = ({ section }: Props) => {
 
   usePageTitle(`Submission Request${data?._id && data?._id !== "new" ? ` - ${data._id}` : ""}`);
 
-  const [lastApp] = useLazyQuery<LastAppResp>(LAST_APP, {
+  const { data: lastAppData } = useQuery<LastAppResp>(LAST_APP, {
     context: { clientName: "backend" },
     fetchPolicy: "cache-first",
+    skip: activeSection !== "A" || formMode !== "Edit",
   });
+
+  const pi = useMemo<PI | null>(() => {
+    if (!lastAppData?.getMyLastApplication?.questionnaireData) {
+      return null;
+    }
+
+    return (
+      safeParse<QuestionnaireData>(lastAppData?.getMyLastApplication?.questionnaireData)?.pi || null
+    );
+  }, [lastAppData]);
 
   /**
    * Determines if the form has unsaved changes.
@@ -450,15 +461,7 @@ const FormView: FC<Props> = ({ section }: Props) => {
     // of Section A to In Progress.
     const additionalContext: RecursivePartial<QuestionnaireData> = {};
     if (activeSection === "A") {
-      try {
-        const { data: lastAppData } = await lastApp();
-        const { getMyLastApplication: lastAppResp } = lastAppData || {};
-        const parsedLastAppData = safeParse<QuestionnaireData>(lastAppResp?.questionnaireData);
-
-        additionalContext.pi = parsedLastAppData?.pi;
-      } catch (err) {
-        Logger.error("Error occurred while building additional context", err);
-      }
+      additionalContext.pi = pi;
     }
 
     const newStatus: SectionStatus = determineSectionStatus(

--- a/src/utils/formUtils.test.ts
+++ b/src/utils/formUtils.test.ts
@@ -887,6 +887,105 @@ describe("sectionHasData", () => {
         )
       ).toBe(false);
     });
+
+    it("should return false for empty object input", () => {
+      expect(utils.sectionHasData("A", {}, {})).toBe(false);
+    });
+
+    it("should treat the presence of only autofilled PI information as empty", () => {
+      const lastAppPi = {
+        ...contactFactory.build({
+          firstName: "John",
+          lastName: "Doe",
+          email: "john.doe@example.com",
+        }),
+        address: "100 Main St",
+      };
+
+      const data = questionnaireDataFactory.build({
+        pi: lastAppPi,
+        primaryContact: null,
+        additionalContacts: [],
+      });
+
+      expect(utils.sectionHasData("A", data, { pi: lastAppPi })).toBe(false);
+    });
+
+    it("should return true when PI is autofilled but other Section A data exists (additionalContacts)", () => {
+      const lastAppPi = {
+        ...contactFactory.build({
+          firstName: "John",
+          lastName: "Doe",
+          email: "john.doe@example.com",
+        }),
+        address: "100 Main St",
+      };
+
+      const dataWithOther = questionnaireDataFactory.build({
+        pi: lastAppPi,
+        additionalContacts: [contactFactory.build({ firstName: "jane" })],
+      });
+
+      expect(utils.sectionHasData("A", dataWithOther, { pi: lastAppPi })).toBe(true);
+    });
+
+    it("should return true when PI is autofilled but other Section A data exists (primaryContactSameAsPI)", () => {
+      const lastAppPi = {
+        ...contactFactory.build({
+          firstName: "John",
+          lastName: "Doe",
+          email: "john.doe@example.com",
+        }),
+        address: "100 Main St",
+      };
+
+      const dataWithOther = questionnaireDataFactory.build({
+        pi: lastAppPi,
+        piAsPrimaryContact: true,
+      });
+
+      expect(utils.sectionHasData("A", dataWithOther, { pi: lastAppPi })).toBe(true);
+    });
+
+    it("should return true when PI is autofilled but modified", () => {
+      const lastAppPi = {
+        ...contactFactory.build({
+          firstName: "John",
+          lastName: "Doe",
+          email: "john.doe@example.com",
+        }),
+        address: "100 Main St",
+      };
+
+      const dataWithOther = questionnaireDataFactory.build({
+        pi: {
+          ...lastAppPi,
+          firstName: "Brad",
+        },
+      });
+
+      expect(utils.sectionHasData("A", dataWithOther, { pi: lastAppPi })).toBe(true);
+    });
+
+    it("should return false when contextual PI exists but user cleared PI field", () => {
+      const lastAppPi = {
+        ...contactFactory.build({
+          firstName: "John",
+          lastName: "Doe",
+          email: "john.doe@example.com",
+        }),
+        address: "100 Main St",
+      };
+
+      const data = questionnaireDataFactory.build({
+        pi: {
+          ...contactFactory.build(),
+          address: "",
+        },
+      });
+
+      expect(utils.sectionHasData("A", data, { pi: lastAppPi })).toBe(false);
+    });
   });
 
   describe("Section B", () => {

--- a/src/utils/formUtils.ts
+++ b/src/utils/formUtils.ts
@@ -1,4 +1,4 @@
-import { cloneDeep, mergeWith, has, unset, some, values, get } from "lodash";
+import { cloneDeep, mergeWith, has, unset, some, values, get, isEqual } from "lodash";
 import type * as z from "zod";
 
 import { ColumnKey, shouldPersistColumnValue } from "@/classes/Excel/PersistentColumns";
@@ -452,15 +452,18 @@ export const determineSectionStatus = (passed: boolean, hasData: boolean): Secti
  *
  * @param section The section to check for data
  * @param data The questionnaire data to check against
+ * @param contextualData Provides additional data that may be needed to determine if the section has data.
  * @returns A boolean flag indicating if the section has any meaningful data
  */
 export const sectionHasData = (
   section: SectionKey,
-  data: RecursivePartial<QuestionnaireData>
+  data: RecursivePartial<QuestionnaireData>,
+  contextualData: RecursivePartial<QuestionnaireData> = {}
 ): boolean => {
   switch (section) {
     case "A": {
       const hasPIFields = some(values(data?.pi), (v) => typeof v === "string" && v.trim() !== "");
+      const piIsNotAutoFilled = hasPIFields && !isEqual(data?.pi, contextualData?.pi);
       const hasPrimaryContactFields = some(
         values(data?.primaryContact),
         (v) => typeof v === "string" && v.trim() !== ""
@@ -470,7 +473,12 @@ export const sectionHasData = (
       );
       const sameAsPI = data?.piAsPrimaryContact === true;
 
-      return hasPIFields || sameAsPI || hasPrimaryContactFields || hasAdditionalContactFields;
+      return (
+        (hasPIFields && piIsNotAutoFilled) ||
+        sameAsPI ||
+        hasPrimaryContactFields ||
+        hasAdditionalContactFields
+      );
     }
     case "B": {
       const hasProgramFields = some(

--- a/src/utils/formUtils.ts
+++ b/src/utils/formUtils.ts
@@ -468,8 +468,9 @@ export const sectionHasData = (
       const hasAdditionalContactFields = some(data?.additionalContacts || [], (contact) =>
         some(values(contact), (v) => typeof v === "string" && v.trim() !== "")
       );
+      const sameAsPI = data?.piAsPrimaryContact === true;
 
-      return hasPIFields || hasPrimaryContactFields || hasAdditionalContactFields;
+      return hasPIFields || sameAsPI || hasPrimaryContactFields || hasAdditionalContactFields;
     }
     case "B": {
       const hasProgramFields = some(

--- a/src/utils/formUtils.ts
+++ b/src/utils/formUtils.ts
@@ -463,7 +463,7 @@ export const sectionHasData = (
   switch (section) {
     case "A": {
       const hasPIFields = some(values(data?.pi), (v) => typeof v === "string" && v.trim() !== "");
-      const piIsNotAutoFilled = hasPIFields && !isEqual(data?.pi, contextualData?.pi);
+      const hasEnteredPIFields = hasPIFields && !isEqual(data?.pi, contextualData?.pi);
       const hasPrimaryContactFields = some(
         values(data?.primaryContact),
         (v) => typeof v === "string" && v.trim() !== ""
@@ -474,10 +474,7 @@ export const sectionHasData = (
       const sameAsPI = data?.piAsPrimaryContact === true;
 
       return (
-        (hasPIFields && piIsNotAutoFilled) ||
-        sameAsPI ||
-        hasPrimaryContactFields ||
-        hasAdditionalContactFields
+        hasEnteredPIFields || sameAsPI || hasPrimaryContactFields || hasAdditionalContactFields
       );
     }
     case "B": {


### PR DESCRIPTION
### Overview

This PR revises a long-standing assumption (if that..) that we should consider the auto-filled Principal Investigator's contact information as the form being started. i.e. If a PI's information was autofilled, and no other information was provided in the section, the section status should remain "New"

> [!NOTE]
> This is very much a ROUGH solution to the issue, but I couldn't think of an alternative that can be implemented in a short period of time and keep minimal code changes

> [!NOTE]
> This logic does not apply to imported submission request templates. This was intentional, because imported SRF data should be explicitly considered user provided (IMO).

### Change Details (Specifics)

- Switch `LAST_APP` query calls to cache-first policy, rather than no-cache. In the real world, it's very unlikely that PI information would change frequently enough for this policy to matter
- Modify the sectionHasData logic to now:
  - Account for whether the "Same as Principal Investigator" checkbox is checked (accidentally ignored previously)
  - Consider the PI fields to be not filled out IF they're equal to the auto-filled information
- Pre-fetch the LAST_APP data and provide it to the sectionHasData logic

### Related Ticket(s)

CRDCDH-3735
